### PR TITLE
feat: add hadolint plugin for Containerfile linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Setup ORAS CLI
         uses: oras-project/setup-oras@v1
 
+      - name: Add tools/ to path
+        run: echo "${GITHUB_WORKSPACE}/tools" >> $GITHUB_PATH
+
       - name: Setup uv
         uses: astral-sh/setup-uv@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,9 @@ jobs:
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@v4
 
+      - name: Setup hadolint
+        uses: ./setup-hadolint
+
       - name: Setup ORAS CLI
         uses: oras-project/setup-oras@v1
 

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -1,0 +1,48 @@
+name: hadolint.yml
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "The version of the Posit Bakery tool to install"
+        default: "main"
+        required: false
+        type: string
+      hadolint-version:
+        description: "The hadolint release version to install (e.g., v2.12.0)"
+        default: "latest"
+        required: false
+        type: string
+      context:
+        description: "The Bakery context to use (directory)"
+        default: "."
+        required: false
+        type: string
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  hadolint:
+    name: Hadolint
+    runs-on: "ubuntu-latest"
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup bakery
+        uses: "posit-dev/images-shared/setup-bakery@main"
+        with:
+          version: ${{ inputs.version }}
+
+      - name: Setup hadolint
+        uses: "posit-dev/images-shared/setup-hadolint@main"
+        with:
+          version: ${{ inputs.hadolint-version }}
+          base_path: ${{ inputs.context }}
+
+      - name: Run hadolint
+        run: |
+          bakery hadolint run --matrix-versions include --dev-versions include \
+            --context ${{ inputs.context }}

--- a/posit-bakery/posit_bakery/error.py
+++ b/posit-bakery/posit_bakery/error.py
@@ -142,7 +142,7 @@ class BakeryToolRuntimeError(BakeryToolError):
             return "\n".join(self.stderr.splitlines()[:lines])
 
     def __str__(self) -> str:
-        s = f"{self.message}'\n"
+        s = f"{self.message}\n"
         s += f"  - Exit code: {self.exit_code}\n"
         s += f"  - Command executed: {' '.join(self.cmd)}\n"
         if self.metadata:

--- a/posit-bakery/posit_bakery/plugins/builtin/dgoss/errors.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/dgoss/errors.py
@@ -28,7 +28,7 @@ class BakeryDGossError(BakeryToolRuntimeError):
         self.parse_error = parse_error
 
     def __str__(self) -> str:
-        s = f"{self.message}'\n"
+        s = f"{self.message}\n"
         s += f"  - Exit code: {self.exit_code}\n"
         s += f"  - Command output: \n{textwrap.indent(self.dump_stdout(), '      ')}\n"
         s += f"  - Command executed: {' '.join(self.cmd)}\n"

--- a/posit-bakery/posit_bakery/plugins/builtin/hadolint/__init__.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/hadolint/__init__.py
@@ -272,41 +272,48 @@ class HadolintPlugin(BakeryToolPlugin):
                 error_list = [errors]
 
         results = []
-        for target in targets:
-            report = None
-            if target.image_name in report_collection:
-                target_reports = report_collection[target.image_name]
-                if target.uid in target_reports:
-                    _, report = target_reports[target.uid]
+        for image_name, uid_reports in report_collection.items():
+            for uid, (target, report) in uid_reports.items():
+                target_error = None
+                for err in error_list:
+                    if hasattr(err, "message") and str(target) in err.message:
+                        target_error = err
+                        break
 
-            target_error = None
-            for err in error_list:
-                if hasattr(err, "message") and str(target) in err.message:
-                    target_error = err
-                    break
-
-            exit_code = 0
-            if target_error is not None:
-                exit_code = getattr(target_error, "exit_code", 1)
-            elif report is not None:
                 exit_code = report.exit_code
+                if target_error is not None:
+                    exit_code = getattr(target_error, "exit_code", 1)
 
-            artifacts = {}
-            if report is not None:
-                artifacts["report"] = report
-            if target_error is not None:
-                artifacts["execution_error"] = target_error
+                artifacts = {"report": report}
+                if target_error is not None:
+                    artifacts["execution_error"] = target_error
 
-            results.append(
-                ToolCallResult(
-                    exit_code=exit_code,
-                    tool_name="hadolint",
-                    target=target,
-                    stdout="",
-                    stderr="",
-                    artifacts=artifacts if artifacts else None,
+                results.append(
+                    ToolCallResult(
+                        exit_code=exit_code,
+                        tool_name="hadolint",
+                        target=target,
+                        stdout="",
+                        stderr="",
+                        artifacts=artifacts,
+                    )
                 )
-            )
+
+        # Include execution errors for targets that failed before producing a report
+        reported_targets = {r.target.uid for r in results}
+        for err in error_list:
+            for target in targets:
+                if target.uid not in reported_targets and hasattr(err, "message") and str(target) in err.message:
+                    results.append(
+                        ToolCallResult(
+                            exit_code=getattr(err, "exit_code", 1),
+                            tool_name="hadolint",
+                            target=target,
+                            stdout="",
+                            stderr="",
+                            artifacts={"execution_error": err},
+                        )
+                    )
 
         return results
 
@@ -325,14 +332,12 @@ class HadolintPlugin(BakeryToolPlugin):
         # Summary table
         stderr_console.print(report_collection.table())
 
-        # Detailed results by image and UID
+        # Detailed results by Containerfile
         if report_collection.has_issues:
             stderr_console.print("-" * 80)
-            for image_name, targets in report_collection.items():
-                stderr_console.print(f"=== {image_name} ===", style="bold")
-                for uid, (target, report) in targets.items():
-                    stderr_console.print(f"--- {uid} ---")
-                    stderr_console.print(f"  Containerfile: {report.containerfile}")
+            for image_name, uid_reports in report_collection.items():
+                for uid, (target, report) in uid_reports.items():
+                    stderr_console.print(f"=== {report.containerfile} ===", style="bold")
                     if report.total_count == 0:
                         stderr_console.print("  No issues found.", style="green3")
                     else:

--- a/posit-bakery/posit_bakery/plugins/builtin/hadolint/__init__.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/hadolint/__init__.py
@@ -345,11 +345,10 @@ class HadolintPlugin(BakeryToolPlugin):
             stderr_console.print("-" * 80)
             for image_name, uid_reports in report_collection.items():
                 for uid, (target, report) in uid_reports.items():
-                    stderr_console.print(f"=== {report.containerfile} ===", style="bold")
                     if report.total_count == 0:
-                        stderr_console.print("  No issues found.", style="green3")
-                    else:
-                        for issue in report.results:
+                        continue
+                    stderr_console.print(f"\n=== {report.containerfile} ===", style="bold")
+                    for issue in report.results:
                             level_style = {
                                 "error": "bright_red",
                                 "warning": "yellow",

--- a/posit-bakery/posit_bakery/plugins/builtin/hadolint/__init__.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/hadolint/__init__.py
@@ -105,10 +105,11 @@ class HadolintPlugin(BakeryToolPlugin):
                 typer.Option(
                     "--failure-threshold",
                     help="Exit with failure if any rule at or above this severity is violated. "
-                    "One of: error, warning, info, style, ignore, none.",
+                    "One of: error, warning, info, style, ignore, none. [default: error]",
+                    show_default=False,
                     rich_help_panel=RichHelpPanelEnum.HADOLINT,
                 ),
-            ] = "error",
+            ] = None,
             ignore: Annotated[
                 Optional[list[str]],
                 typer.Option(

--- a/posit-bakery/posit_bakery/plugins/builtin/hadolint/__init__.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/hadolint/__init__.py
@@ -1,0 +1,362 @@
+import logging
+import re
+from enum import Enum
+from pathlib import Path
+from typing import Annotated, Optional
+
+import typer
+
+from posit_bakery.cli.common import with_verbosity_flags
+from posit_bakery.config.config import BakeryConfig, BakeryConfigFilter, BakerySettings
+from posit_bakery.const import DevVersionInclusionEnum, MatrixVersionInclusionEnum
+from posit_bakery.error import BakeryToolRuntimeErrorGroup
+from posit_bakery.image.image_target import ImageTarget
+from posit_bakery.log import stderr_console
+from posit_bakery.plugins.builtin.hadolint.options import HadolintOptions
+from posit_bakery.plugins.builtin.hadolint.report import HadolintReportCollection
+from posit_bakery.plugins.builtin.hadolint.suite import HadolintSuite
+from posit_bakery.plugins.protocol import BakeryToolPlugin, ToolCallResult
+from posit_bakery.util import auto_path
+
+log = logging.getLogger(__name__)
+
+
+class RichHelpPanelEnum(str, Enum):
+    """Enum for categorizing options into rich help panels."""
+
+    FILTERS = "Filters"
+    HADOLINT = "Hadolint Options"
+
+
+class HadolintPlugin(BakeryToolPlugin):
+    name: str = "hadolint"
+    description: str = "Lint Containerfiles using hadolint"
+    tool_options_class = HadolintOptions
+
+    def register_cli(self, app: typer.Typer) -> None:
+        """Register the hadolint CLI commands with the given Typer app."""
+        hadolint_app = typer.Typer(no_args_is_help=True)
+
+        plugin = self
+
+        @hadolint_app.command()
+        @with_verbosity_flags
+        def run(
+            context: Annotated[
+                Path,
+                typer.Option(
+                    exists=True,
+                    file_okay=False,
+                    dir_okay=True,
+                    readable=True,
+                    writable=True,
+                    resolve_path=True,
+                    help="The root path to use. Defaults to the current working directory.",
+                ),
+            ] = auto_path(),
+            image_name: Annotated[
+                Optional[str],
+                typer.Option(
+                    show_default=False,
+                    help="The image name to isolate linting to.",
+                    rich_help_panel=RichHelpPanelEnum.FILTERS,
+                ),
+            ] = None,
+            image_version: Annotated[
+                Optional[str],
+                typer.Option(
+                    show_default=False,
+                    help="The image version to isolate linting to.",
+                    rich_help_panel=RichHelpPanelEnum.FILTERS,
+                ),
+            ] = None,
+            image_variant: Annotated[
+                Optional[str],
+                typer.Option(
+                    show_default=False,
+                    help="The image variant to isolate linting to.",
+                    rich_help_panel=RichHelpPanelEnum.FILTERS,
+                ),
+            ] = None,
+            image_os: Annotated[
+                Optional[str],
+                typer.Option(
+                    show_default=False,
+                    help="The image OS to isolate linting to.",
+                    rich_help_panel=RichHelpPanelEnum.FILTERS,
+                ),
+            ] = None,
+            dev_versions: Annotated[
+                Optional[DevVersionInclusionEnum],
+                typer.Option(
+                    help="Include or exclude development versions defined in config.",
+                    rich_help_panel=RichHelpPanelEnum.FILTERS,
+                ),
+            ] = DevVersionInclusionEnum.EXCLUDE,
+            matrix_versions: Annotated[
+                Optional[MatrixVersionInclusionEnum],
+                typer.Option(
+                    help="Include or exclude versions defined in image matrix.",
+                    rich_help_panel=RichHelpPanelEnum.FILTERS,
+                ),
+            ] = MatrixVersionInclusionEnum.EXCLUDE,
+            failure_threshold: Annotated[
+                Optional[str],
+                typer.Option(
+                    "--failure-threshold",
+                    help="Exit with failure if any rule at or above this severity is violated. "
+                    "One of: error, warning, info, style, ignore, none.",
+                    rich_help_panel=RichHelpPanelEnum.HADOLINT,
+                ),
+            ] = "error",
+            ignore: Annotated[
+                Optional[list[str]],
+                typer.Option(
+                    "--ignore",
+                    help="Rule code to ignore (can be repeated).",
+                    rich_help_panel=RichHelpPanelEnum.HADOLINT,
+                ),
+            ] = None,
+            require_label: Annotated[
+                Optional[list[str]],
+                typer.Option(
+                    "--require-label",
+                    help="Label to require in format 'name:type' (can be repeated).",
+                    rich_help_panel=RichHelpPanelEnum.HADOLINT,
+                ),
+            ] = None,
+            no_fail: Annotated[
+                Optional[bool],
+                typer.Option(
+                    "--no-fail",
+                    help="Always exit with status 0, even when rule violations are found.",
+                    rich_help_panel=RichHelpPanelEnum.HADOLINT,
+                ),
+            ] = None,
+            error: Annotated[
+                Optional[list[str]],
+                typer.Option(
+                    "--error",
+                    help="Rule code to treat as error (can be repeated).",
+                    rich_help_panel=RichHelpPanelEnum.HADOLINT,
+                ),
+            ] = None,
+            warning: Annotated[
+                Optional[list[str]],
+                typer.Option(
+                    "--warning",
+                    help="Rule code to treat as warning (can be repeated).",
+                    rich_help_panel=RichHelpPanelEnum.HADOLINT,
+                ),
+            ] = None,
+            info: Annotated[
+                Optional[list[str]],
+                typer.Option(
+                    "--info",
+                    help="Rule code to treat as info (can be repeated).",
+                    rich_help_panel=RichHelpPanelEnum.HADOLINT,
+                ),
+            ] = None,
+            style: Annotated[
+                Optional[list[str]],
+                typer.Option(
+                    "--style",
+                    help="Rule code to treat as style (can be repeated).",
+                    rich_help_panel=RichHelpPanelEnum.HADOLINT,
+                ),
+            ] = None,
+            strict_labels: Annotated[
+                Optional[bool],
+                typer.Option(
+                    "--strict-labels",
+                    help="Require labels to match the label schema.",
+                    rich_help_panel=RichHelpPanelEnum.HADOLINT,
+                ),
+            ] = None,
+            disable_ignore_pragma: Annotated[
+                Optional[bool],
+                typer.Option(
+                    "--disable-ignore-pragma",
+                    help="Disable inline hadolint ignore comments.",
+                    rich_help_panel=RichHelpPanelEnum.HADOLINT,
+                ),
+            ] = None,
+            trusted_registry: Annotated[
+                Optional[list[str]],
+                typer.Option(
+                    "--trusted-registry",
+                    help="Trusted Docker registry (can be repeated).",
+                    rich_help_panel=RichHelpPanelEnum.HADOLINT,
+                ),
+            ] = None,
+        ) -> None:
+            """Runs hadolint against Containerfiles in the context path
+
+            \b
+            If no options are provided, the command lints all image Containerfiles in the project and writes
+            results to the `results/hadolint/` directory in the context path.
+
+            \b
+            Requires hadolint to be installed on the system. The path to the binary can be set with the
+            `HADOLINT_PATH` environment variable if not present in the system PATH.
+            """
+            settings = BakerySettings(
+                filter=BakeryConfigFilter(
+                    image_name=image_name,
+                    image_version=re.escape(image_version) if image_version else None,
+                    image_variant=image_variant,
+                    image_os=image_os,
+                    image_platform=[],
+                ),
+                dev_versions=dev_versions,
+                matrix_versions=matrix_versions,
+            )
+            c = BakeryConfig.from_context(context, settings)
+
+            # Build options override from CLI flags
+            override_dict = {}
+            if error or warning or info or style:
+                if error:
+                    override_dict["error"] = error
+                if warning:
+                    override_dict["warning"] = warning
+                if info:
+                    override_dict["info"] = info
+                if style:
+                    override_dict["style"] = style
+
+            label_schema = None
+            if require_label:
+                label_schema = {}
+                for label_spec in require_label:
+                    name, sep, schema_type = label_spec.partition(":")
+                    if sep:
+                        label_schema[name] = schema_type
+                    else:
+                        label_schema[name] = "text"
+
+            options_override = HadolintOptions(
+                failureThreshold=failure_threshold,
+                ignored=ignore,
+                labelSchema=label_schema,
+                noFail=no_fail,
+                override=override_dict if override_dict else None,
+                strictLabels=strict_labels,
+                disableIgnorePragma=disable_ignore_pragma,
+                trustedRegistries=trusted_registry,
+            )
+
+            results = plugin.execute(c.base_path, c.targets, options_override=options_override)
+            plugin.results(results)
+
+        app.add_typer(hadolint_app, name="hadolint", help="Lint Containerfiles using hadolint")
+
+    def execute(
+        self,
+        base_path: Path,
+        targets: list[ImageTarget],
+        *,
+        options_override: HadolintOptions | None = None,
+        **kwargs,
+    ) -> list[ToolCallResult]:
+        """Execute hadolint against the given image targets."""
+        suite = HadolintSuite(base_path, targets, options_override=options_override)
+        report_collection, errors = suite.run()
+
+        error_list = []
+        if errors is not None:
+            if isinstance(errors, BakeryToolRuntimeErrorGroup):
+                error_list = list(errors.exceptions)
+            else:
+                error_list = [errors]
+
+        results = []
+        for target in targets:
+            report = None
+            if target.image_name in report_collection:
+                target_reports = report_collection[target.image_name]
+                if target.uid in target_reports:
+                    _, report = target_reports[target.uid]
+
+            target_error = None
+            for err in error_list:
+                if hasattr(err, "message") and str(target) in err.message:
+                    target_error = err
+                    break
+
+            exit_code = 0
+            if target_error is not None:
+                exit_code = getattr(target_error, "exit_code", 1)
+            elif report is not None and report.error_count > 0:
+                exit_code = 1
+
+            artifacts = {}
+            if report is not None:
+                artifacts["report"] = report
+            if target_error is not None:
+                artifacts["execution_error"] = target_error
+
+            results.append(
+                ToolCallResult(
+                    exit_code=exit_code,
+                    tool_name="hadolint",
+                    target=target,
+                    stdout="",
+                    stderr="",
+                    artifacts=artifacts if artifacts else None,
+                )
+            )
+
+        return results
+
+    def results(self, results: list[ToolCallResult]) -> None:
+        """Display hadolint results and raise typer.Exit(1) on failures."""
+        report_collection = HadolintReportCollection()
+        has_errors = False
+        errors = []
+        for result in results:
+            if result.artifacts and "report" in result.artifacts:
+                report_collection.add_report(result.target, result.artifacts["report"])
+            if result.artifacts and "execution_error" in result.artifacts:
+                has_errors = True
+                errors.append(result.artifacts["execution_error"])
+
+        # Summary table
+        stderr_console.print(report_collection.table())
+
+        # Detailed results by image and UID
+        if report_collection.has_issues:
+            stderr_console.print("-" * 80)
+            for image_name, targets in report_collection.items():
+                stderr_console.print(f"=== {image_name} ===", style="bold")
+                for uid, (target, report) in targets.items():
+                    stderr_console.print(f"--- {uid} ---")
+                    stderr_console.print(f"  Containerfile: {report.containerfile}")
+                    if report.total_count == 0:
+                        stderr_console.print("  No issues found.", style="green3")
+                    else:
+                        for issue in report.results:
+                            level_style = {
+                                "error": "bright_red",
+                                "warning": "yellow",
+                                "info": "bright_blue",
+                                "style": "bright_black",
+                            }.get(issue.level, "")
+                            stderr_console.print(
+                                f"  {issue.code} {issue.level} line {issue.line}: {issue.message}",
+                                style=level_style,
+                            )
+
+        # Execution errors
+        if has_errors:
+            stderr_console.print("-" * 80)
+            for err in errors:
+                stderr_console.print(err, style="error")
+            stderr_console.print("\u274c hadolint command(s) failed to execute", style="error")
+
+        # Determine exit
+        has_failures = any(r.exit_code != 0 for r in results)
+        if has_failures or has_errors:
+            raise typer.Exit(code=1)
+
+        stderr_console.print("\u2705 Linting completed", style="success")

--- a/posit-bakery/posit_bakery/plugins/builtin/hadolint/__init__.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/hadolint/__init__.py
@@ -287,8 +287,8 @@ class HadolintPlugin(BakeryToolPlugin):
             exit_code = 0
             if target_error is not None:
                 exit_code = getattr(target_error, "exit_code", 1)
-            elif report is not None and report.error_count > 0:
-                exit_code = 1
+            elif report is not None:
+                exit_code = report.exit_code
 
             artifacts = {}
             if report is not None:

--- a/posit-bakery/posit_bakery/plugins/builtin/hadolint/__init__.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/hadolint/__init__.py
@@ -236,16 +236,24 @@ class HadolintPlugin(BakeryToolPlugin):
                     else:
                         label_schema[name] = "text"
 
-            options_override = HadolintOptions(
-                failureThreshold=failure_threshold,
-                ignored=ignore,
-                labelSchema=label_schema,
-                noFail=no_fail,
-                override=override_dict if override_dict else None,
-                strictLabels=strict_labels,
-                disableIgnorePragma=disable_ignore_pragma,
-                trustedRegistries=trusted_registry,
-            )
+            options_kwargs: dict = {}
+            if failure_threshold is not None:
+                options_kwargs["failureThreshold"] = failure_threshold
+            if ignore is not None:
+                options_kwargs["ignored"] = ignore
+            if label_schema is not None:
+                options_kwargs["labelSchema"] = label_schema
+            if no_fail is not None:
+                options_kwargs["noFail"] = no_fail
+            if override_dict:
+                options_kwargs["override"] = override_dict
+            if strict_labels is not None:
+                options_kwargs["strictLabels"] = strict_labels
+            if disable_ignore_pragma is not None:
+                options_kwargs["disableIgnorePragma"] = disable_ignore_pragma
+            if trusted_registry is not None:
+                options_kwargs["trustedRegistries"] = trusted_registry
+            options_override = HadolintOptions(**options_kwargs)
 
             results = plugin.execute(c.base_path, c.targets, options_override=options_override)
             plugin.results(results)

--- a/posit-bakery/posit_bakery/plugins/builtin/hadolint/command.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/hadolint/command.py
@@ -1,0 +1,95 @@
+import logging
+from pathlib import Path
+from typing import Annotated
+
+from pydantic import BaseModel, Field, computed_field
+
+from posit_bakery.image.image_target import ImageTarget
+from posit_bakery.plugins.builtin.hadolint.options import HadolintOptions
+from posit_bakery.settings import SETTINGS
+from posit_bakery.util import find_bin
+
+
+def find_hadolint_bin(base_path: Path) -> str:
+    """Find the path to the hadolint binary."""
+    return find_bin(base_path, "hadolint", "HADOLINT_PATH") or "hadolint"
+
+
+class HadolintCommand(BaseModel):
+    image_target: ImageTarget
+    hadolint_bin: Annotated[str, Field()]
+    containerfile_path: Annotated[Path, Field(description="Absolute path to the Containerfile.")]
+    options: Annotated[HadolintOptions, Field(default_factory=HadolintOptions)]
+
+    @classmethod
+    def from_image_target(
+        cls,
+        image_target: ImageTarget,
+        options_override: HadolintOptions | None = None,
+    ) -> "HadolintCommand":
+        hadolint_bin = find_hadolint_bin(image_target.context.base_path)
+        containerfile_path = image_target.context.base_path / image_target.containerfile
+
+        # Load options from variant, then merge with override
+        variant_options = None
+        if image_target.image_variant:
+            variant_options = image_target.image_variant.get_tool_option("hadolint")
+
+        if options_override and variant_options:
+            options = options_override.update(variant_options)
+        elif options_override:
+            options = options_override
+        elif variant_options:
+            options = variant_options
+        else:
+            options = HadolintOptions()
+
+        return cls(
+            image_target=image_target,
+            hadolint_bin=hadolint_bin,
+            containerfile_path=containerfile_path,
+            options=options,
+        )
+
+    @computed_field
+    @property
+    def command(self) -> list[str]:
+        """Return the full hadolint command to run."""
+        cmd = [self.hadolint_bin, "--format", "json"]
+
+        if SETTINGS.log_level == logging.DEBUG:
+            cmd.append("--verbose")
+
+        if self.options.failureThreshold is not None:
+            cmd.extend(["--failure-threshold", self.options.failureThreshold])
+
+        if self.options.ignored:
+            for rule in self.options.ignored:
+                cmd.extend(["--ignore", rule])
+
+        if self.options.labelSchema:
+            for label, schema_type in self.options.labelSchema.items():
+                cmd.extend(["--require-label", f"{label}:{schema_type}"])
+
+        if self.options.noFail is True:
+            cmd.append("--no-fail")
+
+        if self.options.override:
+            for level in ("error", "warning", "info", "style"):
+                rules = getattr(self.options.override, level, None)
+                if rules:
+                    for rule in rules:
+                        cmd.extend([f"--{level}", rule])
+
+        if self.options.strictLabels is True:
+            cmd.append("--strict-labels")
+
+        if self.options.disableIgnorePragma is True:
+            cmd.append("--disable-ignore-pragma")
+
+        if self.options.trustedRegistries:
+            for registry in self.options.trustedRegistries:
+                cmd.extend(["--trusted-registry", registry])
+
+        cmd.append(str(self.containerfile_path))
+        return cmd

--- a/posit-bakery/posit_bakery/plugins/builtin/hadolint/command.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/hadolint/command.py
@@ -5,7 +5,7 @@ from typing import Annotated
 from pydantic import BaseModel, Field, computed_field
 
 from posit_bakery.image.image_target import ImageTarget
-from posit_bakery.plugins.builtin.hadolint.options import HadolintOptions
+from posit_bakery.plugins.builtin.hadolint.options import DEFAULT_IGNORED_RULES, HadolintOptions
 from posit_bakery.settings import SETTINGS
 from posit_bakery.util import find_bin
 
@@ -47,6 +47,10 @@ class HadolintCommand(BaseModel):
         # Apply default failure threshold if no source provided one
         if options.failureThreshold is None:
             options = options.model_copy(update={"failureThreshold": "error"})
+
+        # Apply default ignored rules if no source provided any
+        if options.ignored is None and "ignored" not in options.model_fields_set:
+            options = options.model_copy(update={"ignored": list(DEFAULT_IGNORED_RULES)})
 
         return cls(
             image_target=image_target,

--- a/posit-bakery/posit_bakery/plugins/builtin/hadolint/command.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/hadolint/command.py
@@ -44,6 +44,10 @@ class HadolintCommand(BaseModel):
         else:
             options = HadolintOptions()
 
+        # Apply default failure threshold if no source provided one
+        if options.failureThreshold is None:
+            options = options.model_copy(update={"failureThreshold": "error"})
+
         return cls(
             image_target=image_target,
             hadolint_bin=hadolint_bin,

--- a/posit-bakery/posit_bakery/plugins/builtin/hadolint/errors.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/hadolint/errors.py
@@ -1,0 +1,39 @@
+import textwrap
+from typing import List
+
+from posit_bakery.error import BakeryToolRuntimeError
+
+
+class BakeryHadolintError(BakeryToolRuntimeError):
+    def __init__(
+        self,
+        message: str = None,
+        tool_name: str = None,
+        cmd: List[str] = None,
+        stdout: str | bytes | None = None,
+        stderr: str | bytes | None = None,
+        exit_code: int = 1,
+        parse_error: Exception = None,
+        metadata: dict | None = None,
+    ) -> None:
+        super().__init__(
+            message=message,
+            tool_name=tool_name,
+            cmd=cmd,
+            stdout=stdout,
+            stderr=stderr,
+            exit_code=exit_code,
+            metadata=metadata,
+        )
+        self.parse_error = parse_error
+
+    def __str__(self) -> str:
+        s = f"{self.message}'\n"
+        s += f"  - Exit code: {self.exit_code}\n"
+        s += f"  - Command output: \n{textwrap.indent(self.dump_stdout(), '      ')}\n"
+        s += f"  - Command executed: {' '.join(self.cmd)}\n"
+        if self.metadata:
+            s += "  - Metadata:\n"
+            for key, value in self.metadata.items():
+                s += f"    - {key}: {value}\n"
+        return s

--- a/posit-bakery/posit_bakery/plugins/builtin/hadolint/errors.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/hadolint/errors.py
@@ -28,7 +28,7 @@ class BakeryHadolintError(BakeryToolRuntimeError):
         self.parse_error = parse_error
 
     def __str__(self) -> str:
-        s = f"{self.message}'\n"
+        s = f"{self.message}\n"
         s += f"  - Exit code: {self.exit_code}\n"
         s += f"  - Command output: \n{textwrap.indent(self.dump_stdout(), '      ')}\n"
         s += f"  - Command executed: {' '.join(self.cmd)}\n"

--- a/posit-bakery/posit_bakery/plugins/builtin/hadolint/options.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/hadolint/options.py
@@ -5,6 +5,11 @@ from pydantic import BaseModel, Field
 
 from posit_bakery.config.tools.base import ToolOptions
 
+# Package-pinning rules ignored by default since Posit images do not pin
+# OS-level package versions. Users can override by setting `ignored` explicitly;
+# setting `ignored: []` clears the defaults entirely.
+DEFAULT_IGNORED_RULES: list[str] = ["DL3008", "DL3018", "DL3033", "DL3037", "DL3041"]
+
 
 class HadolintOverride(BaseModel):
     """Override the default severity level of specific hadolint rules."""

--- a/posit-bakery/posit_bakery/plugins/builtin/hadolint/options.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/hadolint/options.py
@@ -1,0 +1,99 @@
+from copy import deepcopy
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, Field
+
+from posit_bakery.config.tools.base import ToolOptions
+
+
+class HadolintOverride(BaseModel):
+    """Override the default severity level of specific hadolint rules."""
+
+    error: Annotated[
+        list[str] | None,
+        Field(default=None, description="List of rule codes to treat as errors."),
+    ]
+    warning: Annotated[
+        list[str] | None,
+        Field(default=None, description="List of rule codes to treat as warnings."),
+    ]
+    info: Annotated[
+        list[str] | None,
+        Field(default=None, description="List of rule codes to treat as info."),
+    ]
+    style: Annotated[
+        list[str] | None,
+        Field(default=None, description="List of rule codes to treat as style."),
+    ]
+
+
+class HadolintOptions(ToolOptions):
+    """Configuration options for hadolint Containerfile linting."""
+
+    tool: Literal["hadolint"] = "hadolint"
+    failureThreshold: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description="Exit with failure status if any rule at or above this severity is violated. "
+            "One of: error, warning, info, style, ignore, none.",
+        ),
+    ]
+    ignored: Annotated[
+        list[str] | None,
+        Field(default=None, description="List of hadolint rule codes to ignore (e.g. DL3008, SC2086)."),
+    ]
+    labelSchema: Annotated[
+        dict[str, str] | None,
+        Field(
+            default=None,
+            description="Label validation schema mapping label names to expected value formats "
+            "(text, rfc3339, semver, url, hash, spdx, email).",
+        ),
+    ]
+    noFail: Annotated[
+        bool | None,
+        Field(default=None, description="Always exit with status 0, even when rule violations are found."),
+    ]
+    override: Annotated[
+        HadolintOverride | None,
+        Field(default=None, description="Override the default severity level of specific rules."),
+    ]
+    strictLabels: Annotated[
+        bool | None,
+        Field(
+            default=None,
+            description="Require labels to match the label schema. Only labels set directly in the Containerfile "
+            "can be validated, since hadolint operates on the static Containerfile definition.",
+        ),
+    ]
+    disableIgnorePragma: Annotated[
+        bool | None,
+        Field(
+            default=None,
+            description="Disable inline hadolint ignore comments (e.g. '# hadolint ignore=DL3008').",
+        ),
+    ]
+    trustedRegistries: Annotated[
+        list[str] | None,
+        Field(
+            default=None,
+            description="List of trusted Docker registries. Images from untrusted registries trigger DL3026.",
+        ),
+    ]
+
+    def update(self, other: "HadolintOptions") -> "HadolintOptions":
+        """Update this HadolintOptions with settings from another.
+
+        The merge strategy uses the other instance's values where the current
+        instance has None (not explicitly set).
+        """
+        merged = deepcopy(self)
+        for field_name in HadolintOptions.model_fields:
+            if field_name == "tool":
+                continue
+            if getattr(self, field_name) is None and field_name not in self.model_fields_set:
+                other_value = getattr(other, field_name)
+                if other_value is not None:
+                    setattr(merged, field_name, deepcopy(other_value))
+        return merged

--- a/posit-bakery/posit_bakery/plugins/builtin/hadolint/report.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/hadolint/report.py
@@ -26,6 +26,10 @@ class HadolintReport(BaseModel):
     filepath: Annotated[Path | None, Field(default=None, exclude=True, description="Path to the results JSON file.")]
     containerfile: Annotated[Path, Field(description="Relative path to the Containerfile.")]
     exit_code: Annotated[int, Field(default=0, exclude=True, description="Hadolint process exit code.")]
+    version_label: Annotated[
+        str | None,
+        Field(default=None, exclude=True, description="Display label for the version column. Overrides the target version when set."),
+    ]
     results: Annotated[list[HadolintResult], Field(default_factory=list, description="List of lint issues.")]
 
     @classmethod
@@ -109,6 +113,7 @@ class HadolintReportCollection(dict):
         table.add_column("Version", justify="left")
         table.add_column("OS", justify="left")
         table.add_column("Variant", justify="left")
+        table.add_column("Containerfile", justify="left")
         table.add_column("Errors", justify="right", header_style="bright_red")
         table.add_column("Warnings", justify="right", header_style="yellow")
         table.add_column("Info", justify="right", header_style="bright_blue")
@@ -125,7 +130,7 @@ class HadolintReportCollection(dict):
             for uid, (target, report) in targets.items():
                 variant_name = target.image_variant.name if target.image_variant else ""
                 os_name = target.image_os.name if target.image_os else ""
-                version_name = target.image_version.name
+                version_name = report.version_label or target.image_version.name
 
                 error_style = "bright_red bold" if report.error_count > 0 else "bright_black italic"
                 warning_style = "yellow bold" if report.warning_count > 0 else "bright_black italic"
@@ -137,6 +142,7 @@ class HadolintReportCollection(dict):
                     version_name,
                     os_name,
                     variant_name,
+                    str(report.containerfile),
                     Text(str(report.error_count), style=error_style),
                     Text(str(report.warning_count), style=warning_style),
                     Text(str(report.info_count), style=info_style),
@@ -152,7 +158,7 @@ class HadolintReportCollection(dict):
 
         table.add_section()
         table.add_row(
-            "Total", "", "", "",
+            "Total", "", "", "", "",
             str(total_errors),
             str(total_warnings),
             str(total_info),

--- a/posit-bakery/posit_bakery/plugins/builtin/hadolint/report.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/hadolint/report.py
@@ -25,6 +25,7 @@ class HadolintReport(BaseModel):
 
     filepath: Annotated[Path | None, Field(default=None, exclude=True, description="Path to the results JSON file.")]
     containerfile: Annotated[Path, Field(description="Relative path to the Containerfile.")]
+    exit_code: Annotated[int, Field(default=0, exclude=True, description="Hadolint process exit code.")]
     results: Annotated[list[HadolintResult], Field(default_factory=list, description="List of lint issues.")]
 
     @classmethod

--- a/posit-bakery/posit_bakery/plugins/builtin/hadolint/report.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/hadolint/report.py
@@ -1,0 +1,137 @@
+import json
+from pathlib import Path
+from typing import Annotated
+
+from pydantic import BaseModel, Field
+from rich.table import Table
+from rich.text import Text
+
+from posit_bakery.image.image_target import ImageTarget
+
+
+class HadolintResult(BaseModel):
+    """Models a single lint issue from hadolint JSON output."""
+
+    code: Annotated[str, Field(description="Rule code, e.g. DL3008")]
+    column: Annotated[int, Field(description="Column number")]
+    file: Annotated[str, Field(description="File path as hadolint reported it")]
+    level: Annotated[str, Field(description="Severity level: error, warning, info, style")]
+    line: Annotated[int, Field(description="Line number")]
+    message: Annotated[str, Field(description="Human-readable description")]
+
+
+class HadolintReport(BaseModel):
+    """Holds all hadolint results for a single image target."""
+
+    filepath: Annotated[Path | None, Field(default=None, exclude=True, description="Path to the results JSON file.")]
+    containerfile: Annotated[Path, Field(description="Relative path to the Containerfile.")]
+    results: Annotated[list[HadolintResult], Field(default_factory=list, description="List of lint issues.")]
+
+    @classmethod
+    def load(cls, filepath: Path, containerfile: Path) -> "HadolintReport":
+        """Load a HadolintReport from a JSON results file."""
+        with filepath.open("r") as f:
+            data = json.load(f)
+        results = [HadolintResult.model_validate(item) for item in data]
+        return cls(filepath=filepath, containerfile=containerfile, results=results)
+
+    @property
+    def error_count(self) -> int:
+        return sum(1 for r in self.results if r.level == "error")
+
+    @property
+    def warning_count(self) -> int:
+        return sum(1 for r in self.results if r.level == "warning")
+
+    @property
+    def info_count(self) -> int:
+        return sum(1 for r in self.results if r.level == "info")
+
+    @property
+    def style_count(self) -> int:
+        return sum(1 for r in self.results if r.level == "style")
+
+    @property
+    def total_count(self) -> int:
+        return len(self.results)
+
+    def by_level(self, level: str) -> list[HadolintResult]:
+        """Return results filtered to a specific severity level."""
+        return [r for r in self.results if r.level == level]
+
+
+class HadolintReportCollection(dict):
+    """Collection of HadolintReports keyed by image name and UID."""
+
+    def add_report(self, image_target: ImageTarget, report: HadolintReport):
+        """Add a HadolintReport to the collection."""
+        self.setdefault(image_target.image_name, dict())[image_target.uid] = (image_target, report)
+
+    @property
+    def has_issues(self) -> bool:
+        """Return True if any report has lint issues."""
+        for image_name, targets in self.items():
+            for uid, (_, report) in targets.items():
+                if report.total_count > 0:
+                    return True
+        return False
+
+    def table(self) -> Table:
+        """Generate a Rich table summarizing lint results."""
+        table = Table(title="Hadolint Results")
+        table.add_column("Image Name", justify="left")
+        table.add_column("Version", justify="left")
+        table.add_column("OS", justify="left")
+        table.add_column("Variant", justify="left")
+        table.add_column("Errors", justify="right", header_style="bright_red")
+        table.add_column("Warnings", justify="right", header_style="yellow")
+        table.add_column("Info", justify="right", header_style="bright_blue")
+        table.add_column("Style", justify="right", header_style="bright_black")
+        table.add_column("Total", justify="right")
+
+        total_errors = 0
+        total_warnings = 0
+        total_info = 0
+        total_style = 0
+
+        for image_name, targets in self.items():
+            p_image_name = image_name
+            for uid, (target, report) in targets.items():
+                variant_name = target.image_variant.name if target.image_variant else ""
+                os_name = target.image_os.name if target.image_os else ""
+                version_name = target.image_version.name
+
+                error_style = "bright_red bold" if report.error_count > 0 else "bright_black italic"
+                warning_style = "yellow bold" if report.warning_count > 0 else "bright_black italic"
+                info_style = "bright_blue bold" if report.info_count > 0 else "bright_black italic"
+                style_style = "bright_black italic"
+
+                table.add_row(
+                    p_image_name,
+                    version_name,
+                    os_name,
+                    variant_name,
+                    Text(str(report.error_count), style=error_style),
+                    Text(str(report.warning_count), style=warning_style),
+                    Text(str(report.info_count), style=info_style),
+                    Text(str(report.style_count), style=style_style),
+                    str(report.total_count),
+                )
+                p_image_name = ""
+
+                total_errors += report.error_count
+                total_warnings += report.warning_count
+                total_info += report.info_count
+                total_style += report.style_count
+
+        table.add_section()
+        table.add_row(
+            "Total", "", "", "",
+            str(total_errors),
+            str(total_warnings),
+            str(total_info),
+            str(total_style),
+            str(total_errors + total_warnings + total_info + total_style),
+        )
+
+        return table

--- a/posit-bakery/posit_bakery/plugins/builtin/hadolint/report.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/hadolint/report.py
@@ -56,9 +56,22 @@ class HadolintReport(BaseModel):
     def total_count(self) -> int:
         return len(self.results)
 
+    @property
+    def errors(self) -> list[HadolintResult]:
+        """Return results with error level."""
+        return [r for r in self.results if r.level == "error"]
+
+    @property
+    def warnings(self) -> list[HadolintResult]:
+        """Return results with warning level."""
+        return [r for r in self.results if r.level == "warning"]
+
     def by_level(self, level: str) -> list[HadolintResult]:
         """Return results filtered to a specific severity level."""
         return [r for r in self.results if r.level == level]
+
+
+SEVERITY_ORDER = ["error", "warning", "info", "style"]
 
 
 class HadolintReportCollection(dict):
@@ -76,6 +89,18 @@ class HadolintReportCollection(dict):
                 if report.total_count > 0:
                     return True
         return False
+
+    def issues_by_level(self, threshold: str) -> dict[str, list[HadolintResult]]:
+        """Return issues at or above the given severity threshold, keyed by UID."""
+        threshold_idx = SEVERITY_ORDER.index(threshold) if threshold in SEVERITY_ORDER else 0
+        included_levels = set(SEVERITY_ORDER[: threshold_idx + 1])
+        result = {}
+        for image_name, targets in self.items():
+            for uid, (_, report) in targets.items():
+                issues = [r for r in report.results if r.level in included_levels]
+                if issues:
+                    result[uid] = issues
+        return result
 
     def table(self) -> Table:
         """Generate a Rich table summarizing lint results."""

--- a/posit-bakery/posit_bakery/plugins/builtin/hadolint/suite.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/hadolint/suite.py
@@ -1,0 +1,106 @@
+import json
+import logging
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from posit_bakery.error import BakeryToolRuntimeError, BakeryToolRuntimeErrorGroup
+from posit_bakery.image.image_target import ImageTarget
+from posit_bakery.plugins.builtin.hadolint.command import HadolintCommand
+from posit_bakery.plugins.builtin.hadolint.errors import BakeryHadolintError
+from posit_bakery.plugins.builtin.hadolint.options import HadolintOptions
+from posit_bakery.plugins.builtin.hadolint.report import HadolintReport, HadolintReportCollection
+
+log = logging.getLogger(__name__)
+
+
+class HadolintSuite:
+    def __init__(
+        self,
+        context: Path,
+        image_targets: list[ImageTarget],
+        options_override: HadolintOptions | None = None,
+    ) -> None:
+        self.context = context
+        self.image_targets = image_targets
+        self.hadolint_commands = [
+            HadolintCommand.from_image_target(target, options_override=options_override)
+            for target in image_targets
+        ]
+
+    def run(self) -> tuple[HadolintReportCollection, BakeryToolRuntimeError | BakeryToolRuntimeErrorGroup | None]:
+        results_dir = self.context / "results" / "hadolint"
+        if results_dir.exists():
+            shutil.rmtree(results_dir)
+        results_dir.mkdir(parents=True)
+
+        report_collection = HadolintReportCollection()
+        errors = []
+
+        for hadolint_command in self.hadolint_commands:
+            target = hadolint_command.image_target
+            log.info(f"[bright_blue bold]=== Running hadolint for '{str(target)}' ===")
+            log.debug(f"[bright_black]Executing hadolint command: {' '.join(hadolint_command.command)}")
+
+            run_env = os.environ.copy()
+            p = subprocess.run(hadolint_command.command, env=run_env, capture_output=True)
+            exit_code = p.returncode
+
+            image_subdir = results_dir / target.image_name
+            image_subdir.mkdir(parents=True, exist_ok=True)
+            results_file = image_subdir / f"{target.uid}.json"
+
+            try:
+                output = p.stdout.decode("utf-8").strip()
+            except UnicodeDecodeError:
+                log.warning(f"Unexpected encoding for hadolint output for image '{str(target)}'.")
+                output = p.stdout
+
+            parse_err = None
+            try:
+                result_data = json.loads(output)
+                output = json.dumps(result_data, indent=2)
+                report_collection.add_report(
+                    target,
+                    HadolintReport(
+                        filepath=results_file,
+                        containerfile=target.containerfile,
+                        results=result_data,
+                    ),
+                )
+            except json.JSONDecodeError as e:
+                log.error(f"Failed to decode JSON output from hadolint for image '{str(target)}': {e}")
+                parse_err = e
+
+            if not parse_err:
+                with open(results_file, "w") as f:
+                    log.info(f"Writing results to {results_file}")
+                    f.write(output)
+
+            if exit_code != 0 and parse_err is not None:
+                log.error(f"hadolint for image '{str(target)}' exited with code {exit_code}")
+                errors.append(
+                    BakeryHadolintError(
+                        f"hadolint execution failed for image '{str(target)}'",
+                        "hadolint",
+                        cmd=hadolint_command.command,
+                        stdout=p.stdout,
+                        stderr=p.stderr,
+                        parse_error=parse_err,
+                        exit_code=exit_code,
+                    )
+                )
+            elif exit_code == 0:
+                log.info(f"[bright_green bold]hadolint passed for '{str(target)}'")
+            else:
+                log.warning(f"[yellow bold]hadolint found issues for '{str(target)}'")
+
+        if errors:
+            if len(errors) == 1:
+                errors = errors[0]
+            else:
+                errors = BakeryToolRuntimeErrorGroup("hadolint runtime errors occurred for multiple images.", errors)
+        else:
+            errors = None
+        return report_collection, errors

--- a/posit-bakery/posit_bakery/plugins/builtin/hadolint/suite.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/hadolint/suite.py
@@ -29,6 +29,17 @@ class HadolintSuite:
             for target in image_targets
         ]
 
+    def _group_commands_by_containerfile(self) -> dict[Path, list[HadolintCommand]]:
+        """Group hadolint commands by their Containerfile path.
+
+        Matrix versions sharing the same Containerfile only need to be linted once since
+        hadolint operates on the static Containerfile definition and is agnostic to build args.
+        """
+        groups: dict[Path, list[HadolintCommand]] = {}
+        for cmd in self.hadolint_commands:
+            groups.setdefault(cmd.containerfile_path, []).append(cmd)
+        return groups
+
     def run(self) -> tuple[HadolintReportCollection, BakeryToolRuntimeError | BakeryToolRuntimeErrorGroup | None]:
         results_dir = self.context / "results" / "hadolint"
         if results_dir.exists():
@@ -38,18 +49,25 @@ class HadolintSuite:
         report_collection = HadolintReportCollection()
         errors = []
 
-        for hadolint_command in self.hadolint_commands:
-            target = hadolint_command.image_target
-            log.info(f"[bright_blue bold]=== Running hadolint for '{str(target)}' ===")
-            log.debug(f"[bright_black]Executing hadolint command: {' '.join(hadolint_command.command)}")
+        for containerfile_path, commands in self._group_commands_by_containerfile().items():
+            # Use the first command in the group to run hadolint
+            representative = commands[0]
+            target = representative.image_target
+
+            if len(commands) > 1:
+                other_uids = [cmd.image_target.uid for cmd in commands[1:]]
+                log.info(
+                    f"[bright_blue bold]=== Running hadolint for '{str(target)}' "
+                    f"(shared by {len(commands)} targets) ==="
+                )
+                log.debug(f"[bright_black]Shared targets: {', '.join(other_uids)}")
+            else:
+                log.info(f"[bright_blue bold]=== Running hadolint for '{str(target)}' ===")
+            log.debug(f"[bright_black]Executing hadolint command: {' '.join(representative.command)}")
 
             run_env = os.environ.copy()
-            p = subprocess.run(hadolint_command.command, env=run_env, capture_output=True)
+            p = subprocess.run(representative.command, env=run_env, capture_output=True)
             exit_code = p.returncode
-
-            image_subdir = results_dir / target.image_name
-            image_subdir.mkdir(parents=True, exist_ok=True)
-            results_file = image_subdir / f"{target.uid}.json"
 
             try:
                 output = p.stdout.decode("utf-8").strip()
@@ -58,23 +76,30 @@ class HadolintSuite:
                 output = p.stdout
 
             parse_err = None
+            result_data = None
             try:
                 result_data = json.loads(output)
                 output = json.dumps(result_data, indent=2)
+            except json.JSONDecodeError as e:
+                log.error(f"Failed to decode JSON output from hadolint for image '{str(target)}': {e}")
+                parse_err = e
+
+            image_subdir = results_dir / target.image_name
+            image_subdir.mkdir(parents=True, exist_ok=True)
+            results_file = image_subdir / f"{target.uid}.json"
+
+            if not parse_err:
+                version_label = "matrix" if len(commands) > 1 else None
                 report_collection.add_report(
                     target,
                     HadolintReport(
                         filepath=results_file,
                         containerfile=target.containerfile,
                         exit_code=exit_code,
+                        version_label=version_label,
                         results=result_data,
                     ),
                 )
-            except json.JSONDecodeError as e:
-                log.error(f"Failed to decode JSON output from hadolint for image '{str(target)}': {e}")
-                parse_err = e
-
-            if not parse_err:
                 with open(results_file, "w") as f:
                     log.info(f"Writing results to {results_file}")
                     f.write(output)
@@ -85,7 +110,7 @@ class HadolintSuite:
                     BakeryHadolintError(
                         f"hadolint execution failed for image '{str(target)}'",
                         "hadolint",
-                        cmd=hadolint_command.command,
+                        cmd=representative.command,
                         stdout=p.stdout,
                         stderr=p.stderr,
                         parse_error=parse_err,

--- a/posit-bakery/posit_bakery/plugins/builtin/hadolint/suite.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/hadolint/suite.py
@@ -66,6 +66,7 @@ class HadolintSuite:
                     HadolintReport(
                         filepath=results_file,
                         containerfile=target.containerfile,
+                        exit_code=exit_code,
                         results=result_data,
                     ),
                 )

--- a/posit-bakery/pyproject.toml
+++ b/posit-bakery/pyproject.toml
@@ -33,6 +33,7 @@ bakery = "posit_bakery.cli.main:app"
 [project.entry-points."bakery.plugins"]
 dgoss = "posit_bakery.plugins.builtin.dgoss:DGossPlugin"
 oras = "posit_bakery.plugins.builtin.oras:OrasPlugin"
+hadolint = "posit_bakery.plugins.builtin.hadolint:HadolintPlugin"
 
 [build-system]
 requires = ["hatchling", "uv-dynamic-versioning"]

--- a/posit-bakery/test/config/image/test_variant.py
+++ b/posit-bakery/test/config/image/test_variant.py
@@ -30,7 +30,7 @@ class TestImageVariant:
         assert i.extension == "variant1"
         assert i.tagDisplayName == "variant-1"
         assert len(i.tagPatterns) == 0
-        assert len(i.options) == 1
+        assert len(i.options) == 2
 
     def test_custom_options(self):
         """Test creating an ImageVariant with custom options."""

--- a/posit-bakery/test/config/tools/test_hadolint.py
+++ b/posit-bakery/test/config/tools/test_hadolint.py
@@ -1,0 +1,85 @@
+import pytest
+from _pytest.mark import ParameterSet
+
+from posit_bakery.plugins.builtin.hadolint.options import HadolintOptions
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.hadolint,
+]
+
+
+class TestHadolintOptions:
+    def test_defaults(self):
+        """Test that HadolintOptions has correct defaults."""
+        options = HadolintOptions()
+        assert options.tool == "hadolint"
+        assert options.failureThreshold is None
+        assert options.ignored is None
+        assert options.labelSchema is None
+        assert options.noFail is None
+        assert options.override is None
+        assert options.strictLabels is None
+        assert options.disableIgnorePragma is None
+        assert options.trustedRegistries is None
+
+    def test_with_all_fields(self):
+        """Test creating HadolintOptions with all fields set."""
+        options = HadolintOptions(
+            failureThreshold="warning",
+            ignored=["DL3008", "DL3009"],
+            labelSchema={"maintainer": "text", "version": "semver"},
+            noFail=True,
+            override={"error": ["DL3001"], "warning": ["DL3002"]},
+            strictLabels=True,
+            disableIgnorePragma=True,
+            trustedRegistries=["docker.io", "ghcr.io"],
+        )
+        assert options.failureThreshold == "warning"
+        assert options.ignored == ["DL3008", "DL3009"]
+        assert options.labelSchema == {"maintainer": "text", "version": "semver"}
+        assert options.noFail is True
+        assert options.override.error == ["DL3001"]
+        assert options.override.warning == ["DL3002"]
+        assert options.strictLabels is True
+        assert options.disableIgnorePragma is True
+        assert options.trustedRegistries == ["docker.io", "ghcr.io"]
+
+    @staticmethod
+    def merge_params() -> list[ParameterSet]:
+        return [
+            pytest.param({}, {}, {}, id="both_default"),
+            pytest.param(
+                {},
+                {"failureThreshold": "warning", "ignored": ["DL3008"]},
+                {"failureThreshold": "warning", "ignored": ["DL3008"]},
+                id="left_default_right_set",
+            ),
+            pytest.param(
+                {"failureThreshold": "error", "ignored": ["DL3009"]},
+                {},
+                {"failureThreshold": "error", "ignored": ["DL3009"]},
+                id="left_set_right_default",
+            ),
+            pytest.param(
+                {"failureThreshold": "error"},
+                {"failureThreshold": "warning"},
+                {"failureThreshold": "error"},
+                id="both_set_left_wins",
+            ),
+            pytest.param(
+                {"noFail": True},
+                {"noFail": False, "strictLabels": True},
+                {"noFail": True, "strictLabels": True},
+                id="partial_overlap",
+            ),
+        ]
+
+    @pytest.mark.parametrize("left,right,expected", merge_params())
+    def test_update(self, left, right, expected):
+        left_options = HadolintOptions(**left)
+        right_options = HadolintOptions(**right)
+        merged = left_options.update(right_options)
+
+        for key, value in expected.items():
+            assert getattr(merged, key) == value, f"Expected {key} to be {value}, got {getattr(merged, key)}"

--- a/posit-bakery/test/plugins/builtin/hadolint/conftest.py
+++ b/posit-bakery/test/plugins/builtin/hadolint/conftest.py
@@ -1,0 +1,21 @@
+import pytest
+
+from posit_bakery.image import ImageTarget
+
+
+@pytest.fixture
+def basic_standard_image_target(get_config_obj):
+    """Return a standard ImageTarget object for testing."""
+    basic_config_obj = get_config_obj("basic")
+
+    image = basic_config_obj.model.get_image("test-image")
+    version = image.get_version("1.0.0")
+    variant = image.get_variant("Standard")
+    os = version.os[0]
+
+    return ImageTarget.new_image_target(
+        repository=basic_config_obj.model.repository,
+        image_version=version,
+        image_variant=variant,
+        image_os=os,
+    )

--- a/posit-bakery/test/plugins/builtin/hadolint/test_command.py
+++ b/posit-bakery/test/plugins/builtin/hadolint/test_command.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pytest
 
 from posit_bakery.plugins.builtin.hadolint.command import HadolintCommand
-from posit_bakery.plugins.builtin.hadolint.options import HadolintOptions
+from posit_bakery.plugins.builtin.hadolint.options import DEFAULT_IGNORED_RULES, HadolintOptions
 
 pytestmark = [
     pytest.mark.unit,
@@ -65,14 +65,29 @@ class TestHadolintCommand:
         idx = cmd.command.index("--failure-threshold")
         assert cmd.command[idx + 1] == "warning"
 
+    def test_command_default_ignored_rules(self, basic_standard_image_target):
+        """Test that default ignored rules are applied when none are specified."""
+        cmd = HadolintCommand.from_image_target(basic_standard_image_target)
+        ignore_indices = [i for i, v in enumerate(cmd.command) if v == "--ignore"]
+        assert len(ignore_indices) == len(DEFAULT_IGNORED_RULES)
+        ignored_values = [cmd.command[i + 1] for i in ignore_indices]
+        assert ignored_values == DEFAULT_IGNORED_RULES
+
     def test_command_with_ignored_rules(self, basic_standard_image_target):
-        """Test that --ignore is repeated for each ignored rule."""
+        """Test that user-provided ignored rules replace the defaults."""
         options = HadolintOptions(ignored=["DL3008", "DL3009"])
         cmd = HadolintCommand.from_image_target(basic_standard_image_target, options_override=options)
         ignore_indices = [i for i, v in enumerate(cmd.command) if v == "--ignore"]
         assert len(ignore_indices) == 2
         assert cmd.command[ignore_indices[0] + 1] == "DL3008"
         assert cmd.command[ignore_indices[1] + 1] == "DL3009"
+
+    def test_command_with_empty_ignored_rules(self, basic_standard_image_target):
+        """Test that explicitly setting ignored to [] clears the defaults."""
+        options = HadolintOptions(ignored=[])
+        cmd = HadolintCommand.from_image_target(basic_standard_image_target, options_override=options)
+        ignore_indices = [i for i, v in enumerate(cmd.command) if v == "--ignore"]
+        assert len(ignore_indices) == 0
 
     def test_command_with_no_fail(self, basic_standard_image_target):
         """Test that --no-fail is included when set."""

--- a/posit-bakery/test/plugins/builtin/hadolint/test_command.py
+++ b/posit-bakery/test/plugins/builtin/hadolint/test_command.py
@@ -1,0 +1,134 @@
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from posit_bakery.plugins.builtin.hadolint.command import HadolintCommand
+from posit_bakery.plugins.builtin.hadolint.options import HadolintOptions
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.hadolint,
+]
+
+
+class TestHadolintCommand:
+    def test_from_image_target_defaults(self, basic_standard_image_target):
+        """Test that HadolintCommand initializes with correct defaults."""
+        cmd = HadolintCommand.from_image_target(basic_standard_image_target)
+        assert cmd.image_target == basic_standard_image_target
+        assert cmd.containerfile_path == (
+            basic_standard_image_target.context.base_path / basic_standard_image_target.containerfile
+        )
+
+    def test_command_includes_format_json(self, basic_standard_image_target):
+        """Test that the command always includes --format json."""
+        cmd = HadolintCommand.from_image_target(basic_standard_image_target)
+        assert "--format" in cmd.command
+        idx = cmd.command.index("--format")
+        assert cmd.command[idx + 1] == "json"
+
+    def test_command_includes_containerfile(self, basic_standard_image_target):
+        """Test that the command ends with the containerfile path."""
+        cmd = HadolintCommand.from_image_target(basic_standard_image_target)
+        expected_path = str(
+            basic_standard_image_target.context.base_path / basic_standard_image_target.containerfile
+        )
+        assert cmd.command[-1] == expected_path
+
+    def test_command_verbose_when_debug(self, basic_standard_image_target):
+        """Test that --verbose is included when log level is DEBUG."""
+        with patch("posit_bakery.plugins.builtin.hadolint.command.SETTINGS") as mock_settings:
+            mock_settings.log_level = logging.DEBUG
+            cmd = HadolintCommand.from_image_target(basic_standard_image_target)
+            assert "--verbose" in cmd.command
+
+    def test_command_no_verbose_when_info(self, basic_standard_image_target):
+        """Test that --verbose is NOT included when log level is INFO."""
+        with patch("posit_bakery.plugins.builtin.hadolint.command.SETTINGS") as mock_settings:
+            mock_settings.log_level = logging.INFO
+            cmd = HadolintCommand.from_image_target(basic_standard_image_target)
+            assert "--verbose" not in cmd.command
+
+    def test_command_with_failure_threshold(self, basic_standard_image_target):
+        """Test that --failure-threshold is included when set."""
+        options = HadolintOptions(failureThreshold="warning")
+        cmd = HadolintCommand.from_image_target(basic_standard_image_target, options_override=options)
+        assert "--failure-threshold" in cmd.command
+        idx = cmd.command.index("--failure-threshold")
+        assert cmd.command[idx + 1] == "warning"
+
+    def test_command_with_ignored_rules(self, basic_standard_image_target):
+        """Test that --ignore is repeated for each ignored rule."""
+        options = HadolintOptions(ignored=["DL3008", "DL3009"])
+        cmd = HadolintCommand.from_image_target(basic_standard_image_target, options_override=options)
+        ignore_indices = [i for i, v in enumerate(cmd.command) if v == "--ignore"]
+        assert len(ignore_indices) == 2
+        assert cmd.command[ignore_indices[0] + 1] == "DL3008"
+        assert cmd.command[ignore_indices[1] + 1] == "DL3009"
+
+    def test_command_with_no_fail(self, basic_standard_image_target):
+        """Test that --no-fail is included when set."""
+        options = HadolintOptions(noFail=True)
+        cmd = HadolintCommand.from_image_target(basic_standard_image_target, options_override=options)
+        assert "--no-fail" in cmd.command
+
+    def test_command_no_fail_false_omitted(self, basic_standard_image_target):
+        """Test that --no-fail is NOT included when explicitly False."""
+        options = HadolintOptions(noFail=False)
+        cmd = HadolintCommand.from_image_target(basic_standard_image_target, options_override=options)
+        assert "--no-fail" not in cmd.command
+
+    def test_command_with_strict_labels(self, basic_standard_image_target):
+        """Test that --strict-labels is included when set."""
+        options = HadolintOptions(strictLabels=True)
+        cmd = HadolintCommand.from_image_target(basic_standard_image_target, options_override=options)
+        assert "--strict-labels" in cmd.command
+
+    def test_command_with_disable_ignore_pragma(self, basic_standard_image_target):
+        """Test that --disable-ignore-pragma is included when set."""
+        options = HadolintOptions(disableIgnorePragma=True)
+        cmd = HadolintCommand.from_image_target(basic_standard_image_target, options_override=options)
+        assert "--disable-ignore-pragma" in cmd.command
+
+    def test_command_with_trusted_registries(self, basic_standard_image_target):
+        """Test that --trusted-registry is repeated for each registry."""
+        options = HadolintOptions(trustedRegistries=["docker.io", "ghcr.io"])
+        cmd = HadolintCommand.from_image_target(basic_standard_image_target, options_override=options)
+        reg_indices = [i for i, v in enumerate(cmd.command) if v == "--trusted-registry"]
+        assert len(reg_indices) == 2
+        assert cmd.command[reg_indices[0] + 1] == "docker.io"
+        assert cmd.command[reg_indices[1] + 1] == "ghcr.io"
+
+    def test_command_with_label_schema(self, basic_standard_image_target):
+        """Test that --require-label is repeated for each label."""
+        options = HadolintOptions(labelSchema={"maintainer": "text", "version": "semver"})
+        cmd = HadolintCommand.from_image_target(basic_standard_image_target, options_override=options)
+        label_indices = [i for i, v in enumerate(cmd.command) if v == "--require-label"]
+        assert len(label_indices) == 2
+        label_values = [cmd.command[i + 1] for i in label_indices]
+        assert "maintainer:text" in label_values
+        assert "version:semver" in label_values
+
+    def test_command_with_override(self, basic_standard_image_target):
+        """Test that override rules are mapped to the correct flags."""
+        options = HadolintOptions(
+            override={"error": ["DL3001"], "warning": ["DL3002", "DL3003"], "info": ["DL3004"]}
+        )
+        cmd = HadolintCommand.from_image_target(basic_standard_image_target, options_override=options)
+        error_indices = [i for i, v in enumerate(cmd.command) if v == "--error"]
+        assert len(error_indices) == 1
+        assert cmd.command[error_indices[0] + 1] == "DL3001"
+
+        warning_indices = [i for i, v in enumerate(cmd.command) if v == "--warning"]
+        assert len(warning_indices) == 2
+
+        info_indices = [i for i, v in enumerate(cmd.command) if v == "--info"]
+        assert len(info_indices) == 1
+
+    def test_command_with_options_from_variant(self, basic_standard_image_target):
+        """Test that options from the image variant are loaded and merged with override."""
+        override = HadolintOptions(failureThreshold="warning")
+        cmd = HadolintCommand.from_image_target(basic_standard_image_target, options_override=override)
+        idx = cmd.command.index("--failure-threshold")
+        assert cmd.command[idx + 1] == "warning"

--- a/posit-bakery/test/plugins/builtin/hadolint/test_command.py
+++ b/posit-bakery/test/plugins/builtin/hadolint/test_command.py
@@ -36,6 +36,13 @@ class TestHadolintCommand:
         )
         assert cmd.command[-1] == expected_path
 
+    def test_command_default_failure_threshold(self, basic_standard_image_target):
+        """Test that the default failure threshold is 'error' when no options are provided."""
+        cmd = HadolintCommand.from_image_target(basic_standard_image_target)
+        assert "--failure-threshold" in cmd.command
+        idx = cmd.command.index("--failure-threshold")
+        assert cmd.command[idx + 1] == "error"
+
     def test_command_verbose_when_debug(self, basic_standard_image_target):
         """Test that --verbose is included when log level is DEBUG."""
         with patch("posit_bakery.plugins.builtin.hadolint.command.SETTINGS") as mock_settings:

--- a/posit-bakery/test/plugins/builtin/hadolint/test_report.py
+++ b/posit-bakery/test/plugins/builtin/hadolint/test_report.py
@@ -1,0 +1,166 @@
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from posit_bakery.plugins.builtin.hadolint.report import (
+    HadolintResult,
+    HadolintReport,
+    HadolintReportCollection,
+)
+from posit_bakery.image.image_target import ImageTarget
+
+pytestmark = [pytest.mark.unit, pytest.mark.hadolint]
+
+
+@pytest.fixture
+def sample_results_data():
+    """Sample hadolint JSON output as a list of dicts."""
+    return [
+        {"code": "DL3007", "column": 1, "file": "Containerfile", "level": "warning", "line": 1,
+         "message": "Using latest is prone to errors"},
+        {"code": "DL3008", "column": 1, "file": "Containerfile", "level": "warning", "line": 5,
+         "message": "Pin versions in apt get install"},
+        {"code": "DL3009", "column": 1, "file": "Containerfile", "level": "info", "line": 5,
+         "message": "Delete the apt lists after installing"},
+    ]
+
+
+class TestHadolintResult:
+    def test_parse_result(self):
+        result = HadolintResult(
+            code="DL3008", column=1, file="Containerfile",
+            level="warning", line=10, message="Pin versions in apt get install",
+        )
+        assert result.code == "DL3008"
+        assert result.level == "warning"
+        assert result.line == 10
+
+    def test_parse_from_dict(self):
+        data = {"code": "DL3007", "column": 1, "file": "-", "level": "error", "line": 1,
+                "message": "Using latest"}
+        result = HadolintResult.model_validate(data)
+        assert result.code == "DL3007"
+        assert result.level == "error"
+
+
+class TestHadolintReport:
+    def test_create_report(self, sample_results_data):
+        report = HadolintReport(
+            containerfile=Path("test-image/1.0.0/Containerfile.ubuntu2204.std"),
+            results=[HadolintResult.model_validate(r) for r in sample_results_data],
+        )
+        assert report.total_count == 3
+        assert report.warning_count == 2
+        assert report.info_count == 1
+        assert report.error_count == 0
+        assert report.style_count == 0
+
+    def test_empty_report(self):
+        report = HadolintReport(
+            containerfile=Path("Containerfile"),
+            results=[],
+        )
+        assert report.total_count == 0
+        assert report.error_count == 0
+
+    def test_load_from_file(self, tmp_path, sample_results_data):
+        report_file = tmp_path / "results.json"
+        report_file.write_text(json.dumps(sample_results_data))
+        report = HadolintReport.load(report_file, containerfile=Path("Containerfile"))
+        assert report.total_count == 3
+        assert report.filepath == report_file
+
+    def test_by_level(self, sample_results_data):
+        report = HadolintReport(
+            containerfile=Path("Containerfile"),
+            results=[HadolintResult.model_validate(r) for r in sample_results_data],
+        )
+        warnings = report.by_level("warning")
+        assert len(warnings) == 2
+        infos = report.by_level("info")
+        assert len(infos) == 1
+        errors = report.by_level("error")
+        assert len(errors) == 0
+
+
+class TestHadolintReportCollection:
+    @pytest.fixture
+    def mock_target(self):
+        target = MagicMock(spec=ImageTarget)
+        target.image_name = "test-image"
+        target.uid = "test-image-1.0.0-ubuntu2204-standard"
+        target.image_version = MagicMock()
+        target.image_version.name = "1.0.0"
+        target.image_variant = MagicMock()
+        target.image_variant.name = "Standard"
+        target.image_os = MagicMock()
+        target.image_os.name = "ubuntu2204"
+        return target
+
+    @pytest.fixture
+    def report_with_issues(self, sample_results_data):
+        return HadolintReport(
+            containerfile=Path("test-image/1.0.0/Containerfile.ubuntu2204.std"),
+            results=[HadolintResult.model_validate(r) for r in sample_results_data],
+        )
+
+    def test_add_report(self, mock_target, report_with_issues):
+        collection = HadolintReportCollection()
+        collection.add_report(mock_target, report_with_issues)
+        assert "test-image" in collection
+        assert mock_target.uid in collection["test-image"]
+
+    def test_add_multiple_reports(self, report_with_issues):
+        collection = HadolintReportCollection()
+
+        target1 = MagicMock(spec=ImageTarget)
+        target1.image_name = "image-a"
+        target1.uid = "image-a-1.0.0"
+
+        target2 = MagicMock(spec=ImageTarget)
+        target2.image_name = "image-a"
+        target2.uid = "image-a-2.0.0"
+
+        target3 = MagicMock(spec=ImageTarget)
+        target3.image_name = "image-b"
+        target3.uid = "image-b-1.0.0"
+
+        collection.add_report(target1, report_with_issues)
+        collection.add_report(target2, report_with_issues)
+        collection.add_report(target3, report_with_issues)
+
+        assert len(collection) == 2
+        assert len(collection["image-a"]) == 2
+        assert len(collection["image-b"]) == 1
+
+    def test_has_issues(self, mock_target, report_with_issues):
+        collection = HadolintReportCollection()
+        collection.add_report(mock_target, report_with_issues)
+        assert collection.has_issues is True
+
+    def test_no_issues(self, mock_target):
+        collection = HadolintReportCollection()
+        empty_report = HadolintReport(containerfile=Path("Containerfile"), results=[])
+        collection.add_report(mock_target, empty_report)
+        assert collection.has_issues is False
+
+    def test_empty_collection(self):
+        collection = HadolintReportCollection()
+        assert collection.has_issues is False
+
+    def test_table_generation(self, mock_target, report_with_issues):
+        collection = HadolintReportCollection()
+        collection.add_report(mock_target, report_with_issues)
+        table = collection.table()
+        assert table.title == "Hadolint Results"
+        column_names = [col.header for col in table.columns]
+        assert "Image Name" in column_names
+        assert "Errors" in column_names
+        assert "Warnings" in column_names
+
+    def test_empty_collection_table(self):
+        collection = HadolintReportCollection()
+        table = collection.table()
+        assert table.title == "Hadolint Results"

--- a/posit-bakery/test/plugins/builtin/hadolint/test_report.py
+++ b/posit-bakery/test/plugins/builtin/hadolint/test_report.py
@@ -72,6 +72,21 @@ class TestHadolintReport:
         assert report.total_count == 3
         assert report.filepath == report_file
 
+    def test_errors_property(self, sample_results_data):
+        report = HadolintReport(
+            containerfile=Path("Containerfile"),
+            results=[HadolintResult.model_validate(r) for r in sample_results_data],
+        )
+        assert len(report.errors) == 0
+
+    def test_warnings_property(self, sample_results_data):
+        report = HadolintReport(
+            containerfile=Path("Containerfile"),
+            results=[HadolintResult.model_validate(r) for r in sample_results_data],
+        )
+        assert len(report.warnings) == 2
+        assert all(r.level == "warning" for r in report.warnings)
+
     def test_by_level(self, sample_results_data):
         report = HadolintReport(
             containerfile=Path("Containerfile"),
@@ -164,3 +179,27 @@ class TestHadolintReportCollection:
         collection = HadolintReportCollection()
         table = collection.table()
         assert table.title == "Hadolint Results"
+
+    def test_issues_by_level_warning(self, mock_target, report_with_issues):
+        """Test issues_by_level returns warnings and errors when threshold is warning."""
+        collection = HadolintReportCollection()
+        collection.add_report(mock_target, report_with_issues)
+        issues = collection.issues_by_level("warning")
+        assert mock_target.uid in issues
+        assert len(issues[mock_target.uid]) == 2  # 2 warnings, 0 errors
+        assert all(r.level in ("error", "warning") for r in issues[mock_target.uid])
+
+    def test_issues_by_level_error(self, mock_target, report_with_issues):
+        """Test issues_by_level returns only errors when threshold is error."""
+        collection = HadolintReportCollection()
+        collection.add_report(mock_target, report_with_issues)
+        issues = collection.issues_by_level("error")
+        assert issues == {}  # No errors in sample data
+
+    def test_issues_by_level_style(self, mock_target, report_with_issues):
+        """Test issues_by_level returns all levels when threshold is style."""
+        collection = HadolintReportCollection()
+        collection.add_report(mock_target, report_with_issues)
+        issues = collection.issues_by_level("style")
+        assert mock_target.uid in issues
+        assert len(issues[mock_target.uid]) == 3  # 2 warnings + 1 info

--- a/posit-bakery/test/plugins/builtin/hadolint/test_report.py
+++ b/posit-bakery/test/plugins/builtin/hadolint/test_report.py
@@ -172,6 +172,7 @@ class TestHadolintReportCollection:
         assert table.title == "Hadolint Results"
         column_names = [col.header for col in table.columns]
         assert "Image Name" in column_names
+        assert "Containerfile" in column_names
         assert "Errors" in column_names
         assert "Warnings" in column_names
 

--- a/posit-bakery/test/plugins/builtin/hadolint/test_suite.py
+++ b/posit-bakery/test/plugins/builtin/hadolint/test_suite.py
@@ -1,0 +1,115 @@
+import json
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from posit_bakery.plugins.builtin.hadolint.suite import HadolintSuite
+from posit_bakery.plugins.builtin.hadolint.options import HadolintOptions
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.hadolint,
+]
+
+
+class TestHadolintSuite:
+    def test_init(self, get_config_obj):
+        """Test that HadolintSuite initializes with the correct attributes."""
+        basic_config_obj = get_config_obj("basic")
+        suite = HadolintSuite(basic_config_obj.base_path, basic_config_obj.targets)
+        assert suite.context == basic_config_obj.base_path
+        assert suite.image_targets == basic_config_obj.targets
+        assert len(suite.hadolint_commands) == 2
+
+    def test_run_creates_results_directory(self, get_tmpconfig):
+        """Test that run creates the results/hadolint/ directory."""
+        basic_tmpconfig = get_tmpconfig("basic")
+        suite = HadolintSuite(basic_tmpconfig.base_path, basic_tmpconfig.targets)
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = b"[]"
+        mock_result.stderr = b""
+
+        with patch("posit_bakery.plugins.builtin.hadolint.suite.subprocess.run", return_value=mock_result):
+            suite.run()
+
+        results_dir = basic_tmpconfig.base_path / "results" / "hadolint"
+        assert results_dir.exists()
+
+    def test_run_writes_json_results(self, get_tmpconfig):
+        """Test that run writes JSON results for each target."""
+        basic_tmpconfig = get_tmpconfig("basic")
+        suite = HadolintSuite(basic_tmpconfig.base_path, basic_tmpconfig.targets)
+
+        hadolint_output = json.dumps([
+            {"code": "DL3008", "column": 1, "file": "Containerfile", "level": "warning",
+             "line": 10, "message": "Pin versions"}
+        ])
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = hadolint_output.encode("utf-8")
+        mock_result.stderr = b""
+
+        with patch("posit_bakery.plugins.builtin.hadolint.suite.subprocess.run", return_value=mock_result):
+            report_collection, errors = suite.run()
+
+        assert errors is None
+        for target in basic_tmpconfig.targets:
+            results_file = (
+                basic_tmpconfig.base_path / "results" / "hadolint" / target.image_name / f"{target.uid}.json"
+            )
+            assert results_file.exists()
+            with open(results_file) as f:
+                data = json.load(f)
+            assert len(data) == 1
+            assert data[0]["code"] == "DL3008"
+
+    def test_run_parses_empty_results(self, get_tmpconfig):
+        """Test that run handles empty hadolint output (no issues)."""
+        basic_tmpconfig = get_tmpconfig("basic")
+        suite = HadolintSuite(basic_tmpconfig.base_path, basic_tmpconfig.targets)
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = b"[]"
+        mock_result.stderr = b""
+
+        with patch("posit_bakery.plugins.builtin.hadolint.suite.subprocess.run", return_value=mock_result):
+            report_collection, errors = suite.run()
+
+        assert errors is None
+        for image_name, targets in report_collection.items():
+            for uid, (_, report) in targets.items():
+                assert report.total_count == 0
+
+    def test_run_handles_parse_error(self, get_tmpconfig):
+        """Test that run creates an error when JSON parsing fails and exit code is non-zero."""
+        basic_tmpconfig = get_tmpconfig("basic")
+        suite = HadolintSuite(basic_tmpconfig.base_path, basic_tmpconfig.targets)
+
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = b"not valid json"
+        mock_result.stderr = b"hadolint: error"
+
+        with patch("posit_bakery.plugins.builtin.hadolint.suite.subprocess.run", return_value=mock_result):
+            report_collection, errors = suite.run()
+
+        assert errors is not None
+
+    @pytest.mark.slow
+    def test_run_integration(self, get_tmpconfig):
+        """Test running hadolint against real Containerfiles."""
+        basic_tmpconfig = get_tmpconfig("basic")
+        suite = HadolintSuite(basic_tmpconfig.base_path, basic_tmpconfig.targets)
+        report_collection, errors = suite.run()
+
+        assert errors is None
+        assert len(report_collection) > 0
+        for target in basic_tmpconfig.targets:
+            results_file = (
+                basic_tmpconfig.base_path / "results" / "hadolint" / target.image_name / f"{target.uid}.json"
+            )
+            assert results_file.exists()

--- a/posit-bakery/test/plugins/builtin/hadolint/test_suite.py
+++ b/posit-bakery/test/plugins/builtin/hadolint/test_suite.py
@@ -99,6 +99,65 @@ class TestHadolintSuite:
 
         assert errors is not None
 
+    def test_deduplicates_shared_containerfiles(self, get_tmpconfig):
+        """Test that targets sharing the same Containerfile only run hadolint once."""
+        basic_tmpconfig = get_tmpconfig("basic")
+        suite = HadolintSuite(basic_tmpconfig.base_path, basic_tmpconfig.targets)
+
+        # The basic fixture has 2 targets with different Containerfiles (std/min),
+        # so hadolint should be called twice (once per unique Containerfile).
+        hadolint_output = json.dumps([])
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = hadolint_output.encode("utf-8")
+        mock_result.stderr = b""
+
+        with patch("posit_bakery.plugins.builtin.hadolint.suite.subprocess.run", return_value=mock_result) as mock_run:
+            suite.run()
+
+        assert mock_run.call_count == 2
+
+    def test_deduplicates_matrix_targets(self, get_tmpconfig):
+        """Test that matrix targets sharing a Containerfile are grouped and labeled 'matrix'."""
+        basic_tmpconfig = get_tmpconfig("basic")
+        targets = basic_tmpconfig.targets
+
+        # Simulate matrix by duplicating a target (same containerfile, different uid)
+        from copy import deepcopy
+        extra_target = targets[0].model_copy(deep=True)
+        extra_target.image_version = deepcopy(targets[0].image_version)
+        extra_target.image_version.isMatrixVersion = True
+        targets_with_matrix = [targets[0], extra_target, targets[1]]
+
+        suite = HadolintSuite(basic_tmpconfig.base_path, targets_with_matrix)
+
+        # The first two targets share a Containerfile, the third has a different one.
+        groups = suite._group_commands_by_containerfile()
+        assert len(groups) == 2
+
+        first_containerfile = suite.hadolint_commands[0].containerfile_path
+        assert len(groups[first_containerfile]) == 2
+
+        # Run with mock and verify only 2 hadolint calls (not 3) and version_label is set
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = b"[]"
+        mock_result.stderr = b""
+
+        with patch("posit_bakery.plugins.builtin.hadolint.suite.subprocess.run", return_value=mock_result) as mock_run:
+            report_collection, errors = suite.run()
+
+        assert mock_run.call_count == 2
+        assert errors is None
+
+        # The grouped entry should have version_label="matrix"
+        for image_name, uid_reports in report_collection.items():
+            for uid, (target, report) in uid_reports.items():
+                if target.containerfile == targets[0].containerfile:
+                    assert report.version_label == "matrix"
+                else:
+                    assert report.version_label is None
+
     @pytest.mark.slow
     def test_run_integration(self, get_tmpconfig):
         """Test running hadolint against real Containerfiles."""

--- a/posit-bakery/test/pytest.ini
+++ b/posit-bakery/test/pytest.ini
@@ -12,6 +12,7 @@ markers =
     dependency: Dependency tests
     product_version: Product version tests
     goss: Goss tool tests
+    hadolint: Hadolint tool tests
     build: Docker buildx build tests
     bake: Docker buildx bake tests
     container: Container related tests that leverage Docker

--- a/setup-hadolint/action.yml
+++ b/setup-hadolint/action.yml
@@ -1,0 +1,37 @@
+name: 'Setup hadolint'
+description: 'Installs hadolint to tools/'
+
+inputs:
+  version:
+    description: "The hadolint release version to install (e.g., v2.12.0)"
+    required: false
+    default: "latest"
+  architecture:
+    description: "The system architecture (e.g., x86_64, arm64). If not set, it will be detected automatically."
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: Make tools directory
+      shell: bash
+      run: mkdir -p tools
+    - name: Install hadolint
+      shell: bash
+      run: |
+        # Determine architecture if not provided
+        arch="${{ inputs.architecture }}"
+        if [ -z "$arch" ]; then
+          arch=$(uname -m)
+        fi
+
+        # Map architecture names to hadolint naming conventions
+        if [ "$arch" = "amd64" ]; then
+            arch="x86_64"
+        elif [ "$arch" = "aarch64" ]; then
+            arch="arm64"
+        fi
+
+        curl -fsSL https://github.com/hadolint/hadolint/releases/${{ inputs.version }}/download/hadolint-linux-${arch} -o tools/hadolint
+        chmod +rx tools/hadolint

--- a/setup-hadolint/action.yml
+++ b/setup-hadolint/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: "The system architecture (e.g., x86_64, arm64). If not set, it will be detected automatically."
     required: false
     default: ""
+  base_path:
+    description: "The base path to install hadolint (default: CWD)"
+    required: false
+    default: "."
 
 runs:
   using: "composite"
@@ -33,5 +37,5 @@ runs:
             arch="arm64"
         fi
 
-        curl -fsSL https://github.com/hadolint/hadolint/releases/${{ inputs.version }}/download/hadolint-linux-${arch} -o tools/hadolint
-        chmod +rx tools/hadolint
+        curl -fsSL https://github.com/hadolint/hadolint/releases/${{ inputs.version }}/download/hadolint-linux-${arch} -o ${{ inputs.base_path }}/tools/hadolint
+        chmod +rx ${{ inputs.base_path }}/tools/hadolint

--- a/setup-hadolint/action.yml
+++ b/setup-hadolint/action.yml
@@ -20,7 +20,7 @@ runs:
   steps:
     - name: Make tools directory
       shell: bash
-      run: mkdir -p tools
+      run: mkdir -p "${{ inputs.base_path }}/tools"
     - name: Install hadolint
       shell: bash
       run: |


### PR DESCRIPTION
## Summary

- Adds a new builtin `hadolint` plugin to posit-bakery that lints Containerfiles for each image target
- Registers as `bakery hadolint run` CLI command with filter options and all hadolint configuration properties
- Writes JSON results to `results/hadolint/{image_name}/{uid}.json` and displays a Rich summary table with detailed issue listings sectioned by image and UID
- Provides `HadolintOptions` as a `ToolOptions` subclass for `bakery.yaml` configuration, surfacing all hadolint YAML config properties except `format`, `verbose`, and `no-color`
- Default failure threshold is `error`; `--verbose` is set when bakery is in debug mode; `NO_COLOR` is inherited from the parent environment

## Structure

```
posit_bakery/plugins/builtin/hadolint/
  __init__.py   # HadolintPlugin (BakeryToolPlugin implementation + CLI)
  options.py    # HadolintOptions (ToolOptions for bakery.yaml config)
  command.py    # HadolintCommand (builds hadolint CLI invocation)
  suite.py      # HadolintSuite (orchestrates execution across targets)
  report.py     # HadolintResult, HadolintReport, HadolintReportCollection
  errors.py     # BakeryHadolintError
```

## Test plan

- [ ] 46 new unit tests covering options, command building, report models, suite orchestration
- [ ] All 1273 tests pass with no regressions
- [ ] Integration test runs hadolint against real Containerfiles
- [ ] Manual CLI testing with `--failure-threshold error` (default, warnings pass) and `--failure-threshold warning` (warnings fail)
- [ ] Verbose mode (`-v`) correctly passes `--verbose` to hadolint
- [ ] `bakery.yaml` hadolint options merge correctly with CLI overrides

🤖 Generated with [Claude Code](https://claude.com/claude-code)