### PR TITLE
Add Dependabot config for GHA updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

- Enable weekly Dependabot checks for GitHub Actions version updates

## Test plan

- [ ] Verify Dependabot creates version update PRs for actions on next weekly run