### PR TITLE
Use self-hosted runner for merge jobs

### DIFF
--- a/.github/workflows/bakery-build-native.yml
+++ b/.github/workflows/bakery-build-native.yml
@@ -38,8 +38,8 @@ on:
         required: false
         type: number
       merge-builder:
-        description: "The type of runner to use for merging. Larger images require expanded runners. [default: ubuntu-latest]"
-        default: "ubuntu-latest"
+        description: "The type of runner to use for merging [default: ubuntu-latest-4x]"
+        default: "ubuntu-latest-4x"
         required: false
         type: string
       amd64-builder:


### PR DESCRIPTION
## Summary
- Change `merge-builder` default from `ubuntu-latest` to `ubuntu-latest-4x`
- Remove stale comment about larger images from the input description

No callers override `merge-builder`, so this change applies to all repos using `bakery-build-native.yml`.

## Test plan
- [x] Verify merge jobs run on `ubuntu-latest-4x` in the next native build