### PR TITLE
Add --retry option to bakery build command

### DIFF
--- a/.github/workflows/bakery-build-native.yml
+++ b/.github/workflows/bakery-build-native.yml
@@ -32,6 +32,11 @@ on:
         default: false
         required: false
         type: boolean
+      retry:
+        description: "Number of times to retry a failed build [default: 1]"
+        default: 1
+        required: false
+        type: number
       merge-builder:
         description: "The type of runner to use for merging. Larger images require expanded runners. [default: ubuntu-latest]"
         default: "ubuntu-latest"
@@ -184,6 +189,7 @@ jobs:
           PLATFORM=${BUILD_PLATFORM#linux/} \
           bakery build \
             --strategy build --pull \
+            --retry ${{ inputs.retry }} \
             --image-name '^${{ matrix.img.image }}$' \
             --image-version ${{ matrix.img.version }} \
             --image-platform ${{ matrix.img.platform }} \

--- a/.github/workflows/bakery-build.yml
+++ b/.github/workflows/bakery-build.yml
@@ -33,6 +33,11 @@ on:
         default: false
         required: false
         type: boolean
+      retry:
+        description: "Number of times to retry a failed build [default: 1]"
+        default: 1
+        required: false
+        type: number
       runs-on:
         description: "The type of runner to use [default: ubuntu-latest]"
         default: "ubuntu-latest"
@@ -152,6 +157,7 @@ jobs:
         # FIXME: Currently pushes to ghcr.io for caching. Needs to be conditional
         run: |
           bakery build --load --pull \
+            --retry ${{ inputs.retry }} \
             --image-name '^${{ matrix.img.image }}$' \
             --image-version ${{ matrix.img.version }} \
             --dev-versions ${{ inputs.dev-versions }} \
@@ -179,6 +185,7 @@ jobs:
           GIT_SHA: ${{ github.sha }}
         run: |
           bakery build --push --pull \
+            --retry ${{ inputs.retry }} \
             --image-name '^${{ matrix.img.image }}$' \
             --image-version ${{ matrix.img.version }} \
             --dev-versions ${{ inputs.dev-versions }} \

--- a/posit-bakery/posit_bakery/cli/build.py
+++ b/posit-bakery/posit_bakery/cli/build.py
@@ -58,6 +58,14 @@ def build(
             rich_help_panel=RichHelpPanelEnum.BUILD_CONFIGURATION_AND_OUTPUTS,
         ),
     ] = False,
+    retry: Annotated[
+        int,
+        typer.Option(
+            min=0,
+            help="Number of times to retry a failed build.",
+            rich_help_panel=RichHelpPanelEnum.BUILD_CONFIGURATION_AND_OUTPUTS,
+        ),
+    ] = 0,
     plan: Annotated[
         Optional[bool],
         typer.Option(
@@ -225,6 +233,7 @@ def build(
             platforms=image_platform,
             strategy=strategy,
             fail_fast=fail_fast,
+            retry=retry,
             metadata_file=metadata_file,
         )
     except (python_on_whales.DockerException, BakeryToolRuntimeError):

--- a/posit-bakery/posit_bakery/config/config.py
+++ b/posit-bakery/posit_bakery/config/config.py
@@ -4,6 +4,7 @@ import logging
 import os
 import re
 import shutil
+import time
 from datetime import timedelta
 from pathlib import Path
 from typing import Annotated, Self, Any
@@ -43,6 +44,32 @@ from posit_bakery.image.oras import OrasMergeWorkflow
 from posit_bakery.registry_management import ghcr
 
 log = logging.getLogger(__name__)
+
+_RETRY_DELAY_SECONDS = 5
+
+
+def _retry_build(fn, retry: int, label: str) -> None:
+    """Attempt fn() up to (retry + 1) times, re-raising on final failure.
+
+    :param fn: The function to call.
+    :param retry: Number of retries (0 means no retries, just one attempt).
+    :param label: A label for logging purposes.
+    """
+    for attempt in range(retry + 1):
+        try:
+            fn()
+            return
+        except BakeryFileError:
+            raise  # Never retry file errors
+        except (DockerException, BakeryToolRuntimeError) as e:
+            if attempt < retry:
+                log.warning(
+                    f"Build failed for '{label}' (attempt {attempt + 1}/{retry + 1}). "
+                    f"Retrying in {_RETRY_DELAY_SECONDS}s..."
+                )
+                time.sleep(_RETRY_DELAY_SECONDS)
+            else:
+                raise
 
 
 class BakeryConfigDocument(BakeryPathMixin, BakeryYAMLModel):
@@ -891,6 +918,7 @@ class BakeryConfig:
         strategy: ImageBuildStrategy = ImageBuildStrategy.BAKE,
         metadata_file: Path | None = None,
         fail_fast: bool = False,
+        retry: int = 0,
     ):
         """Build image targets using the specified strategy.
 
@@ -903,6 +931,7 @@ class BakeryConfig:
         :param strategy: The strategy to use when building images.
         :param metadata_file: Optional path to a metadata file to write build metadata to.
         :param fail_fast: If True, stop building targets on the first failure.
+        :param retry: Number of times to retry a failed build (default 0, no retries).
         """
         if strategy == ImageBuildStrategy.BAKE:
             bake_plan = BakePlan.from_image_targets(
@@ -911,28 +940,36 @@ class BakeryConfig:
             set_opts = None
             if self.settings.temp_registry is not None and push:
                 set_opts = {"*.output": {"type": "image", "push-by-digest": True, "name-canonical": True, "push": True}}
-            bake_plan.build(
-                load=load,
-                push=push,
-                pull=pull,
-                cache=cache,
-                clean_bakefile=self.settings.clean_temporary,
-                platforms=platforms,
-                set_opts=set_opts,
+            _retry_build(
+                lambda: bake_plan.build(
+                    load=load,
+                    push=push,
+                    pull=pull,
+                    cache=cache,
+                    clean_bakefile=self.settings.clean_temporary,
+                    platforms=platforms,
+                    set_opts=set_opts,
+                ),
+                retry=retry,
+                label="bake plan",
             )
         elif strategy == ImageBuildStrategy.BUILD:
             errors: list[Exception] = []
             for target in self.targets:
                 try:
-                    target.build(
-                        load=load,
-                        push=push,
-                        pull=pull,
-                        cache=cache,
-                        platforms=platforms,
-                        metadata_file=True if metadata_file else False,
+                    _retry_build(
+                        lambda t=target: t.build(
+                            load=load,
+                            push=push,
+                            pull=pull,
+                            cache=cache,
+                            platforms=platforms,
+                            metadata_file=True if metadata_file else False,
+                        ),
+                        retry=retry,
+                        label=str(target),
                     )
-                except (BakeryFileError, DockerException) as e:
+                except (BakeryFileError, DockerException, BakeryToolRuntimeError) as e:
                     log.error(f"Failed to build image target '{str(target)}'.")
                     if fail_fast:
                         log.info("--fail-fast is set, stopping builds...")

--- a/posit-bakery/posit_bakery/image/bake/bake.py
+++ b/posit-bakery/posit_bakery/image/bake/bake.py
@@ -235,24 +235,24 @@ class BakePlan(BaseModel):
         """Run the bake plan to build all targets."""
         original_cwd = os.getcwd()
         os.chdir(self.context)
+        try:
+            self.write()
 
-        self.write()
+            _set = {}
+            if platforms:
+                _set["*.platform"] = ",".join(platforms)
+            if cache_from:
+                _set["*.cache-from"] = cache_from
+            if cache_to:
+                _set["*.cache-to"] = cache_to
+            if set_opts:
+                _set.update(set_opts)
+            _set = self._set_opts_dict_to_str(_set)
 
-        _set = {}
-        if platforms:
-            _set["*.platform"] = ",".join(platforms)
-        if cache_from:
-            _set["*.cache-from"] = cache_from
-        if cache_to:
-            _set["*.cache-to"] = cache_to
-        if set_opts:
-            _set.update(set_opts)
-        _set = self._set_opts_dict_to_str(_set)
-
-        python_on_whales.docker.buildx.bake(
-            files=[self.bake_file.name], load=load, push=push, pull=pull, cache=cache, set=_set
-        )
-        if clean_bakefile:
-            self.remove()
-
-        os.chdir(original_cwd)
+            python_on_whales.docker.buildx.bake(
+                files=[self.bake_file.name], load=load, push=push, pull=pull, cache=cache, set=_set
+            )
+            if clean_bakefile:
+                self.remove()
+        finally:
+            os.chdir(original_cwd)

--- a/posit-bakery/test/config/test_build_retry.py
+++ b/posit-bakery/test/config/test_build_retry.py
@@ -1,0 +1,113 @@
+"""Tests for the build retry functionality."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from python_on_whales import DockerException
+
+from posit_bakery.config.config import _retry_build, _RETRY_DELAY_SECONDS
+from posit_bakery.error import BakeryFileError, BakeryToolRuntimeError
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.config,
+]
+
+
+class TestRetryBuild:
+    """Tests for the _retry_build helper function."""
+
+    def test_successful_build_no_retry_needed(self):
+        """Test that a successful build completes without retries."""
+        mock_fn = MagicMock()
+
+        _retry_build(mock_fn, retry=2, label="test-target")
+
+        mock_fn.assert_called_once()
+
+    @patch("posit_bakery.config.config.time.sleep")
+    def test_retry_on_docker_exception_then_success(self, mock_sleep):
+        """Test that DockerException triggers retry and succeeds on second attempt."""
+        mock_fn = MagicMock(side_effect=[DockerException(["docker", "build"], 1), None])
+
+        _retry_build(mock_fn, retry=1, label="test-target")
+
+        assert mock_fn.call_count == 2
+        mock_sleep.assert_called_once_with(_RETRY_DELAY_SECONDS)
+
+    @patch("posit_bakery.config.config.time.sleep")
+    def test_retry_on_bakery_tool_runtime_error_then_success(self, mock_sleep):
+        """Test that BakeryToolRuntimeError triggers retry and succeeds on second attempt."""
+        mock_fn = MagicMock(
+            side_effect=[BakeryToolRuntimeError("Build failed", cmd=["docker", "build"]), None]
+        )
+
+        _retry_build(mock_fn, retry=1, label="test-target")
+
+        assert mock_fn.call_count == 2
+        mock_sleep.assert_called_once_with(_RETRY_DELAY_SECONDS)
+
+    @patch("posit_bakery.config.config.time.sleep")
+    def test_all_retries_exhausted_raises_exception(self, mock_sleep):
+        """Test that exception is raised when all retries are exhausted."""
+        error = DockerException(["docker", "build"], 1)
+        mock_fn = MagicMock(side_effect=error)
+
+        with pytest.raises(DockerException):
+            _retry_build(mock_fn, retry=2, label="test-target")
+
+        assert mock_fn.call_count == 3  # initial + 2 retries
+        assert mock_sleep.call_count == 2
+
+    def test_bakery_file_error_not_retried(self):
+        """Test that BakeryFileError is never retried."""
+        error = BakeryFileError("File not found", filepath="/path/to/file")
+        mock_fn = MagicMock(side_effect=error)
+
+        with pytest.raises(BakeryFileError):
+            _retry_build(mock_fn, retry=3, label="test-target")
+
+        # Should only be called once, no retries
+        mock_fn.assert_called_once()
+
+    @patch("posit_bakery.config.config.time.sleep")
+    def test_retry_zero_means_no_retries(self, mock_sleep):
+        """Test that retry=0 means no retries, just one attempt."""
+        error = DockerException(["docker", "build"], 1)
+        mock_fn = MagicMock(side_effect=error)
+
+        with pytest.raises(DockerException):
+            _retry_build(mock_fn, retry=0, label="test-target")
+
+        mock_fn.assert_called_once()
+        mock_sleep.assert_not_called()
+
+    @patch("posit_bakery.config.config.time.sleep")
+    def test_multiple_retries_then_success(self, mock_sleep):
+        """Test multiple failures before eventual success."""
+        mock_fn = MagicMock(
+            side_effect=[
+                DockerException(["docker", "build"], 1),
+                BakeryToolRuntimeError("Network error", cmd=["docker", "push"]),
+                None,  # Success on third attempt
+            ]
+        )
+
+        _retry_build(mock_fn, retry=2, label="test-target")
+
+        assert mock_fn.call_count == 3
+        assert mock_sleep.call_count == 2
+
+    @patch("posit_bakery.config.config.time.sleep")
+    def test_logs_warning_on_retry(self, mock_sleep, caplog):
+        """Test that a warning is logged when retrying."""
+        import logging
+
+        caplog.set_level(logging.WARNING)
+        mock_fn = MagicMock(side_effect=[DockerException(["docker", "build"], 1), None])
+
+        _retry_build(mock_fn, retry=1, label="my-test-target")
+
+        assert "Build failed for 'my-test-target'" in caplog.text
+        assert "attempt 1/2" in caplog.text
+        assert f"Retrying in {_RETRY_DELAY_SECONDS}s" in caplog.text


### PR DESCRIPTION
## Summary
- Add `--retry` CLI option to `bakery build` command (default: 0 for CLI, 1 for CI workflows)
- Add `_retry_build()` helper that retries transient failures (DockerException, BakeryToolRuntimeError) with 5-second delay
- Fix `os.chdir` safety in `BakePlan.build()` to restore cwd on exception
- Add comprehensive unit tests for retry functionality

## Test plan
- [x] All 1176 existing tests pass
- [x] New retry tests in `test_build_retry.py` cover success, retry-then-success, exhausted retries, and BakeryFileError (never retried)
- [x] `bakery build --help` shows `--retry` option
- [ ] Manual test with failing build to verify retry behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)