### PR TITLE
Remove `log.exception` call to stop burying build errors

### DIFF
--- a/posit-bakery/posit_bakery/cli/build.py
+++ b/posit-bakery/posit_bakery/cli/build.py
@@ -86,7 +86,6 @@ def build(
     try:
         config.build_targets(load=load, push=push, cache=cache, strategy=strategy, fail_fast=fail_fast)
     except:
-        log.exception("Error building images")
         stderr_console.print(f"❌ Build failed", style="error")
         raise typer.Exit(code=1)
 


### PR DESCRIPTION
Closes https://github.com/posit-dev/images-shared/issues/223