### PR TITLE
Add Slack build notification action

### DIFF
--- a/.github/actions/slack-build-notify/action.yml
+++ b/.github/actions/slack-build-notify/action.yml
@@ -1,0 +1,197 @@
+name: Slack Build Notification
+description: |
+  Sends Slack notifications on build state transitions on main.
+  Notifies when a previously-passing workflow starts failing,
+  and when a previously-failing workflow recovers.
+
+inputs:
+  result:
+    description: Current build result (success or failure)
+    required: true
+  slack-webhook-url:
+    description: Slack incoming webhook URL
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Notify Slack on state transition
+      if: inputs.slack-webhook-url != ''
+      uses: actions/github-script@v7
+      env:
+        SLACK_WEBHOOK_URL: ${{ inputs.slack-webhook-url }}
+        CURRENT_RESULT: ${{ inputs.result }}
+      with:
+        script: |
+          const webhookUrl = process.env.SLACK_WEBHOOK_URL;
+          const currentResult = process.env.CURRENT_RESULT;
+
+          // Get the current run to find the workflow ID
+          const { data: currentRun } = await github.rest.actions.getWorkflowRun({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            run_id: context.runId,
+          });
+
+          const workflowId = currentRun.workflow_id;
+          const workflowName = currentRun.name;
+          const repo = `${context.repo.owner}/${context.repo.repo}`;
+
+          // Get previous completed runs of the same workflow on main
+          const { data: { workflow_runs: runs } } = await github.rest.actions.listWorkflowRuns({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            workflow_id: workflowId,
+            branch: 'main',
+            status: 'completed',
+            per_page: 50,
+            exclude_pull_requests: true,
+          });
+
+          // Filter out the current run and cancelled runs
+          const previousRuns = runs
+            .filter(r => r.id !== context.runId && r.conclusion !== 'cancelled')
+            .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+
+          if (previousRuns.length === 0) {
+            core.info('No previous completed runs found, skipping notification');
+            return;
+          }
+
+          const previousRun = previousRuns[0];
+          const currentFailed = currentResult !== 'success';
+          const previousFailed = previousRun.conclusion !== 'success';
+
+          if (currentFailed === previousFailed) {
+            core.info(`No state transition (current: ${currentResult}, previous: ${previousRun.conclusion}), skipping`);
+            return;
+          }
+
+          const runUrl = currentRun.html_url;
+          let blocks;
+
+          if (currentFailed) {
+            // === Build just broke ===
+
+            // Get failed job details from the current run
+            const { data: { jobs } } = await github.rest.actions.listJobsForWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+            });
+
+            const failedJobs = jobs.filter(j => j.conclusion === 'failure');
+
+            let failureLines = [];
+            for (const job of failedJobs) {
+              const failedSteps = (job.steps || []).filter(s => s.conclusion === 'failure');
+              const jobUrl = job.html_url;
+              if (failedSteps.length > 0) {
+                for (const step of failedSteps) {
+                  failureLines.push(`  <${jobUrl}|${job.name}> \u2014 ${step.name}`);
+                }
+              } else {
+                failureLines.push(`  <${jobUrl}|${job.name}>`);
+              }
+            }
+
+            const commitSha = currentRun.head_sha?.substring(0, 7) || '';
+            const commitMsg = currentRun.head_commit?.message?.split('\n')[0] || '';
+            const commitUrl = `https://github.com/${repo}/commit/${currentRun.head_sha}`;
+            const actor = currentRun.actor?.login || 'unknown';
+            const trigger = currentRun.event === 'schedule' ? 'scheduled' : currentRun.event;
+
+            blocks = [
+              {
+                type: 'section',
+                text: {
+                  type: 'mrkdwn',
+                  text: `:red_circle: *<https://github.com/${repo}|${repo}>* / *${workflowName}* build failed`
+                }
+              },
+              {
+                type: 'section',
+                text: {
+                  type: 'mrkdwn',
+                  text: `*Failed:*\n${failureLines.join('\n')}`
+                }
+              },
+              {
+                type: 'context',
+                elements: [
+                  {
+                    type: 'mrkdwn',
+                    text: `${trigger} \u2022 <${commitUrl}|\`${commitSha}\`> ${commitMsg} \u2022 ${actor}`
+                  }
+                ]
+              },
+              {
+                type: 'actions',
+                elements: [
+                  {
+                    type: 'button',
+                    text: { type: 'plain_text', text: 'View Run' },
+                    url: runUrl
+                  }
+                ]
+              }
+            ];
+          } else {
+            // === Build recovered ===
+
+            // Count consecutive failures before this recovery
+            let failedCount = 0;
+            let firstFailureRun = null;
+            for (const run of previousRuns) {
+              if (run.conclusion !== 'success') {
+                failedCount++;
+                firstFailureRun = run;
+              } else {
+                break;
+              }
+            }
+
+            blocks = [
+              {
+                type: 'section',
+                text: {
+                  type: 'mrkdwn',
+                  text: `:large_green_circle: *<https://github.com/${repo}|${repo}>* / *${workflowName}* build recovered`
+                }
+              },
+              {
+                type: 'context',
+                elements: [
+                  {
+                    type: 'mrkdwn',
+                    text: `Failed for ${failedCount} consecutive run${failedCount !== 1 ? 's' : ''}` +
+                      (firstFailureRun ? ` since <${firstFailureRun.html_url}|${new Date(firstFailureRun.created_at).toISOString().split('T')[0]}>` : '')
+                  }
+                ]
+              },
+              {
+                type: 'actions',
+                elements: [
+                  {
+                    type: 'button',
+                    text: { type: 'plain_text', text: 'View Run' },
+                    url: runUrl
+                  }
+                ]
+              }
+            ];
+          }
+
+          // Send Slack message
+          const response = await fetch(webhookUrl, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ blocks }),
+          });
+
+          if (!response.ok) {
+            const body = await response.text();
+            core.warning(`Slack notification failed: ${response.status} ${body}`);
+          } else {
+            core.info(`Slack ${currentFailed ? 'failure' : 'recovery'} notification sent`);
+          }

--- a/.github/actions/slack-build-notify/action.yml
+++ b/.github/actions/slack-build-notify/action.yml
@@ -72,12 +72,13 @@ runs:
               per_page: 100,
             });
             const prevCiJob = prevJobs.find(j => j.name === 'CI');
-            const previousFailed = prevCiJob
-              ? prevCiJob.conclusion !== 'success'
-              : previousRun.conclusion !== 'success';
+            const previousConclusion = prevCiJob
+              ? prevCiJob.conclusion
+              : previousRun.conclusion;
+            const previousFailed = previousConclusion !== 'success';
 
             if (currentFailed === previousFailed) {
-              core.info(`No state transition (current: ${currentResult}, previous: ${previousRun.conclusion}), skipping`);
+              core.info(`No state transition (current: ${currentResult}, previous: ${previousConclusion}), skipping`);
               return;
             }
 

--- a/.github/actions/slack-build-notify/action.yml
+++ b/.github/actions/slack-build-notify/action.yml
@@ -16,7 +16,7 @@ runs:
   using: composite
   steps:
     - name: Notify Slack on state transition
-      if: inputs.slack-webhook-url != ''
+      if: inputs.slack-webhook-url != '' && github.repository_owner == 'posit-dev'
       uses: actions/github-script@v7
       env:
         SLACK_WEBHOOK_URL: ${{ inputs.slack-webhook-url }}
@@ -61,6 +61,10 @@ runs:
 
             const previousRun = previousRuns[0];
             const currentFailed = currentResult !== 'success';
+            // NOTE: currentResult reflects the CI meta-job's alls-green outcome (typically
+            // just the build job), while previousRun.conclusion reflects the entire workflow
+            // (including clean, etc). A clean-only failure followed by a clean recovery can
+            // produce a false recovery notification. Acceptable for now.
             const previousFailed = previousRun.conclusion !== 'success';
 
             if (currentFailed === previousFailed) {

--- a/.github/actions/slack-build-notify/action.yml
+++ b/.github/actions/slack-build-notify/action.yml
@@ -117,7 +117,9 @@ runs:
                 : '  _No individual job failures identified \u2014 check the run for details_';
 
               const commitSha = currentRun.head_sha?.substring(0, 7) || '';
-              const commitMsg = currentRun.head_commit?.message?.split('\n')[0] || '';
+              // Escape Slack mrkdwn special characters to prevent injection (e.g. <!here>)
+              const rawMsg = currentRun.head_commit?.message?.split('\n')[0] || '';
+              const commitMsg = rawMsg.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
               const commitUrl = `https://github.com/${repo}/commit/${currentRun.head_sha}`;
               const actor = currentRun.actor?.login || 'unknown';
               const trigger = currentRun.event === 'schedule' ? 'scheduled' : currentRun.event;

--- a/.github/actions/slack-build-notify/action.yml
+++ b/.github/actions/slack-build-notify/action.yml
@@ -61,11 +61,20 @@ runs:
 
             const previousRun = previousRuns[0];
             const currentFailed = currentResult !== 'success';
-            // NOTE: currentResult reflects the CI meta-job's alls-green outcome (typically
-            // just the build job), while previousRun.conclusion reflects the entire workflow
-            // (including clean, etc). A clean-only failure followed by a clean recovery can
-            // produce a false recovery notification. Acceptable for now.
-            const previousFailed = previousRun.conclusion !== 'success';
+
+            // Compare against the previous run's CI job conclusion (not the workflow
+            // conclusion) so that clean-job flaps don't trigger false notifications.
+            // Falls back to workflow conclusion if the CI job isn't found.
+            const { data: { jobs: prevJobs } } = await github.rest.actions.listJobsForWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: previousRun.id,
+              per_page: 100,
+            });
+            const prevCiJob = prevJobs.find(j => j.name === 'CI');
+            const previousFailed = prevCiJob
+              ? prevCiJob.conclusion !== 'success'
+              : previousRun.conclusion !== 'success';
 
             if (currentFailed === previousFailed) {
               core.info(`No state transition (current: ${currentResult}, previous: ${previousRun.conclusion}), skipping`);

--- a/.github/actions/slack-build-notify/action.yml
+++ b/.github/actions/slack-build-notify/action.yml
@@ -112,9 +112,17 @@ runs:
                 }
               }
 
-              const failureDetail = failureLines.length > 0
-                ? failureLines.join('\n')
-                : '  _No individual job failures identified \u2014 check the run for details_';
+              const maxShown = 5;
+              let failureDetail;
+              if (failureLines.length === 0) {
+                failureDetail = '  _No individual job failures identified \u2014 check the run for details_';
+              } else if (failureLines.length <= maxShown) {
+                failureDetail = failureLines.join('\n');
+              } else {
+                const hidden = failureLines.length - maxShown;
+                failureDetail = failureLines.slice(0, maxShown).join('\n') +
+                  `\n  _… and ${hidden} more_`;
+              }
 
               const commitSha = currentRun.head_sha?.substring(0, 7) || '';
               // Escape Slack mrkdwn special characters to prevent injection (e.g. <!here>)
@@ -129,7 +137,8 @@ runs:
                   type: 'section',
                   text: {
                     type: 'mrkdwn',
-                    text: `:red_circle: *<https://github.com/${repo}|${repo}>* / *${workflowName}* build failed`
+                    text: `:red_circle: *<https://github.com/${repo}|${repo}>* / *${workflowName}* build failed` +
+                      (failedJobs.length > 0 ? ` (${failedJobs.length} job${failedJobs.length !== 1 ? 's' : ''})` : '')
                   }
                 },
                 {

--- a/.github/actions/slack-build-notify/action.yml
+++ b/.github/actions/slack-build-notify/action.yml
@@ -26,172 +26,184 @@ runs:
           const webhookUrl = process.env.SLACK_WEBHOOK_URL;
           const currentResult = process.env.CURRENT_RESULT;
 
-          // Get the current run to find the workflow ID
-          const { data: currentRun } = await github.rest.actions.getWorkflowRun({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            run_id: context.runId,
-          });
-
-          const workflowId = currentRun.workflow_id;
-          const workflowName = currentRun.name;
-          const repo = `${context.repo.owner}/${context.repo.repo}`;
-
-          // Get previous completed runs of the same workflow on main
-          const { data: { workflow_runs: runs } } = await github.rest.actions.listWorkflowRuns({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            workflow_id: workflowId,
-            branch: 'main',
-            status: 'completed',
-            per_page: 50,
-            exclude_pull_requests: true,
-          });
-
-          // Filter out the current run and cancelled runs
-          const previousRuns = runs
-            .filter(r => r.id !== context.runId && r.conclusion !== 'cancelled')
-            .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
-
-          if (previousRuns.length === 0) {
-            core.info('No previous completed runs found, skipping notification');
-            return;
-          }
-
-          const previousRun = previousRuns[0];
-          const currentFailed = currentResult !== 'success';
-          const previousFailed = previousRun.conclusion !== 'success';
-
-          if (currentFailed === previousFailed) {
-            core.info(`No state transition (current: ${currentResult}, previous: ${previousRun.conclusion}), skipping`);
-            return;
-          }
-
-          const runUrl = currentRun.html_url;
-          let blocks;
-
-          if (currentFailed) {
-            // === Build just broke ===
-
-            // Get failed job details from the current run
-            const { data: { jobs } } = await github.rest.actions.listJobsForWorkflowRun({
+          try {
+            // Get the current run to find the workflow ID
+            const { data: currentRun } = await github.rest.actions.getWorkflowRun({
               owner: context.repo.owner,
               repo: context.repo.repo,
               run_id: context.runId,
             });
 
-            const failedJobs = jobs.filter(j => j.conclusion === 'failure');
+            const workflowId = currentRun.workflow_id;
+            const workflowName = currentRun.name;
+            const repo = `${context.repo.owner}/${context.repo.repo}`;
 
-            let failureLines = [];
-            for (const job of failedJobs) {
-              const failedSteps = (job.steps || []).filter(s => s.conclusion === 'failure');
-              const jobUrl = job.html_url;
-              if (failedSteps.length > 0) {
-                for (const step of failedSteps) {
-                  failureLines.push(`  <${jobUrl}|${job.name}> \u2014 ${step.name}`);
-                }
-              } else {
-                failureLines.push(`  <${jobUrl}|${job.name}>`);
-              }
+            // Get previous completed runs of the same workflow on main
+            const { data: { workflow_runs: runs } } = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: workflowId,
+              branch: 'main',
+              status: 'completed',
+              per_page: 50,
+              exclude_pull_requests: true,
+            });
+
+            // Filter out the current run and cancelled runs
+            const previousRuns = runs
+              .filter(r => r.id !== context.runId && r.conclusion !== 'cancelled')
+              .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+
+            if (previousRuns.length === 0) {
+              core.info('No previous completed runs found, skipping notification');
+              return;
             }
 
-            const commitSha = currentRun.head_sha?.substring(0, 7) || '';
-            const commitMsg = currentRun.head_commit?.message?.split('\n')[0] || '';
-            const commitUrl = `https://github.com/${repo}/commit/${currentRun.head_sha}`;
-            const actor = currentRun.actor?.login || 'unknown';
-            const trigger = currentRun.event === 'schedule' ? 'scheduled' : currentRun.event;
+            const previousRun = previousRuns[0];
+            const currentFailed = currentResult !== 'success';
+            const previousFailed = previousRun.conclusion !== 'success';
 
-            blocks = [
-              {
-                type: 'section',
-                text: {
-                  type: 'mrkdwn',
-                  text: `:red_circle: *<https://github.com/${repo}|${repo}>* / *${workflowName}* build failed`
-                }
-              },
-              {
-                type: 'section',
-                text: {
-                  type: 'mrkdwn',
-                  text: `*Failed:*\n${failureLines.join('\n')}`
-                }
-              },
-              {
-                type: 'context',
-                elements: [
-                  {
-                    type: 'mrkdwn',
-                    text: `${trigger} \u2022 <${commitUrl}|\`${commitSha}\`> ${commitMsg} \u2022 ${actor}`
-                  }
-                ]
-              },
-              {
-                type: 'actions',
-                elements: [
-                  {
-                    type: 'button',
-                    text: { type: 'plain_text', text: 'View Run' },
-                    url: runUrl
-                  }
-                ]
-              }
-            ];
-          } else {
-            // === Build recovered ===
-
-            // Count consecutive failures before this recovery
-            let failedCount = 0;
-            let firstFailureRun = null;
-            for (const run of previousRuns) {
-              if (run.conclusion !== 'success') {
-                failedCount++;
-                firstFailureRun = run;
-              } else {
-                break;
-              }
+            if (currentFailed === previousFailed) {
+              core.info(`No state transition (current: ${currentResult}, previous: ${previousRun.conclusion}), skipping`);
+              return;
             }
 
-            blocks = [
-              {
-                type: 'section',
-                text: {
-                  type: 'mrkdwn',
-                  text: `:large_green_circle: *<https://github.com/${repo}|${repo}>* / *${workflowName}* build recovered`
+            const runUrl = currentRun.html_url;
+            let summary;
+            let blocks;
+
+            if (currentFailed) {
+              // === Build just broke ===
+              summary = `Build failed: ${repo} / ${workflowName}`;
+
+              // Get failed job details from the current run
+              const { data: { jobs } } = await github.rest.actions.listJobsForWorkflowRun({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: context.runId,
+                per_page: 100,
+              });
+
+              const failedJobs = jobs.filter(j => j.conclusion === 'failure');
+
+              let failureLines = [];
+              for (const job of failedJobs) {
+                const failedSteps = (job.steps || []).filter(s => s.conclusion === 'failure');
+                const jobUrl = job.html_url;
+                if (failedSteps.length > 0) {
+                  for (const step of failedSteps) {
+                    failureLines.push(`  <${jobUrl}|${job.name}> \u2014 ${step.name}`);
+                  }
+                } else {
+                  failureLines.push(`  <${jobUrl}|${job.name}>`);
                 }
-              },
-              {
-                type: 'context',
-                elements: [
-                  {
-                    type: 'mrkdwn',
-                    text: `Failed for ${failedCount} consecutive run${failedCount !== 1 ? 's' : ''}` +
-                      (firstFailureRun ? ` since <${firstFailureRun.html_url}|${new Date(firstFailureRun.created_at).toISOString().split('T')[0]}>` : '')
-                  }
-                ]
-              },
-              {
-                type: 'actions',
-                elements: [
-                  {
-                    type: 'button',
-                    text: { type: 'plain_text', text: 'View Run' },
-                    url: runUrl
-                  }
-                ]
               }
-            ];
-          }
 
-          // Send Slack message
-          const response = await fetch(webhookUrl, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ blocks }),
-          });
+              const failureDetail = failureLines.length > 0
+                ? failureLines.join('\n')
+                : '  _No individual job failures identified \u2014 check the run for details_';
 
-          if (!response.ok) {
-            const body = await response.text();
-            core.warning(`Slack notification failed: ${response.status} ${body}`);
-          } else {
-            core.info(`Slack ${currentFailed ? 'failure' : 'recovery'} notification sent`);
+              const commitSha = currentRun.head_sha?.substring(0, 7) || '';
+              const commitMsg = currentRun.head_commit?.message?.split('\n')[0] || '';
+              const commitUrl = `https://github.com/${repo}/commit/${currentRun.head_sha}`;
+              const actor = currentRun.actor?.login || 'unknown';
+              const trigger = currentRun.event === 'schedule' ? 'scheduled' : currentRun.event;
+
+              blocks = [
+                {
+                  type: 'section',
+                  text: {
+                    type: 'mrkdwn',
+                    text: `:red_circle: *<https://github.com/${repo}|${repo}>* / *${workflowName}* build failed`
+                  }
+                },
+                {
+                  type: 'section',
+                  text: {
+                    type: 'mrkdwn',
+                    text: `*Failed:*\n${failureDetail}`
+                  }
+                },
+                {
+                  type: 'context',
+                  elements: [
+                    {
+                      type: 'mrkdwn',
+                      text: `${trigger} \u2022 <${commitUrl}|\`${commitSha}\`> ${commitMsg} \u2022 ${actor}`
+                    }
+                  ]
+                },
+                {
+                  type: 'actions',
+                  elements: [
+                    {
+                      type: 'button',
+                      text: { type: 'plain_text', text: 'View Run' },
+                      url: runUrl
+                    }
+                  ]
+                }
+              ];
+            } else {
+              // === Build recovered ===
+              summary = `Build recovered: ${repo} / ${workflowName}`;
+
+              // Count consecutive failures before this recovery
+              let failedCount = 0;
+              let firstFailureRun = null;
+              for (const run of previousRuns) {
+                if (run.conclusion !== 'success') {
+                  failedCount++;
+                  firstFailureRun = run;
+                } else {
+                  break;
+                }
+              }
+
+              blocks = [
+                {
+                  type: 'section',
+                  text: {
+                    type: 'mrkdwn',
+                    text: `:large_green_circle: *<https://github.com/${repo}|${repo}>* / *${workflowName}* build recovered`
+                  }
+                },
+                {
+                  type: 'context',
+                  elements: [
+                    {
+                      type: 'mrkdwn',
+                      text: `Failed for ${failedCount} consecutive run${failedCount !== 1 ? 's' : ''}` +
+                        (firstFailureRun ? ` since <${firstFailureRun.html_url}|${new Date(firstFailureRun.created_at).toISOString().split('T')[0]}>` : '')
+                    }
+                  ]
+                },
+                {
+                  type: 'actions',
+                  elements: [
+                    {
+                      type: 'button',
+                      text: { type: 'plain_text', text: 'View Run' },
+                      url: runUrl
+                    }
+                  ]
+                }
+              ];
+            }
+
+            // Send Slack message
+            const response = await fetch(webhookUrl, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ text: summary, blocks }),
+            });
+
+            if (!response.ok) {
+              const body = await response.text();
+              core.warning(`Slack notification failed: ${response.status} ${body}`);
+            } else {
+              core.info(`Slack ${currentFailed ? 'failure' : 'recovery'} notification sent`);
+            }
+          } catch (error) {
+            core.warning(`Slack build notification error: ${error.message}`);
           }

--- a/.github/actions/slack-build-notify/action.yml
+++ b/.github/actions/slack-build-notify/action.yml
@@ -97,11 +97,12 @@ runs:
                 per_page: 100,
               });
 
-              const failedJobs = jobs.filter(j => j.conclusion === 'failure');
+              const badConclusions = new Set(['failure', 'timed_out', 'action_required']);
+              const failedJobs = jobs.filter(j => badConclusions.has(j.conclusion));
 
               let failureLines = [];
               for (const job of failedJobs) {
-                const failedSteps = (job.steps || []).filter(s => s.conclusion === 'failure');
+                const failedSteps = (job.steps || []).filter(s => badConclusions.has(s.conclusion));
                 const jobUrl = job.html_url;
                 if (failedSteps.length > 0) {
                   for (const step of failedSteps) {


### PR DESCRIPTION
## Summary

Adds a reusable composite action at `.github/actions/slack-build-notify/` that sends Slack notifications on build state transitions on `main`:

- **Failure**: notifies when a previously-passing workflow starts failing, with failed job/step details and links
- **Recovery**: notifies when a previously-failing workflow recovers, with consecutive failure count

Designed for use in the CI meta-job across product image repos (`images-connect`, `images-package-manager`, `images-workbench`).

### Design decisions

- Uses `actions/github-script` for pre-authenticated GitHub API access
- Compares the previous run's CI job conclusion (not workflow conclusion) to avoid false notifications from clean-job flaps
- Graceful failure: try/catch + `continue-on-error` in callers so notification issues never block CI
- Restricted to `posit-dev/` repos via `github.repository_owner` guard
- Slack Block Kit messages with `text` fallback for notification previews

### Required setup

Each product repo needs a `SLACK_WEBHOOK_URL` repository secret pointing at the `#platform-builds-images` channel webhook.

## Test plan

- [x] Add `SLACK_WEBHOOK_URL` secret to a test repo
- [ ] Trigger a failure on `main` and verify Slack message appears
- [ ] Trigger a recovery and verify consecutive failure count is correct
- [ ] Verify no notification fires when state doesn't change
- [ ] Verify no notification fires on PR branches