### PR TITLE
Auto-add `--init` to dgoss calls

### DIFF
--- a/posit-bakery/posit_bakery/models/project/project.py
+++ b/posit-bakery/posit_bakery/models/project/project.py
@@ -343,6 +343,10 @@ class Project(BaseModel):
             if runtime_options:
                 cmd.extend(runtime_options)
 
+            # Add the --init flag to the dgoss command if it is not already present to ensure processes get reaped
+            if "--init" not in cmd:
+                cmd.append("--init")
+
             # Set the output options for Goss
             run_env["GOSS_OPTS"] = "--format json --no-color"
 

--- a/posit-bakery/test/models/project/test_project.py
+++ b/posit-bakery/test/models/project/test_project.py
@@ -232,7 +232,7 @@ class TestProjectGoss:
         cmdstr = " ".join(cmd[2])
         pat = re.compile(
             r"dgoss run --mount=type=bind,source=.*/test-image/1.0.0/deps,destination=/tmp/deps "
-            f"-e IMAGE_TYPE={img_min.target} {img_min.tags[0]} {goss_min.command}"
+            f"-e IMAGE_TYPE={img_min.target} --init {img_min.tags[0]} {goss_min.command}"
         )
         assert re.fullmatch(pat, cmdstr) is not None
 
@@ -251,7 +251,7 @@ class TestProjectGoss:
         cmdstr = " ".join(cmd[2])
         pat = re.compile(
             r"dgoss run --mount=type=bind,source=.*/test-image/1.0.0/deps,destination=/tmp/deps "
-            f"-e IMAGE_TYPE={img_std.target} {img_std.tags[0]} {goss_std.command}"
+            f"-e IMAGE_TYPE={img_std.target} --init {img_std.tags[0]} {goss_std.command}"
         )
         assert re.fullmatch(pat, cmdstr) is not None
 


### PR DESCRIPTION
This is a small enhancement to `dgoss` execution. Since we run some container tests that spur off multiple calls, such as for Workbench, we should always use `--init` for signal forwarding and process reaping.