### PR TITLE
Add `version` alias to `versions`

### DIFF
--- a/posit-bakery/test/config/dependencies/test_dependency.py
+++ b/posit-bakery/test/config/dependencies/test_dependency.py
@@ -8,9 +8,6 @@ from posit_bakery.config.dependencies.quarto import QuartoDependencyVersions
 from posit_bakery.config.dependencies.r import RDependencyVersions
 
 
-from test.config.dependencies.test_version import R_VERSIONS, PYTHON_VERSIONS
-
-
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.config,
@@ -47,8 +44,10 @@ class TestDependencyVersions:
     @pytest.mark.parametrize(
         "versions",
         [
+            pytest.param("0.1.2", id="single_version_string"),
             pytest.param(["0.1.2"], id="single_version"),
             pytest.param(["1.0.0", "2.0.0"], id="multiple_versions"),
+            pytest.param("0.1.2,2.0.0", id="multi_version_string"),
             pytest.param(["1.0.0", "2.0.0", "3.0.0"], id="three_versions"),
         ],
     )
@@ -60,8 +59,19 @@ class TestDependencyVersions:
                 "versions": versions,
             }
         )
+        if isinstance(versions, str):
+            versions = [v.strip() for v in versions.split(",")]
 
         assert dep.dependency.versions == versions
+
+    def test_version_alias(self):
+        dep = FakeDependencyVersions(
+            dependency={
+                "dependency": "python",
+                "version": "3.9.1",
+            }
+        )
+        assert dep.dependency.versions == ["3.9.1"]
 
     def test_version_list_empty(self):
         """Test that empty list fails validation.."""
@@ -76,7 +86,6 @@ class TestDependencyVersions:
     @pytest.mark.parametrize(
         "versions",
         [
-            pytest.param("1.0.0", id="string"),
             pytest.param(1.5, id="float"),
             pytest.param(123, id="integer"),
             pytest.param([1], id="list_ints"),
@@ -113,3 +122,43 @@ class TestDependencyVersions:
 
         assert isinstance(dep.dependency, expected_type)
         assert dep.dependency.dependency == discriminator
+
+    @pytest.mark.parametrize(
+        "versions_obj,expected_dict",
+        [
+            pytest.param(
+                PythonDependencyVersions(dependency="python", versions=["3.8.10"]),
+                {"dependency": "python", "version": "3.8.10"},
+                id="python_single_version",
+            ),
+            pytest.param(
+                PythonDependencyVersions(dependency="python", versions=["3.8.10", "3.9.5"]),
+                {"dependency": "python", "versions": ["3.8.10", "3.9.5"]},
+                id="python_multiple_versions",
+            ),
+            pytest.param(
+                RDependencyVersions(dependency="R", versions=["4.0.5"]),
+                {"dependency": "R", "version": "4.0.5"},
+                id="R_single_version",
+            ),
+            pytest.param(
+                RDependencyVersions(dependency="R", versions=["4.0.5", "4.1.2"]),
+                {"dependency": "R", "versions": ["4.0.5", "4.1.2"]},
+                id="R_multiple_versions",
+            ),
+            pytest.param(
+                QuartoDependencyVersions(dependency="quarto", versions=["1.7.34"]),
+                {"dependency": "quarto", "version": "1.7.34"},
+                id="quarto_single_version",
+            ),
+            pytest.param(
+                QuartoDependencyVersions(dependency="quarto", versions=["1.7.34", "1.6.43"]),
+                {"dependency": "quarto", "versions": ["1.7.34", "1.6.43"]},
+                id="quarto_multiple_versions",
+            ),
+        ],
+    )
+    def test_version_serialization(self, versions_obj: DependencyVersions, expected_dict: dict):
+        """Test that version serialization works as expected."""
+        serialized = versions_obj.model_dump(exclude_unset=True, exclude_defaults=True, exclude_none=True)
+        assert serialized == expected_dict


### PR DESCRIPTION
- Add `version` alias to `versions` validation.
- Coerce `versions` to `version` when only a single version is defined
- Update tests