### PR TITLE
Fixes to image version rendering

### DIFF
--- a/posit-bakery/posit_bakery/cli.py
+++ b/posit-bakery/posit_bakery/cli.py
@@ -98,10 +98,8 @@ def render(
     value: Annotated[
         List[str], typer.Option(help="A 'key=value' pair to pass to the templates. Accepts multiple pairs.")
     ] = None,
-    skip_render_minimal: Annotated[
-        bool, typer.Option(help="Skip rendering the minimal version of the Containerfile.")
-    ] = False,
-    skip_mark_latest: Annotated[bool, typer.Option(help="Skip marking the latest version of the image.")] = False,
+    mark_latest: Annotated[bool, typer.Option(help="Skip marking the latest version of the image.")] = True,
+    force: Annotated[bool, typer.Option(help="Force overwrite of existing version directory.")] = False,
 ) -> None:
     """Renders templates for an image to a versioned subdirectory of the image directory.
 
@@ -130,7 +128,9 @@ def render(
     project.new_image_version(
         image_name=image_name,
         image_version=image_version,
-        mark_latest=(not skip_mark_latest),
+        template_values=value_map,
+        mark_latest=mark_latest,
+        force=force,
     )
 
     log.info(f"✅ Successfully created version '{image_name}/{image_version}'")

--- a/posit-bakery/posit_bakery/models/image/image.py
+++ b/posit-bakery/posit_bakery/models/image/image.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 from pathlib import Path
-from typing import List
+from typing import List, Dict, Any
 
 from pydantic import BaseModel
 
@@ -49,12 +49,12 @@ class Image(BaseModel):
         context: Path = project_context / name
         create_image_templates(context=context, image_name=name, base_tag=base_tag)
 
-    def create_version(self, manifest: ManifestDocument, version: str, mark_latest: bool) -> ImageVersion:
+    def create_version(self, manifest: ManifestDocument, version: str, template_values: Dict[str, Any]) -> ImageVersion:
         new_version: ImageVersion = ImageVersion.create(
             image_context=self.context,
             version=version,
+            template_values=template_values,
             targets=manifest.target.keys(),
-            mark_latest=mark_latest,
         )
 
         return new_version

--- a/posit-bakery/posit_bakery/models/image/version.py
+++ b/posit-bakery/posit_bakery/models/image/version.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 from pathlib import Path
-from typing import List
+from typing import List, Any, Dict
 
 from pydantic import BaseModel
 
@@ -43,13 +43,13 @@ class ImageVersion(BaseModel):
         return cls(version=meta.version, context=meta.context, variants=variants)
 
     @classmethod
-    def create(cls, image_context: Path, version: str, targets: List[str], mark_latest: bool):
+    def create(cls, image_context: Path, version: str, template_values: Dict[str, Any], targets: List[str]):
         context: Path = image_context / version
         render_image_templates(
             context=context,
             version=version,
+            template_values=template_values,
             targets=targets,
-            latest=mark_latest,
         )
 
         # TODO: Pull in the variants after render

--- a/posit-bakery/posit_bakery/models/manifest/build_os.py
+++ b/posit-bakery/posit_bakery/models/manifest/build_os.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, computed_field
 
 from posit_bakery.templating.filters import condense
 
@@ -9,11 +9,9 @@ class BuildOS(BaseModel):
     distributor_id: str
     name: str
     version: str
-    codename: str | None
+    codename: str | None = None
     base_image: str
     image_tag: str
-    pretty: str
-    condensed: str
 
     """
     Represent the operating systems that are supported for image builds
@@ -29,23 +27,12 @@ class BuildOS(BaseModel):
     :param codename: VERSION_CODENAME from os-release
     """
 
-    def __init__(
-        self,
-        distributor_id: str,
-        name: str,
-        version: str,
-        base_image: str,
-        image_tag: str,
-        codename: str = None,
-    ):
-        pretty: str = f"{name} {version}"
-        super().__init__(
-            distributor_id=distributor_id,
-            name=name,
-            version=version,
-            base_image=base_image,
-            image_tag=image_tag,
-            codename=codename,
-            pretty=pretty,
-            condensed=condense(pretty),
-        )
+    @computed_field
+    @property
+    def pretty(self) -> str:
+        return f"{self.name} {self.version}"
+
+    @computed_field
+    @property
+    def condensed(self) -> str:
+        return condense(self.pretty)

--- a/posit-bakery/posit_bakery/models/manifest/manifest.py
+++ b/posit-bakery/posit_bakery/models/manifest/manifest.py
@@ -1,7 +1,6 @@
 import logging
 import os
 
-from packaging.version import Version
 from pathlib import Path
 from typing import Union, List
 
@@ -42,7 +41,7 @@ class Manifest(GenericTOMLModel):
         return [version for version in self.model.build.keys()]
 
     def add_version(self, version: str, os_list: List[str], latest: bool):
-        existing_builds = self.document["build"]
+        existing_builds = self.document.get("build", {})
 
         if latest:
             for b in existing_builds.values():
@@ -52,9 +51,9 @@ class Manifest(GenericTOMLModel):
             new_build = {"os": os_list}
 
         # TODO: Should we sort the manifest by version in descending order?
-        builds = {version: new_build, **existing_builds, version: new_build}
+        builds = {version: new_build, **existing_builds}
         # Sort versions in descending order
-        versions = [Version(v) for v in builds.keys()]
+        versions = builds.keys()
         builds = {str(v): builds[str(v)] for v in sorted(versions, reverse=True)}
         self.document["build"] = builds
         self.dump()

--- a/posit-bakery/posit_bakery/templating/default.py
+++ b/posit-bakery/posit_bakery/templating/default.py
@@ -1,4 +1,5 @@
 import logging
+from copy import copy
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -72,7 +73,7 @@ def create_image_templates(context: Path, image_name: str, base_tag: str) -> Non
     image_deps_package_file.touch(exist_ok=True)
 
 
-def render_image_templates(context: Path, version: str, targets: List[str], latest: bool) -> None:
+def render_image_templates(context: Path, version: str, template_values: Dict[str, Any], targets: List[str]) -> None:
     image_context: Path = context.parent
     project_context: Path = image_context.parent
 
@@ -86,7 +87,7 @@ def render_image_templates(context: Path, version: str, targets: List[str], late
         context.mkdir()
 
     # Initialize the value map with relative path
-    value_map: Dict[str, Any] = {}
+    value_map: Dict[str, Any] = copy(template_values)
     if "rel_path" not in value_map:
         value_map["rel_path"] = context.relative_to(project_context)
 


### PR DESCRIPTION
Fixes #94
Closes #95
- Add --force option to force re-render of a version from templates
- Change --skip-mark-latest to --mark-latest defaulted to True
- Fix missing value_map pass down to new version rendering
- Fix (assumingly) unintentional usage of packaging.Version for build version output to manifest.toml, caused weird artifacts on non-standard versions (e.g. 2024.11.0-7 renders to 2024.11.0.post7)
- Change BuildOS to use computed field properties instead of fields generated at __init__ to fix OS identification not working in version rendering