### PR TITLE
Handle ORAS temp index cleanup failure gracefully

### DIFF
--- a/posit-bakery/posit_bakery/image/oras/oras.py
+++ b/posit-bakery/posit_bakery/image/oras/oras.py
@@ -241,14 +241,17 @@ class OrasMergeWorkflow(BaseModel):
                 )
                 copy_cmd.run(dry_run=dry_run)
 
-            # Step 3: Delete the temporary index
+            # Step 3: Delete the temporary index (non-fatal)
             log.info(f"Cleaning up temporary index {self.temp_index_tag}")
             delete_cmd = OrasManifestDelete(
                 oras_bin=self.oras_bin,
                 reference=self.temp_index_tag,
                 plain_http=self.plain_http,
             )
-            delete_cmd.run(dry_run=dry_run)
+            try:
+                delete_cmd.run(dry_run=dry_run)
+            except BakeryToolRuntimeError as e:
+                log.warning(f"Failed to clean up temporary index {self.temp_index_tag}: {e}")
 
             log.info(f"ORAS merge workflow completed successfully")
             return OrasMergeWorkflowResult(


### PR DESCRIPTION
It looks like GCHR doesn't  support manifest deletion via the
OCI Distribution API with GITHUB_TOKEN (requires delete:packages scope).
The cleanup step now logs a warning instead of failing the
entire merge workflow.
