### PR TITLE
Make GitHub App secrets inputs optional

### DIFF
--- a/.github/workflows/bakery-build-native.yml
+++ b/.github/workflows/bakery-build-native.yml
@@ -57,10 +57,10 @@ on:
       # TODO: Remove secret requirements once repository is public
       APP_ID:
         description: "GitHub App ID with access to posit-dev repositories"
-        required: true
+        required: false
       APP_PRIVATE_KEY:
         description: "GitHub App private key with access to posit-dev repositories"
-        required: true
+        required: false
 
 defaults:
   run:
@@ -78,19 +78,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Token
-        uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          owner: posit-dev
-          repositories: images-shared
-
       - name: Install
         uses: "posit-dev/images-shared/setup-bakery@main"
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           version: ${{ inputs.version }}
 
@@ -116,19 +105,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Token
-        uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          owner: posit-dev
-          repositories: images-shared
-
       - name: Setup bakery
         uses: "posit-dev/images-shared/setup-bakery@main"
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           version: ${{ inputs.version }}
 
@@ -248,19 +226,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Token
-        uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          owner: posit-dev
-          repositories: images-shared
-
       - name: Setup bakery
         uses: "posit-dev/images-shared/setup-bakery@main"
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           version: ${{ inputs.version }}
 

--- a/.github/workflows/bakery-build.yml
+++ b/.github/workflows/bakery-build.yml
@@ -48,10 +48,10 @@ on:
       # TODO: Remove secret requirements once repository is public
       APP_ID:
         description: "GitHub App ID with access to posit-dev repositories"
-        required: true
+        required: false
       APP_PRIVATE_KEY:
         description: "GitHub App private key with access to posit-dev repositories"
-        required: true
+        required: false
 
 defaults:
   run:
@@ -68,19 +68,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Token
-        uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          owner: posit-dev
-          repositories: images-shared
-
       - name: Install
         uses: "posit-dev/images-shared/setup-bakery@main"
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           version: ${{ inputs.version }}
 
@@ -102,19 +91,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Token
-        uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          owner: posit-dev
-          repositories: images-shared
-
       - name: Setup bakery
         uses: "posit-dev/images-shared/setup-bakery@main"
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           version: ${{ inputs.version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
     needs:
       - test
       - bakery
+      - bakery-native
       - release
 
     steps:
@@ -107,9 +108,6 @@ jobs:
       packages: write
 
     uses: "./.github/workflows/bakery-build.yml"
-    secrets:
-      APP_ID: ${{ secrets.APP_ID }}
-      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
     with:
       version: ${{ github.head_ref || github.ref_name }}
       context: "./posit-bakery/test/resources/with-macros/"
@@ -122,9 +120,6 @@ jobs:
       packages: write
 
     uses: "./.github/workflows/bakery-build-native.yml"
-    secrets:
-      APP_ID: ${{ secrets.APP_ID }}
-      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
     with:
       version: ${{ github.head_ref || github.ref_name }}
       context: "./posit-bakery/test/resources/multiplatform/"
@@ -137,9 +132,6 @@ jobs:
       packages: write
 
     uses: "./.github/workflows/clean.yml"
-    secrets:
-      APP_ID: ${{ secrets.APP_ID }}
-      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
     with:
       version: ${{ github.head_ref || github.ref_name }}
       context: "./posit-bakery/test/resources/with-macros/"
@@ -151,7 +143,10 @@ jobs:
   release:
     name: Release/Snapshot
     if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') || github.event_name == 'pull_request')
-    needs: [test, bakery]
+    needs:
+      - test
+      - bakery
+      - bakery-native
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -54,10 +54,10 @@ on:
       # TODO: Remove secret requirements once repository is public
       APP_ID:
         description: "GitHub App ID with access to posit-dev repositories"
-        required: true
+        required: false
       APP_PRIVATE_KEY:
         description: "GitHub App private key with access to posit-dev repositories"
-        required: true
+        required: false
 
 defaults:
   run:
@@ -73,19 +73,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Token
-        uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          owner: posit-dev
-          repositories: images-shared
-
       - name: Setup bakery
         uses: "posit-dev/images-shared/setup-bakery@main"
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           version: ${{ inputs.version }}
 
@@ -115,19 +104,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Token
-        uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          owner: posit-dev
-          repositories: images-shared
-
       - name: Setup bakery
         uses: "posit-dev/images-shared/setup-bakery@main"
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           version: ${{ inputs.version }}
 

--- a/CI.md
+++ b/CI.md
@@ -83,8 +83,6 @@ jobs:
     uses: "posit-dev/images-shared/.github/workflows/bakery-build.yml@main"
     secrets:
       DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-      APP_ID: ${{ secrets.APP_ID }}
-      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
     with:
       dev-versions: "exclude"
       # Push images only for merges into main and weekly schduled re-builds.
@@ -104,9 +102,6 @@ jobs:
       packages: write
 
     uses: "posit-dev/images-shared/.github/workflows/bakery-build.yml@main"
-    secrets:
-      APP_ID: ${{ secrets.APP_ID }}
-      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
     with:
       dev-versions: "only"
       # Push images only for merges into main and hourly schduled re-builds.
@@ -211,8 +206,6 @@ jobs:
     uses: "posit-dev/images-shared/.github/workflows/bakery-build-native.yml@main"
     secrets:
       DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-      APP_ID: ${{ secrets.APP_ID }}
-      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
     with:
       dev-versions: "exclude"
       # Push images only for merges into main and weekly schduled re-builds.
@@ -229,9 +222,6 @@ jobs:
       contents: read
       packages: write
     uses: "posit-dev/images-shared/.github/workflows/bakery-build-native.yml@main"
-    secrets:
-      APP_ID: ${{ secrets.APP_ID }}
-      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
     with:
       dev-versions: "only"
       # Push images only for merges into main and hourly schduled re-builds.


### PR DESCRIPTION
Now that the repository is public, we no longer need to use GitHub App
authentication for cross-repository workflow invocations.

Step 1 is making these parameters optional. A follow-up PR will be
required to remove them completely after consuming workflows no longer
use them.
