### PR TITLE
fix: use separate default tag patterns for matrix images

### DIFF
--- a/posit-bakery/posit_bakery/config/image/image.py
+++ b/posit-bakery/posit_bakery/config/image/image.py
@@ -10,7 +10,7 @@ from pydantic_core.core_schema import ValidationInfo
 from posit_bakery.config.dependencies import DependencyConstraintField, DependencyVersions, DependencyConstraint
 from posit_bakery.config.registry import BaseRegistry, Registry
 from posit_bakery.config.shared import BakeryPathMixin, BakeryYAMLModel
-from posit_bakery.config.tag import default_tag_patterns, TagPattern
+from posit_bakery.config.tag import default_matrix_tag_patterns, default_tag_patterns, TagPattern
 from posit_bakery.config.tools import ToolField, ToolOptions
 from .dev_version import DevelopmentVersionField
 from .matrix import ImageMatrix
@@ -63,14 +63,6 @@ class Image(BakeryPathMixin, BakeryYAMLModel):
             description="List of registries to use in place of registries defined globally or for the image.",
         ),
     ]
-    tagPatterns: Annotated[
-        list[TagPattern],
-        Field(
-            default_factory=default_tag_patterns,
-            validate_default=True,
-            description="List of tag patterns for this image.",
-        ),
-    ]
     dependencyConstraints: Annotated[
         list[DependencyConstraintField],
         Field(
@@ -101,6 +93,16 @@ class Image(BakeryPathMixin, BakeryYAMLModel):
             default=None,
             validate_default=True,
             description="Matrix configuration for generating image versions.",
+        ),
+    ]
+    tagPatterns: Annotated[
+        list[TagPattern],
+        Field(
+            default_factory=lambda data: default_matrix_tag_patterns()
+            if data.get("matrix") is not None
+            else default_tag_patterns(),
+            validate_default=True,
+            description="List of tag patterns for this image.",
         ),
     ]
     buildTarget: Annotated[

--- a/posit-bakery/posit_bakery/config/tag.py
+++ b/posit-bakery/posit_bakery/config/tag.py
@@ -113,3 +113,34 @@ def default_tag_patterns() -> list[TagPattern]:
             only=[TagPatternFilter.LATEST, TagPatternFilter.PRIMARY_OS, TagPatternFilter.PRIMARY_VARIANT],
         ),
     ]
+
+
+def default_matrix_tag_patterns() -> list[TagPattern]:
+    """Return the default tag patterns for matrix images in the Bakery configuration.
+
+    Matrix images use composite version names (e.g., "R4.3.3-python3.11.15") where the
+    hyphen separators conflict with the stripMetadata filter, which strips from the last
+    hyphen onward. This set excludes stripMetadata patterns to avoid tag collisions across
+    matrix combinations. It also excludes latest-filtered patterns since matrices are
+    currently naive to the concept of "latest".
+
+    :return: A list of TagPattern objects representing the default matrix tag patterns.
+    """
+    return [
+        TagPattern(
+            patterns=["{{ Version }}-{{ OS }}-{{ Variant }}"],
+            only=[TagPatternFilter.ALL],
+        ),
+        TagPattern(
+            patterns=["{{ Version }}-{{ Variant }}"],
+            only=[TagPatternFilter.PRIMARY_OS],
+        ),
+        TagPattern(
+            patterns=["{{ Version }}-{{ OS }}"],
+            only=[TagPatternFilter.PRIMARY_VARIANT],
+        ),
+        TagPattern(
+            patterns=["{{ Version }}"],
+            only=[TagPatternFilter.PRIMARY_OS, TagPatternFilter.PRIMARY_VARIANT],
+        ),
+    ]

--- a/posit-bakery/test/config/image/test_image.py
+++ b/posit-bakery/test/config/image/test_image.py
@@ -11,6 +11,7 @@ from posit_bakery.config.dependencies.python import PythonDependencyVersions
 from posit_bakery.config.dependencies.quarto import QuartoDependencyVersions
 from posit_bakery.config.dependencies.r import RDependencyVersions
 from posit_bakery.config.image.posit_product.main import ReleaseStreamResult
+from posit_bakery.config.tag import default_matrix_tag_patterns, default_tag_patterns
 
 pytestmark = [
     pytest.mark.unit,
@@ -36,11 +37,48 @@ class TestImage:
         assert i.parent is None
         assert i.subpath == "my-image"
         assert len(i.extraRegistries) == 0
-        assert len(i.tagPatterns) == 8
+        assert i.tagPatterns == default_tag_patterns()
         assert len(i.variants) == 0
         assert len(i.versions) == 1
         for version in i.versions:
             assert version.parent is i
+
+    def test_default_tag_patterns_for_matrix_image(self):
+        """Test that an image with a matrix gets default_matrix_tag_patterns instead of default_tag_patterns.
+
+        Matrix images use composite version names (e.g., "R4.3.3-python3.11.15") where the
+        stripMetadata filter in default_tag_patterns would strip from the last hyphen, causing
+        tag collisions across matrix combinations.
+        """
+        i = Image(
+            name="my-matrix-image",
+            matrix={
+                "namePattern": "R{{ Dependencies.R }}-python{{ Dependencies.python }}",
+                "dependencies": [
+                    {"dependency": "R", "versions": ["4.3.3"]},
+                    {"dependency": "python", "versions": ["3.11.15"]},
+                ],
+            },
+        )
+
+        assert i.tagPatterns == default_matrix_tag_patterns()
+
+    def test_explicit_tag_patterns_not_overridden_by_matrix(self):
+        """Test that explicitly provided tagPatterns are not overridden when a matrix is defined."""
+        custom_patterns = [{"patterns": ["{{ Version }}-{{ OS }}"]}]
+        i = Image(
+            name="my-matrix-image",
+            tagPatterns=custom_patterns,
+            matrix={
+                "namePattern": "R{{ Dependencies.R }}",
+                "dependencies": [
+                    {"dependency": "R", "versions": ["4.3.3"]},
+                ],
+            },
+        )
+
+        assert len(i.tagPatterns) == 1
+        assert i.tagPatterns[0].patterns == ["{{ Version }}-{{ OS }}"]
 
     def test_valid(self):
         """Test creating a valid Image object with all fields."""

--- a/posit-bakery/test/config/test_tag.py
+++ b/posit-bakery/test/config/test_tag.py
@@ -1,6 +1,6 @@
 import pytest
 
-from posit_bakery.config.tag import TagPattern, TagPatternFilter, default_tag_patterns
+from posit_bakery.config.tag import TagPattern, TagPatternFilter, default_matrix_tag_patterns, default_tag_patterns
 
 pytestmark = [
     pytest.mark.unit,
@@ -59,3 +59,79 @@ def test_default_tag_patterns():
         rendered_tags.extend(pattern.render(Version=version, OS=os, Variant=variant))
     for tag in expected_tags:
         assert tag in rendered_tags
+
+
+def test_default_matrix_tag_patterns():
+    """Test that the default matrix tag patterns are created correctly."""
+    patterns = default_matrix_tag_patterns()
+    version = "R4.3.3-python3.11.15"
+    os = "ubuntu2404"
+    variant = "min"
+    expected_tags = [
+        f"{version}-{os}-{variant}",
+        f"{version}-{variant}",
+        f"{version}-{os}",
+        version,
+    ]
+    rendered_tags = []
+    for pattern in patterns:
+        rendered_tags.extend(pattern.render(Version=version, OS=os, Variant=variant))
+    for tag in expected_tags:
+        assert tag in rendered_tags
+
+
+def test_default_matrix_tag_patterns_no_strip_metadata():
+    """Test that default matrix tag patterns do not include stripMetadata patterns.
+
+    The stripMetadata filter strips from the last hyphen onward, which breaks composite
+    matrix version names like "R4.3.3-python3.11.15" by collapsing them to "R4.3.3".
+    """
+    patterns = default_matrix_tag_patterns()
+    for pattern in patterns:
+        for p in pattern.patterns:
+            assert "stripMetadata" not in p, f"Matrix tag pattern should not use stripMetadata: {p}"
+
+
+def test_default_matrix_tag_patterns_no_latest_filter():
+    """Test that default matrix tag patterns do not include latest-filtered patterns.
+
+    Matrices are currently naive to the concept of "latest", so latest-filtered patterns
+    should not be included.
+    """
+    patterns = default_matrix_tag_patterns()
+    for pattern in patterns:
+        assert TagPatternFilter.LATEST not in pattern.only, (
+            f"Matrix tag pattern should not filter by latest: {pattern.patterns}"
+        )
+
+
+def test_default_matrix_tag_patterns_no_tag_collisions():
+    """Test that matrix tag patterns do not produce colliding tags across different matrix combinations.
+
+    This reproduces the bug where stripMetadata caused "R4.3.3-python3.11.15" and
+    "R4.3.3-python3.12.13" to both produce the tag "R4.3.3".
+
+    Checks that different versions within the same OS produce unique tags. Cross-OS overlap
+    (e.g., the PRIMARY_OS pattern producing "R4.3.3-python3.11.15" for both OSes) is expected
+    and handled by tag pattern filters at the ImageTarget level.
+    """
+    patterns = default_matrix_tag_patterns()
+    versions = ["R4.3.3-python3.11.15", "R4.3.3-python3.12.13", "R4.3.3-python3.13.12"]
+    os_values = ["ubuntu2404", "ubuntu2204"]
+
+    for os in os_values:
+        tags_by_version = {}
+        for version in versions:
+            tags = []
+            for pattern in patterns:
+                tags.extend(pattern.render(Version=version, OS=os, Variant=""))
+            tags_by_version[version] = set(tags)
+
+        # Verify no two different versions within the same OS share any tags
+        version_list = list(tags_by_version.keys())
+        for i, v1 in enumerate(version_list):
+            for v2 in version_list[i + 1 :]:
+                overlap = tags_by_version[v1] & tags_by_version[v2]
+                assert not overlap, (
+                    f"Tag collision for OS {os} between {v1} and {v2}: {overlap}"
+                )


### PR DESCRIPTION
## Summary

- The `stripMetadata` Jinja2 filter strips from the last hyphen onward, which breaks composite matrix version names like `R4.3.3-python3.11.15` by collapsing them to `R4.3.3`, causing tag collisions across matrix combinations
- Added `default_matrix_tag_patterns()` which excludes `stripMetadata` patterns and `latest`-filtered patterns (matrices are naive to "latest")
- The `Image` model now conditionally selects the pattern set based on whether a `matrix` is defined, using Pydantic's `default_factory` with validated data

Fixes #417

## Test plan

- [x] Existing tag and image config tests pass
- [x] New `test_default_matrix_tag_patterns` verifies correct rendering of matrix tag patterns
- [x] New `test_default_matrix_tag_patterns_no_strip_metadata` asserts no `stripMetadata` in matrix patterns
- [x] New `test_default_matrix_tag_patterns_no_latest_filter` asserts no `LATEST` filter in matrix patterns
- [x] New `test_default_matrix_tag_patterns_no_tag_collisions` regression test verifies no tag overlaps across matrix combinations
- [x] New `test_default_tag_patterns_for_matrix_image` verifies matrix images get the correct default patterns
- [x] New `test_explicit_tag_patterns_not_overridden_by_matrix` verifies explicit `tagPatterns` are respected
- [x] Run `bakery build --matrix-versions only --image-name 'workbench-session$' --plan` in images-workbench to verify no overlapping tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)