### PR TITLE
Add explicit dependency for `packaging`

### DIFF
--- a/posit-bakery/poetry.lock
+++ b/posit-bakery/poetry.lock
@@ -660,7 +660,7 @@ version = "25.0"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484"},
     {file = "packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"},
@@ -1354,4 +1354,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "<4,>=3.10"
-content-hash = "45dba9e393c0d707dc5560ca709b430b663a1b585d8d8a4008571825a7d80438"
+content-hash = "68a81b4144533c1664f442a4bc05153069923c17cd5405a35d1f411458b4d6d9"

--- a/posit-bakery/pyproject.toml
+++ b/posit-bakery/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "ruamel-yaml (>=0.18.14,<0.19.0)",
     "requests (>=2.32.5,<3.0.0)",
     "requests-cache (>=1.2.1,<2.0.0)",
+    "packaging (>=25.0,<26.0)",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
This is used by the Dependency Verison logic and is causing failing
builds
