### PR TITLE
Prevent bad responses from caching

### DIFF
--- a/posit-bakery/posit_bakery/config/image/posit_product/main.py
+++ b/posit-bakery/posit_bakery/config/image/posit_product/main.py
@@ -36,9 +36,7 @@ class ReleaseStreamPath:
 
     def get(self, metadata: dict) -> ReleaseStreamResult:
         """Fetches data from the stream URL and resolves the data using the given resolvers."""
-        session = cached_session(
-            allowable_codes=[200],
-        )
+        session = cached_session()
         response = session.get(self.stream_url)
         response.raise_for_status()
         try:

--- a/posit-bakery/posit_bakery/util.py
+++ b/posit-bakery/posit_bakery/util.py
@@ -71,6 +71,8 @@ def cached_session(**kwargs) -> CachedSession:
         "backend": "filesystem",
         "use_temp": True,
         "allowable_methods": ["GET"],
+        "allowable_codes": [200],
+        "stale_if_error": True,
     }
     session_kwargs.update(kwargs)
 


### PR DESCRIPTION
Add `allowable_codes` and `stale_if_error` flags to prevent bad responses from being cached