### PR TITLE
Change GOSS_BIN to GOSS_PATH

### DIFF
--- a/posit-bakery/posit_bakery/image/goss/dgoss.py
+++ b/posit-bakery/posit_bakery/image/goss/dgoss.py
@@ -72,7 +72,7 @@ class DGossCommand(BaseModel):
             "GOSS_OPTS": "--format json --no-color",
         }
         if self.goss_bin:
-            env["GOSS_BIN"] = self.goss_bin
+            env["GOSS_PATH"] = self.goss_bin
         if self.wait > 0:
             env["GOSS_SLEEP"] = str(self.wait)
         return env


### PR DESCRIPTION
The docs list `GOSS_PATH`. It may have been changed in `dgoss` at some point.

https://goss.readthedocs.io/en/stable/containers/docker/?h=environment#goss_path