### PR TITLE
Add shared product-release workflow

### DIFF
--- a/.github/workflows/product-release.yml
+++ b/.github/workflows/product-release.yml
@@ -1,0 +1,153 @@
+name: Product Release
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Product version (e.g. 2026.03.0, 2026.02.1+500.pro12, 2025.12.0-14)"
+        required: true
+        type: string
+      images:
+        description: "Space-separated list of versioned (non-matrix) image names"
+        required: true
+        type: string
+    secrets:
+      APP_ID:
+        description: "GitHub App ID for creating tokens"
+        required: true
+      APP_PRIVATE_KEY:
+        description: "GitHub App private key for creating tokens"
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Install bakery
+        uses: posit-dev/images-shared/setup-bakery@main
+
+      - name: Parse version
+        id: parse
+        run: |
+          VERSION="${{ inputs.version }}"
+          DISPLAY_VERSION="${VERSION%%[+-]*}"
+          EDITION="${DISPLAY_VERSION%.*}"
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "display_version=$DISPLAY_VERSION" >> "$GITHUB_OUTPUT"
+          echo "edition=$EDITION" >> "$GITHUB_OUTPUT"
+
+      - name: Create or update versions
+        id: release
+        env:
+          IMAGES: ${{ inputs.images }}
+          VERSION: ${{ steps.parse.outputs.version }}
+          DISPLAY_VERSION: ${{ steps.parse.outputs.display_version }}
+          EDITION: ${{ steps.parse.outputs.edition }}
+        run: |
+          LATEST_CHANGED=false
+          OLD_DISPLAY_VERSION=""
+
+          for IMAGE in $IMAGES; do
+            EXISTING=$(bakery get version "$IMAGE" --subpath "$EDITION" 2>/dev/null || true)
+
+            if [ -n "$EXISTING" ]; then
+              echo "Patching $IMAGE: $EXISTING -> $VERSION"
+              bakery update version "$IMAGE" "$VERSION" --target-version "$EXISTING"
+            else
+              # Determine whether this edition should become latest.
+              CURRENT_LATEST=$(bakery get version "$IMAGE" 2>/dev/null || true)
+              if [ -z "$CURRENT_LATEST" ]; then
+                MARK_LATEST="--mark-latest"
+              else
+                CURRENT_DISPLAY="${CURRENT_LATEST%%[+-]*}"
+                CURRENT_EDITION="${CURRENT_DISPLAY%.*}"
+                if [[ "$EDITION" > "$CURRENT_EDITION" ]]; then
+                  MARK_LATEST="--mark-latest"
+                else
+                  MARK_LATEST="--no-mark-latest"
+                fi
+              fi
+
+              echo "Creating $IMAGE: $VERSION (subpath=$EDITION, $MARK_LATEST)"
+              bakery create version "$IMAGE" "$VERSION" --subpath "$EDITION" $MARK_LATEST
+            fi
+          done
+
+          # Check if latest changed by comparing before/after.
+          FIRST_IMAGE=$(echo "$IMAGES" | awk '{print $1}')
+          NEW_LATEST=$(bakery get version "$FIRST_IMAGE" 2>/dev/null || true)
+          NEW_LATEST_DISPLAY="${NEW_LATEST%%[+-]*}"
+
+          if [ "$NEW_LATEST_DISPLAY" = "$DISPLAY_VERSION" ]; then
+            LATEST_CHANGED=true
+            # Find the old latest from git diff of bakery.yaml.
+            OLD_LATEST=$(git diff bakery.yaml | grep -E '^\-.*latest: true' -B5 | grep '^\-.*name:' | head -1 | sed 's/.*name: //')
+            if [ -n "$OLD_LATEST" ]; then
+              OLD_DISPLAY_VERSION="${OLD_LATEST%%[+-]*}"
+            fi
+          fi
+
+          echo "latest_changed=$LATEST_CHANGED" >> "$GITHUB_OUTPUT"
+          echo "old_display_version=$OLD_DISPLAY_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Update READMEs
+        if: steps.release.outputs.latest_changed == 'true' && steps.release.outputs.old_display_version != ''
+        env:
+          DISPLAY_VERSION: ${{ steps.parse.outputs.display_version }}
+          EDITION: ${{ steps.parse.outputs.edition }}
+          OLD_DISPLAY_VERSION: ${{ steps.release.outputs.old_display_version }}
+        run: |
+          OLD_EDITION="${OLD_DISPLAY_VERSION%.*}"
+
+          # Pass 1: Replace full display version (e.g. 2026.02.0 -> 2026.03.0)
+          find . -name 'README.md' -not -path './.git/*' \
+            -exec sed -i "s/${OLD_DISPLAY_VERSION}/${DISPLAY_VERSION}/g" {} +
+
+          # Pass 2: Replace edition/subpath (e.g. 2026.02 -> 2026.03)
+          # Only when the edition actually changed.
+          if [ "$OLD_EDITION" != "$EDITION" ]; then
+            find . -name 'README.md' -not -path './.git/*' \
+              -exec sed -i "s/${OLD_EDITION}/${EDITION}/g" {} +
+          fi
+
+      - name: Create pull request
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          IMAGES: ${{ inputs.images }}
+          VERSION: ${{ steps.parse.outputs.version }}
+          DISPLAY_VERSION: ${{ steps.parse.outputs.display_version }}
+        run: |
+          BRANCH="release/${DISPLAY_VERSION}"
+          git checkout -B "$BRANCH"
+          git add -A
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -m "Release ${DISPLAY_VERSION}"
+          git push -u origin "$BRANCH" --force-with-lease
+
+          BODY="Updates images to version \`${VERSION}\`."
+          BODY+=$'\n\n'"**Images:** $(echo $IMAGES | tr ' ' ', ')"
+          if [ "${{ steps.release.outputs.latest_changed }}" = "true" ]; then
+            BODY+=$'\n'"**Latest changed:** \`${{ steps.release.outputs.old_display_version }}\` → \`${DISPLAY_VERSION}\`"
+          fi
+
+          gh pr create \
+            --title "Release ${DISPLAY_VERSION}" \
+            --body "$BODY" \
+            --base main \
+            --head "$BRANCH" || echo "PR already exists"


### PR DESCRIPTION
## Summary

- Add reusable `product-release.yml` workflow that automates version creation and patching across product image repos
- Takes a version string and space-separated image list as inputs
- Determines whether to create a new edition or patch an existing one
- Updates README version references when latest changes
- Opens a PR with the changes

Product repos call this with a thin `workflow_dispatch` wrapper (~18 lines) that passes their image list.

## Related

- Closes #349
- Depends on #393 (bakery CLI changes)
- posit-dev/images-connect#41
- posit-dev/images-workbench#49
- posit-dev/images-package-manager#55

## Test plan

- [x] Merge #393 first
- [x] Merge readme-updates branches in product repos
- [ ] Trigger connect workflow with `version: 2026.03.0`
- [ ] Verify PR created with updated bakery.yaml, rendered files, and READMEs