### PR TITLE
Add home_path parameter to quarto TinyTeX installation macros

### DIFF
--- a/posit-bakery/posit_bakery/config/templating/macros/quarto.j2
+++ b/posit-bakery/posit_bakery/config/templating/macros/quarto.j2
@@ -24,9 +24,10 @@ ${{ name }}
 
 :param quarto_binary: The path to the Quarto binary.
 :param update_path: Adds --update-path to the command to add TinyTeX binaries to the PATH. Defaults to False.
+:param home_path: An optional path to set the HOME environment variable for the command, which controls where TinyTeX is installed. If not provided, TinyTeX will be installed to the default location under the current user's home directory.
 #}
-{% macro install_tinytex_command(quarto_binary, update_path = False) -%}
-{{ quarto_binary }} install tinytex --no-prompt --quiet{% if update_path %} --update-path{% endif %}
+{% macro install_tinytex_command(quarto_binary, update_path = False, home_path = None) -%}
+{% if home_path %}HOME="{{ home_path }}" {% endif %}{{ quarto_binary }} install tinytex --no-prompt --quiet{% if update_path %} --update-path{% endif %}
 {%- endmacro %}
 
 {# Command to download and install a specific version of Quarto, optionally installing TinyTeX as well
@@ -34,24 +35,26 @@ ${{ name }}
 :param version: The Quarto version to install, e.g. "1.8.24"
 :param with_tinytex: Whether to install TinyTeX along with Quarto. Defaults to False.
 :param tinytex_update_path: Adds --update-path to the TinyTeX install command to add TinyTeX binaries to the PATH. Defaults to False.
+:param tinytex_home_path: An optional path to set the HOME environment variable for the TinyTeX install command, which controls where TinyTeX is installed. If not provided, TinyTeX will be installed to the default location under the current user's home directory.
 #}
-{% macro install(version, with_tinytex = False, tinytex_update_path = False) -%}
+{% macro install(version, with_tinytex = False, tinytex_update_path = False, tinytex_home_path = None) -%}
 mkdir -p {{ get_version_directory(version) }} && \
 curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v{{ version | trim }}/quarto-{{ version | trim }}-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "{{ get_version_directory(version | trim) }}" --strip-components=1{% if with_tinytex %} && \
-{{ install_tinytex_command(get_version_directory(version | trim) + "/bin/quarto", tinytex_update_path) }}{% endif %}
+{{ install_tinytex_command(get_version_directory(version | trim) + "/bin/quarto", tinytex_update_path, tinytex_home_path) }}{% endif %}
 {%- endmacro %}
 
 {# Installs one or more versions of Quarto as separate RUN statements
 
 :param versions: A list of Quarto versions or a comma separated string of Quarto versions to install
 :param with_tinytex: Whether to install TinyTeX along with each Quarto version. Defaults to False.
+:param tinytex_home_path: An optional path to set the HOME environment variable for the TinyTeX install command, which controls where TinyTeX is installed. If not provided, TinyTeX will be installed to the default location under the current user's home directory.
 #}
-{% macro run_install(versions, with_tinytex = False, tinytex_update_path = False) -%}
+{% macro run_install(versions, with_tinytex = False, tinytex_update_path = False, tinytex_home_path = None) -%}
 {%- if versions is string -%}
 {%- set versions = versions | split(",") -%}
 {%- endif -%}
 {% for version in versions -%}
-RUN {{ install(version, with_tinytex, tinytex_update_path) | indent(4) }}
+RUN {{ install(version, with_tinytex, tinytex_update_path, tinytex_home_path) | indent(4) }}
 {%- if not loop.last %}{# Handles whitespace for next RUN line if present #}
 {% endif %}
 {%- endfor %}

--- a/posit-bakery/test/config/templating/test_macros.py
+++ b/posit-bakery/test/config/templating/test_macros.py
@@ -1529,35 +1529,50 @@ class TestQuartoMacros:
         assert rendered == expected
 
     @pytest.mark.parametrize(
-        "update_path,expected",
+        "update_path,home_path,expected",
         [
             pytest.param(
                 True,
+                None,
                 "/opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path",
                 id="with-update-path",
             ),
             pytest.param(
                 False,
+                None,
                 "/opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet",
                 id="without-update-path",
             ),
+            pytest.param(
+                False,
+                "/root",
+                'HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet',
+                id="with-home-path",
+            ),
+            pytest.param(
+                True,
+                "/root",
+                'HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path',
+                id="with-home-path-and-update-path",
+            ),
         ],
     )
-    def test_install_tinytex_command(self, environment_with_macros, update_path, expected):
+    def test_install_tinytex_command(self, environment_with_macros, update_path, home_path, expected):
         template = textwrap.dedent(
             """\
             {%- import "quarto.j2" as quarto -%}
-            {{ quarto.install_tinytex_command("/opt/quarto/1.8.24/bin/quarto", update_path) }}"""
+            {{ quarto.install_tinytex_command("/opt/quarto/1.8.24/bin/quarto", update_path, home_path) }}"""
         )
-        rendered = environment_with_macros.from_string(template).render(update_path=update_path)
+        rendered = environment_with_macros.from_string(template).render(update_path=update_path, home_path=home_path)
         assert rendered == expected
 
     @pytest.mark.parametrize(
-        "with_tinytex,tinytex_update_path,expected",
+        "with_tinytex,tinytex_update_path,tinytex_home_path,expected",
         [
             pytest.param(
                 False,
                 False,
+                None,
                 textwrap.dedent(
                     """\
                     mkdir -p /opt/quarto/1.8.24 && \\
@@ -1568,6 +1583,7 @@ class TestQuartoMacros:
             pytest.param(
                 False,
                 True,
+                None,
                 textwrap.dedent(
                     """\
                     mkdir -p /opt/quarto/1.8.24 && \\
@@ -1578,6 +1594,7 @@ class TestQuartoMacros:
             pytest.param(
                 True,
                 False,
+                None,
                 textwrap.dedent(
                     """\
                     mkdir -p /opt/quarto/1.8.24 && \\
@@ -1589,6 +1606,7 @@ class TestQuartoMacros:
             pytest.param(
                 True,
                 True,
+                None,
                 textwrap.dedent(
                     """\
                     mkdir -p /opt/quarto/1.8.24 && \\
@@ -1597,16 +1615,43 @@ class TestQuartoMacros:
                 ),
                 id="with-tinytex-update-path",
             ),
+            pytest.param(
+                True,
+                False,
+                "/root",
+                textwrap.dedent(
+                    """\
+                    mkdir -p /opt/quarto/1.8.24 && \\
+                    curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
+                    HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet"""
+                ),
+                id="with-tinytex-home-path",
+            ),
+            pytest.param(
+                True,
+                True,
+                "/root",
+                textwrap.dedent(
+                    """\
+                    mkdir -p /opt/quarto/1.8.24 && \\
+                    curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
+                    HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path"""
+                ),
+                id="with-tinytex-home-path-update-path",
+            ),
         ],
     )
-    def test_install(self, environment_with_macros, with_tinytex, tinytex_update_path, expected):
+    def test_install(self, environment_with_macros, with_tinytex, tinytex_update_path, tinytex_home_path, expected):
         template = textwrap.dedent(
             """\
             {%- import "quarto.j2" as quarto -%}
-            {{ quarto.install(version, with_tinytex, tinytex_update_path) }}"""
+            {{ quarto.install(version, with_tinytex, tinytex_update_path, tinytex_home_path) }}"""
         )
         rendered = environment_with_macros.from_string(template).render(
-            version="1.8.24", with_tinytex=with_tinytex, tinytex_update_path=tinytex_update_path
+            version="1.8.24",
+            with_tinytex=with_tinytex,
+            tinytex_update_path=tinytex_update_path,
+            tinytex_home_path=tinytex_home_path,
         )
         assert rendered == expected
 
@@ -1614,7 +1659,7 @@ class TestQuartoMacros:
         "input,expected",
         [
             pytest.param(
-                (["1.8.24"], False, False),
+                (["1.8.24"], False, False, None),
                 textwrap.dedent(
                     """\
                     RUN mkdir -p /opt/quarto/1.8.24 && \\
@@ -1623,7 +1668,7 @@ class TestQuartoMacros:
                 id="single-version-no-tinytex",
             ),
             pytest.param(
-                (["1.8.24", "1.7.8"], False, False),
+                (["1.8.24", "1.7.8"], False, False, None),
                 textwrap.dedent(
                     """\
                     RUN mkdir -p /opt/quarto/1.8.24 && \\
@@ -1634,7 +1679,7 @@ class TestQuartoMacros:
                 id="multiple-versions-no-tinytex",
             ),
             pytest.param(
-                ("1.8.24,1.7.8", False, False),
+                ("1.8.24,1.7.8", False, False, None),
                 textwrap.dedent(
                     """\
                     RUN mkdir -p /opt/quarto/1.8.24 && \\
@@ -1645,7 +1690,7 @@ class TestQuartoMacros:
                 id="string-versions-no-tinytex",
             ),
             pytest.param(
-                (["1.8.24"], True, False),
+                (["1.8.24"], True, False, None),
                 textwrap.dedent(
                     """\
                     RUN mkdir -p /opt/quarto/1.8.24 && \\
@@ -1655,7 +1700,7 @@ class TestQuartoMacros:
                 id="single-version-with-tinytex",
             ),
             pytest.param(
-                (["1.8.24", "1.7.8"], True, False),
+                (["1.8.24", "1.7.8"], True, False, None),
                 textwrap.dedent(
                     """\
                     RUN mkdir -p /opt/quarto/1.8.24 && \\
@@ -1668,7 +1713,7 @@ class TestQuartoMacros:
                 id="multiple-versions-with-tinytex",
             ),
             pytest.param(
-                (["1.8.24"], True, True),
+                (["1.8.24"], True, True, None),
                 textwrap.dedent(
                     """\
                     RUN mkdir -p /opt/quarto/1.8.24 && \\
@@ -1678,7 +1723,7 @@ class TestQuartoMacros:
                 id="single-version-with-tinytex-update-path",
             ),
             pytest.param(
-                (["1.8.24", "1.7.8"], True, True),
+                (["1.8.24", "1.7.8"], True, True, None),
                 textwrap.dedent(
                     """\
                     RUN mkdir -p /opt/quarto/1.8.24 && \\
@@ -1689,6 +1734,52 @@ class TestQuartoMacros:
                         /opt/quarto/1.7.8/bin/quarto install tinytex --no-prompt --quiet --update-path"""
                 ),
                 id="multiple-versions-with-tinytex-update-path",
+            ),
+            pytest.param(
+                (["1.8.24"], True, False, "/root"),
+                textwrap.dedent(
+                    """\
+                    RUN mkdir -p /opt/quarto/1.8.24 && \\
+                        curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
+                        HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet"""
+                ),
+                id="single-version-with-tinytex-home-path",
+            ),
+            pytest.param(
+                (["1.8.24", "1.7.8"], True, False, "/root"),
+                textwrap.dedent(
+                    """\
+                    RUN mkdir -p /opt/quarto/1.8.24 && \\
+                        curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
+                        HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet
+                    RUN mkdir -p /opt/quarto/1.7.8 && \\
+                        curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.7.8/quarto-1.7.8-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.7.8" --strip-components=1 && \\
+                        HOME="/root" /opt/quarto/1.7.8/bin/quarto install tinytex --no-prompt --quiet"""
+                ),
+                id="multiple-versions-with-tinytex-home-path",
+            ),
+            pytest.param(
+                (["1.8.24"], True, True, "/root"),
+                textwrap.dedent(
+                    """\
+                    RUN mkdir -p /opt/quarto/1.8.24 && \\
+                        curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
+                        HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path"""
+                ),
+                id="single-version-with-tinytex-home-path-update-path",
+            ),
+            pytest.param(
+                (["1.8.24", "1.7.8"], True, True, "/root"),
+                textwrap.dedent(
+                    """\
+                    RUN mkdir -p /opt/quarto/1.8.24 && \\
+                        curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
+                        HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path
+                    RUN mkdir -p /opt/quarto/1.7.8 && \\
+                        curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.7.8/quarto-1.7.8-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.7.8" --strip-components=1 && \\
+                        HOME="/root" /opt/quarto/1.7.8/bin/quarto install tinytex --no-prompt --quiet --update-path"""
+                ),
+                id="multiple-versions-with-tinytex-home-path-update-path",
             ),
         ],
     )


### PR DESCRIPTION
## Summary
- Add `home_path` parameter to `install_tinytex_command` macro to override the HOME environment variable during TinyTeX installation
- Add `tinytex_home_path` parameter to `install` and `run_install` macros to pass through to `install_tinytex_command`
- Update tests to cover all new parameter combinations

## Test plan
- [x] All `TestQuartoMacros` tests pass (29 tests)
- [ ] Manual verification in a container build that uses the `tinytex_home_path` parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)