### PR TITLE
Implement a `Tag` model for representing image tags

### DIFF
--- a/posit-bakery/posit_bakery/image/bake/bake.py
+++ b/posit-bakery/posit_bakery/image/bake/bake.py
@@ -98,7 +98,7 @@ class BakeTarget(BaseModel):
         :param platforms: Optional platform override (e.g., from CLI --platform flag). When provided, this takes
             precedence over the image target's OS platform configuration for cache tag generation.
         """
-        kwargs = {"tags": [str(tag) for tag in image_target.tags]}
+        kwargs = {"tags": image_target.tags.as_strings()}
         effective_platforms = platforms or (
             image_target.image_os.platforms if image_target.image_os is not None else DEFAULT_PLATFORMS
         )

--- a/posit-bakery/posit_bakery/image/image_target.py
+++ b/posit-bakery/posit_bakery/image/image_target.py
@@ -93,6 +93,9 @@ class Tag(BaseModel):
 
         return tag
 
+    def __repr__(self):
+        return self.__str__()
+
     def __ge__(self, other):
         if not isinstance(other, Tag):
             return NotImplemented
@@ -112,6 +115,14 @@ class Tag(BaseModel):
         if not isinstance(other, Tag):
             return NotImplemented
         return self.__str__() < other.__str__()
+
+
+class StringableList(list):
+    """A list that can convert all its items to strings"""
+
+    def as_strings(self) -> list[str]:
+        """Convert all items in the list to their string representation."""
+        return [str(item) for item in self]
 
 
 class ImageBuildStrategy(str, Enum):
@@ -312,11 +323,10 @@ class ImageTarget(BaseModel):
 
         return tags
 
-    @computed_field
     @property
-    def tags(self) -> list[Tag]:
+    def tags(self) -> StringableList[Tag]:
         """Generate tags for the image based on tag patterns."""
-        tags = []
+        tags: StringableList[Tag] = StringableList()
         for registry in self.image_version.all_registries or [None]:
             for suffix in self.tag_suffixes:
                 tags.append(
@@ -327,7 +337,8 @@ class ImageTarget(BaseModel):
                     )
                 )
 
-        return sorted(tags)
+        tags.sort()
+        return tags
 
     @computed_field
     @property
@@ -426,8 +437,7 @@ class ImageTarget(BaseModel):
 
     def remove(self, prune: bool = True, force: bool = False):
         """Remove the image from the local image cache or registry."""
-        for tag in self.tags:
-            tag = str(tag)
+        for tag in self.tags.as_strings():
             if python_on_whales.docker.image.exists(tag):
                 log.info(f"Deleting image '{tag}' from local cache.")
                 python_on_whales.docker.image.remove(tag, prune=prune, force=force)
@@ -471,7 +481,7 @@ class ImageTarget(BaseModel):
         if isinstance(metadata_file, bool) and metadata_file:
             metadata_file = SETTINGS.temporary_storage / f"{self.uid}.json"
 
-        tags = self.tags
+        tags = self.tags.as_strings()
         output = {}
         if self.temp_name is not None:
             tags = [self.temp_name]
@@ -479,7 +489,6 @@ class ImageTarget(BaseModel):
             if push:
                 output = {"type": "image", "push-by-digest": True, "name-canonical": True, "push": True}
                 push = False
-        tags = [str(tag) for tag in tags]
 
         # This context manager is **NOT** thread-safe. If we implement this as parallel in the future, the working
         # directory change should be managed at a higher level.
@@ -548,7 +557,7 @@ class ImageTarget(BaseModel):
         if dry_run:
             return python_on_whales.docker.buildx.imagetools.create(
                 sources=sources,
-                tags=self.tags,
+                tags=self.tags.as_strings(),
                 dry_run=dry_run,
             )
 
@@ -586,13 +595,15 @@ class ImageTarget(BaseModel):
 
             # Tag the index reference appropriately with each target tag.
             log.debug("Applying tags...")
-            for tag in self.tags:
+            for tag in self.tags.as_strings():
                 python_on_whales.docker.image.tag(index_ref, tag)
 
             # Push each tag to the target registries. Since every individual piece of the image has been pulled locally,
             # Docker will push all the component manifests as well as the index.
             log.info(f"Pushing image {self.uid}...")
-            python_on_whales.docker.image.push(self.tags, quiet=False if SETTINGS.log_level == logging.DEBUG else True)
+            python_on_whales.docker.image.push(
+                self.tags.as_strings(), quiet=False if SETTINGS.log_level == logging.DEBUG else True
+            )
 
         # Return the final manifest for the merged image as a sanity check.
-        return python_on_whales.docker.buildx.imagetools.inspect(self.tags[0])
+        return python_on_whales.docker.buildx.imagetools.inspect(str(self.tags[0]))

--- a/posit-bakery/test/cli/test_build.py
+++ b/posit-bakery/test/cli/test_build.py
@@ -62,7 +62,7 @@ def check_build_artifacts(resource_path, bakery_command, suite_name, get_config_
             for target_platform in target.image_os.platforms
         ):
             continue
-        for tag in target.tags:
+        for tag in target.tags.as_strings():
             python_on_whales.docker.image.exists(tag)
             for label, value in target.labels.items():
                 image = python_on_whales.docker.image.inspect(tag)
@@ -82,7 +82,7 @@ def check_multiplatform_build(resource_path, bakery_command, suite_name, get_con
 
     config = get_config_obj(suite_name)
     for target in config.targets:
-        for tag in target.tags:
+        for tag in target.tags.as_strings():
             for row in datatable:
                 platform = row[0]
                 if all(re.search(platform, target_platform) is None for target_platform in target.image_os.platforms):
@@ -103,7 +103,7 @@ def check_multiplatform_no_build(resource_path, bakery_command, suite_name, get_
 
     config = get_config_obj(suite_name)
     for target in config.targets:
-        for tag in target.tags:
+        for tag in target.tags.as_strings():
             for row in datatable:
                 platform = row[0]
                 proc = subprocess.run([docker_path, "image", "inspect", "--platform", platform, tag])
@@ -117,7 +117,7 @@ def check_build_artifacts_not_built(resource_path, bakery_command, suite_name, g
 
     config = get_config_obj(suite_name)
     for target in config.targets:
-        for tag in target.tags:
+        for tag in target.tags.as_strings():
             assert not python_on_whales.docker.image.exists(tag)
 
 

--- a/posit-bakery/test/helpers.py
+++ b/posit-bakery/test/helpers.py
@@ -55,14 +55,13 @@ def remove_images(obj: BakeryConfig | ImageTarget | None = None):
     """Remove any images created during testing."""
     if isinstance(obj, BakeryConfig):
         for target in obj.targets:
-            for tag in target.tags:
-                tag = str(tag)
+            for tag in target.tags.as_strings():
                 try:
                     python_on_whales.docker.image.remove(tag)
                 except python_on_whales.exceptions.DockerException:
                     pass
     elif isinstance(obj, ImageTarget):
-        for tag in obj.tags:
+        for tag in obj.tags.as_strings():
             try:
                 python_on_whales.docker.image.remove(tag)
             except python_on_whales.exceptions.DockerException:

--- a/posit-bakery/test/image/bake/test_bake.py
+++ b/posit-bakery/test/image/bake/test_bake.py
@@ -66,7 +66,7 @@ class TestBakeTarget:
         assert bake_target.image_os == "Ubuntu 22.04"
         assert bake_target.dockerfile == basic_standard_image_target.containerfile
         assert bake_target.labels == basic_standard_image_target.labels
-        assert bake_target.tags == [str(t) for t in basic_standard_image_target.tags]
+        assert bake_target.tags == basic_standard_image_target.tags.as_strings()
 
 
 class TestBakePlan:

--- a/posit-bakery/test/image/test_image_target.py
+++ b/posit-bakery/test/image/test_image_target.py
@@ -318,7 +318,7 @@ class TestImageTarget:
         ]
 
         assert len(expected_tags) == len(target.tags)
-        assert all(tag in [str(t) for t in target.tags] for tag in expected_tags)
+        assert all(tag in target.tags.as_strings() for tag in expected_tags)
 
     @pytest.mark.parametrize(
         "is_matrix,dependencies,values,expected_args",
@@ -521,7 +521,7 @@ class TestImageTarget:
             "context_path": basic_standard_image_target.context.base_path,
             "file": basic_standard_image_target.containerfile,
             "build_args": {},
-            "tags": [str(t) for t in basic_standard_image_target.tags],
+            "tags": basic_standard_image_target.tags.as_strings(),
             "labels": basic_standard_image_target.labels,
             "load": True,
             "push": False,
@@ -551,7 +551,7 @@ class TestImageTarget:
             "context_path": basic_standard_image_target.context.base_path,
             "file": basic_standard_image_target.containerfile,
             "build_args": {"PYTHON_VERSION": "3.13.7", "R_VERSION": "4.3.3"},
-            "tags": [str(t) for t in basic_standard_image_target.tags],
+            "tags": basic_standard_image_target.tags.as_strings(),
             "labels": basic_standard_image_target.labels,
             "load": True,
             "push": False,
@@ -577,7 +577,7 @@ class TestImageTarget:
             "context_path": basic_standard_image_target.context.base_path,
             "file": basic_standard_image_target.containerfile,
             "build_args": {},
-            "tags": [str(t) for t in basic_standard_image_target.tags],
+            "tags": basic_standard_image_target.tags.as_strings(),
             "labels": basic_standard_image_target.labels,
             "load": True,
             "push": False,
@@ -628,11 +628,10 @@ class TestImageTarget:
         image_targets = get_targets(suite)
         for target in image_targets:
             target.build()
-            for tag in target.tags:
-                tag_str = str(tag)
-                assert python_on_whales.docker.image.exists(tag_str)
+            for tag in target.tags.as_strings():
+                assert python_on_whales.docker.image.exists(tag)
                 for key, value in target.labels.items():
-                    meta = python_on_whales.docker.image.inspect(tag_str)
+                    meta = python_on_whales.docker.image.inspect(tag)
                     assert key in meta.config.labels
                     assert value == meta.config.labels[key]
 
@@ -647,11 +646,10 @@ class TestImageTarget:
         image_targets = get_targets(suite)
         for target in image_targets:
             target.build(metadata_file=True)
-            for tag in target.tags:
-                tag_str = str(tag)
-                assert python_on_whales.docker.image.exists(tag_str)
+            for tag in target.tags.as_strings():
+                assert python_on_whales.docker.image.exists(tag)
                 for key, value in target.labels.items():
-                    meta = python_on_whales.docker.image.inspect(tag_str)
+                    meta = python_on_whales.docker.image.inspect(tag)
                     assert key in meta.config.labels
                     assert value == meta.config.labels[key]
 
@@ -660,7 +658,8 @@ class TestImageTarget:
             with open(metadata_file) as f:
                 data = f.read()
             metadata = BuildMetadata.model_validate_json(data)
-            assert metadata.image_tags.sort() == [str(t) for t in target.tags].sort()
+            metadata.image_tags.sort()
+            assert metadata.image_tags == target.tags.as_strings()
 
             remove_images(target)
 
@@ -754,7 +753,7 @@ class TestImageTarget:
 
         patch_imagetools_create.assert_called_once_with(
             sources=expected_sources,
-            tags=basic_standard_image_target.tags,
+            tags=basic_standard_image_target.tags.as_strings(),
             dry_run=True,
         )
         assert isinstance(manifest, Manifest)
@@ -810,17 +809,17 @@ class TestImageTarget:
             quiet=True,
         )
 
-        for tag in basic_standard_image_target.tags:
+        for tag in basic_standard_image_target.tags.as_strings():
             patch_docker_tag.assert_any_call(
                 f"{expected_temp_tag}@{inspection_manifest.digest}",
                 tag,
             )
 
         patch_docker_push.assert_called_once_with(
-            basic_standard_image_target.tags,
+            basic_standard_image_target.tags.as_strings(),
             quiet=True,
         )
 
-        patch_imagetools_inspect.assert_called_once_with(basic_standard_image_target.tags[0])
+        patch_imagetools_inspect.assert_called_once_with(str(basic_standard_image_target.tags[0]))
 
         assert isinstance(manifest, Manifest)


### PR DESCRIPTION
Stacks #358

## Summary
I added this to make `oras` manipulations easier in a follow-up PR since we'll need to group operations by registry.

- Add `Tag` model to represent image tags and their subcomponents
- Update existing code to utilize new `Tag` models or convert to strings

## Test plan
- [x] Run `just test` - all 1089 tests pass
- [x] Run `poetry run mypy posit_bakery/` - no new type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)