### PR TITLE
Add PreToolUse hook to enforce git -C pattern

### DIFF
--- a/.claude/hooks/enforce-git-c.sh
+++ b/.claude/hooks/enforce-git-c.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# PreToolUse hook for Bash commands.
+# Blocks "cd <dir> && git ..." patterns and instructs Claude to use "git -C <dir> ..." instead.
+# This avoids permission prompts when committing in sibling repositories because
+# "git -C <dir> add ..." matches "Bash(git add:*)" while "cd <dir> && git add ..." does not.
+
+set -euo pipefail
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+if [[ -z "$COMMAND" ]]; then
+  exit 0
+fi
+
+# Match: cd <path> && git <subcommand>
+# Also match: cd <path> ; git <subcommand>
+# Allow multiple && chains as long as git isn't after cd
+if echo "$COMMAND" | grep -qP '^\s*cd\s+\S+.*[;&]+\s*git\s'; then
+  cat >&2 <<'MSG'
+Do not use "cd <dir> && git ..." or "cd <dir> ; git ...".
+Use "git -C <dir> ..." instead. Each git subcommand should be a separate call:
+
+  git -C <dir> add <files>
+  git -C <dir> commit -m "message"
+  git -C <dir> status
+
+This matches the project's allowed Bash permission patterns and avoids interactive prompts.
+MSG
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,19 @@
   "enabledPlugins": {
     "pyright-lsp@claude-plugins-official": true
   },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/enforce-git-c.sh"
+          }
+        ]
+      }
+    ]
+  },
   "permissions": {
     "additionalDirectories": [
       "../images",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     -   id: no-commit-to-branch
         args: [--branch, main]
     -   id: pretty-format-json
-        exclude: "^.*testdata.*json$"
+        exclude: "^(.*testdata.*json|\\.claude/settings\\.json)$"
     -   id: requirements-txt-fixer
     -   id: trailing-whitespace
         exclude: "docs/_extensions"


### PR DESCRIPTION
When committing in sibling repositories, Claude chains
"cd <dir> && git add" which doesn't match permission rules
like "Bash(git add:*)" — the entire string starts with "cd".
This triggers interactive permission prompts every time.

- Add hook that blocks "cd <dir> && git ..." and instructs
  Claude to use "git -C <dir> ..." instead
- Exclude .claude/settings.json from pretty-format-json
  pre-commit hook to preserve key ordering
