### PR TITLE
Remove GITHUB token from the setup-bakery action

### DIFF
--- a/setup-bakery/action.yml
+++ b/setup-bakery/action.yml
@@ -10,10 +10,6 @@ inputs:
     description: "The version of Python to use"
     required: false
     default: "3.x"
-  setup-goss:
-    description: "Whether to install goss and dgoss tools"
-    required: false
-    default: "false"
 
 runs:
   using: "composite"
@@ -23,17 +19,7 @@ runs:
       with:
         python-version: "${{ inputs.python-version }}"
 
-    - name: Check Token
-      shell: bash
-      run: |
-        if [ -z "${GITHUB_TOKEN}" ]; then
-          echo "GITHUB_TOKEN environment variable is not set"
-          exit 1
-        fi
-
-    # Relies on the GITHUB_TOKEN environment variable
     - name: Install Bakery
       shell: bash
       run: |
-        gh auth setup-git
         pipx install "git+https://github.com/posit-dev/images-shared.git@${{ inputs.version }}#subdirectory=posit-bakery&egg=posit-bakery"


### PR DESCRIPTION
Since the repository is public, we no longer need to auth with GitHub in
order to pull down the repository.

Also remove the `setup-goss` parameter since that is independent now
