### PR TITLE
Replace remaining pipx/poetry refs with uv

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -34,7 +34,7 @@
       "Bash(gh run watch:*)",
       "Bash(bakery *)",
       "Bash(just test:*)",
-      "Bash(poetry run:*)",
+      "Bash(uv run:*)",
       "Bash(python3:*)",
       "WebFetch(domain:github.com)",
       "WebFetch(domain:raw.githubusercontent.com)"

--- a/.gitignore
+++ b/.gitignore
@@ -97,12 +97,9 @@ ipython_config.py
 #   install all needed dependencies.
 #Pipfile.lock
 
-# poetry
-#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
-#   This is especially recommended for binary packages to ensure reproducibility, and is more
-#   commonly ignored for libraries.
-#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
-#poetry.lock
+# uv
+#   https://docs.astral.sh/uv/concepts/projects/layout/#the-lockfile
+#uv.lock
 
 # pdm
 #   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.

--- a/justfile
+++ b/justfile
@@ -19,7 +19,7 @@ setup:
 
 [private]
 _python-executable executable:
-    echo -e "\n{{ executable }} not found, please install it using one of\n  pipx install {{ executable }}\n  uvx install {{ executable }}\n"
+    echo -e "\n{{ executable }} not found, please install it with\n  uv tool install {{ executable }}\n"
     exit 1
 
 [private]

--- a/setup-bakery/action.yml
+++ b/setup-bakery/action.yml
@@ -14,6 +14,9 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Setup uv
+      uses: astral-sh/setup-uv@v6
+
     - name: Setup Python
       uses: actions/setup-python@v6
       with:
@@ -22,4 +25,4 @@ runs:
     - name: Install Bakery
       shell: bash
       run: |
-        pipx install "git+https://github.com/posit-dev/images-shared.git@${{ inputs.version }}#subdirectory=posit-bakery&egg=posit-bakery"
+        uv tool install "git+https://github.com/posit-dev/images-shared.git@${{ inputs.version }}#subdirectory=posit-bakery&egg=posit-bakery"


### PR DESCRIPTION
## Summary
- Replace `poetry run` permission with `uv run` in `.claude/settings.json`
- Replace poetry.lock gitignore section with uv.lock
- Fix justfile error message to say `uv tool install` instead of `pipx install`/`uvx install`
- Replace `pipx install` with `uv tool install` in `setup-bakery/action.yml`
- Add `astral-sh/setup-uv@v6` step to CI action since uv isn't pre-installed on GHA runners

## Test plan
- [ ] Verify `setup-bakery` action works in a CI run after `feature/use-uv` merges