### PR TITLE
Add method to convert set options dictionary to string format for Docker Buildx Bake

### DIFF
--- a/posit-bakery/posit_bakery/config/config.py
+++ b/posit-bakery/posit_bakery/config/config.py
@@ -907,9 +907,7 @@ class BakeryConfig:
             )
             set_opts = None
             if self.settings.temp_registry is not None and push:
-                set_opts = {
-                    "*.output": [{"type": "image", "push-by-digest": True, "name-canonical": True, "push": True}]
-                }
+                set_opts = {"*.output": {"type": "image", "push-by-digest": True, "name-canonical": True, "push": True}}
             bake_plan.build(
                 load=load,
                 push=push,

--- a/posit-bakery/posit_bakery/image/bake/bake.py
+++ b/posit-bakery/posit_bakery/image/bake/bake.py
@@ -202,6 +202,24 @@ class BakePlan(BaseModel):
         """Delete the bake plan file if it exists."""
         self.bake_file.unlink(missing_ok=True)
 
+    @staticmethod
+    def _set_opts_dict_to_str(set_opts: dict[str, Any]) -> dict[str, str]:
+        """Convert a dictionary of set options to a comma-delimited, key=value string format for Docker Buildx Bake.
+
+        :param set_opts: A dictionary of set options to convert.
+
+        :return: A dictionary of set options with string values.
+        """
+        for opt, data in set_opts.items():
+            if isinstance(data, list):
+                set_opts[opt] = ",".join(data)
+            elif isinstance(data, dict):
+                set_opts[opt] = ",".join(f"{k}={v}" for k, v in data.items())
+            else:
+                set_opts[opt] = str(data)
+
+        return set_opts
+
     def build(
         self,
         load: bool = True,
@@ -229,6 +247,7 @@ class BakePlan(BaseModel):
             _set["*.cache-to"] = cache_to
         if set_opts:
             _set.update(set_opts)
+        _set = self._set_opts_dict_to_str(_set)
 
         python_on_whales.docker.buildx.bake(
             files=[self.bake_file.name], load=load, push=push, pull=pull, cache=cache, set=_set


### PR DESCRIPTION
Fixes the following error message when using `--strategy bake` with `--temp-registry` set:
```bash
$ bakery build --image-platform linux/amd64 --image-version 2025.12 --metadata-file package-manager-2025.12-amd64.json --temp-registry cripittwood.azurecr.io --push
[11:24:52] INFO     Loading Bakery config from /home/ianp/Projects/images-package-manager/bakery.yaml                                                                                                                                 config.py:333
[+] Building 22.6s (1/1) FINISHED                                                                                                                                                                                   docker-container:posit-builder
 => [internal] load local bake definitions                                                                                                                                                                                                    0.0s
 => => reading .bakery-bake.json 8.56kB / 8.56kB                                                                                                                                                                                              0.0s
ERROR: invalid value for outputs: invalid value [{'type': 'image'                                                                                                                                                                                  
❌ Build failed
```