### PR TITLE
Add Pulumi program for GitHub App management

### DIFF
--- a/pulumi/github/github-apps/.gitignore
+++ b/pulumi/github/github-apps/.gitignore
@@ -1,0 +1,4 @@
+*.pyc
+__pycache__/
+.venv/
+uv.lock

--- a/pulumi/github/github-apps/Pulumi.posit-dev.yaml
+++ b/pulumi/github/github-apps/Pulumi.posit-dev.yaml
@@ -1,0 +1,8 @@
+config:
+  github:owner: posit-dev
+  github-apps:installationIds:
+    connect-bot: ""
+    workbench-bot: ""
+    ppm-bot: ""
+    platform-bot: ""
+    posit-docs: ""

--- a/pulumi/github/github-apps/Pulumi.rstudio.yaml
+++ b/pulumi/github/github-apps/Pulumi.rstudio.yaml
@@ -1,0 +1,8 @@
+config:
+  github:owner: rstudio
+  github-apps:installationIds:
+    connect-bot: ""
+    workbench-bot: ""
+    ppm-bot: ""
+    platform-bot: ""
+    posit-docs: ""

--- a/pulumi/github/github-apps/Pulumi.yaml
+++ b/pulumi/github/github-apps/Pulumi.yaml
@@ -1,0 +1,7 @@
+name: platform-github-apps
+runtime:
+  name: python
+  options:
+    toolchain: uv
+    virtualenv: .venv
+description: Manage GitHub App installations and org-level secret sharing for Posit container image repos

--- a/pulumi/github/github-apps/README.md
+++ b/pulumi/github/github-apps/README.md
@@ -1,0 +1,157 @@
+# github-apps
+
+Manages GitHub App installations and org-level secret sharing for the Posit
+container image ecosystem.
+
+## What this manages
+
+- **App installations**: Which repositories each GitHub App can access
+- **Org-level secrets**: Created with `visibility: selected` and shared with
+  the app's repositories
+
+## What this does NOT manage
+
+- **GitHub App creation**: Apps must be created via the GitHub UI or API.
+  Once created, add the `installationId` to the stack config.
+- **Secret values**: Secret values are created as placeholders and must be
+  set out-of-band via `gh secret set` or the GitHub UI. Pulumi ignores
+  changes to secret values after creation.
+
+## Apps
+
+| App | posit-dev repos | rstudio repos |
+|---|---|---|
+| connect-bot | connect, images-connect | helm (app only) |
+| workbench-bot | images-workbench | rstudio-pro, helm (app only) |
+| ppm-bot | images-package-manager | package-manager, helm (app only) |
+| platform-bot | images-shared | helm |
+| posit-docs | connect, troubleshooting, data-sources | docs.rstudio.com, package-manager |
+
+| Line | Meaning |
+|---|---|
+| **Thick** (`==>`) | App installed + secrets shared |
+| **Thin** (`-->`) | App installed only |
+
+### Full Ecosystem
+
+```mermaid
+graph TD
+    CB["**Connect Bot** 🤖"]
+    WB["**Workbench Bot** 🤖"]
+    PB["**PPM Bot** 🤖"]
+    PLB["**Platform Bot** 🤖"]
+
+    CB ==> PCT["posit-dev/<br/>connect"]
+    CB ==> IC["posit-dev/<br/>images-connect"]
+    CB --> HELM["rstudio/helm"]
+
+    WB ==> IW["posit-dev/<br/>images-workbench"]
+    WB ==> RSP["rstudio/<br/>rstudio-pro"]
+    WB --> HELM
+
+    PB ==> IP["posit-dev/<br/>images-package-manager"]
+    PB ==> PPM["rstudio/<br/>package-manager"]
+    PB --> HELM
+
+    PLB ==> IS["posit-dev/<br/>images-shared"]
+    PLB ==> HELM
+
+    PD["**Posit Docs** 🤖"]
+    PD ==> PCT
+    PD ==> TS["posit-dev/<br/>troubleshooting"]
+    PD ==> DS["posit-dev/<br/>data-sources"]
+    PD --> DR["posit-dev/<br/>doc-reviewer"]
+    PD ==> DOCS["rstudio/<br/>docs.rstudio.com"]
+    PD ==> PPM
+```
+
+### Connect Bot
+
+```mermaid
+graph TD
+    BOT["**Connect Bot** 🤖"]
+
+    BOT ==> PCT["posit-dev/connect"]
+    BOT ==> IC["posit-dev/images-connect"]
+    BOT --> HELM["rstudio/helm"]
+```
+
+### Workbench Bot
+
+```mermaid
+graph TD
+    BOT["**Workbench Bot** 🤖"]
+
+    BOT ==> IW["posit-dev/images-workbench"]
+    BOT ==> RSP["rstudio/rstudio-pro"]
+    BOT --> HELM["rstudio/helm"]
+```
+
+### PPM Bot
+
+```mermaid
+graph TD
+    BOT["**PPM Bot** 🤖"]
+
+    BOT ==> IP["posit-dev/images-package-manager"]
+    BOT ==> PPM["rstudio/package-manager"]
+    BOT --> HELM["rstudio/helm"]
+```
+
+### Platform Bot
+
+```mermaid
+graph TD
+    BOT["**Platform Bot** 🤖"]
+
+    BOT ==> IS["posit-dev/images-shared"]
+    BOT ==> HELM["rstudio/helm"]
+```
+
+### Posit Docs
+
+```mermaid
+graph TD
+    BOT["**Posit Docs** 🤖"]
+
+    BOT ==> PCT["posit-dev/connect"]
+    BOT ==> TS["posit-dev/troubleshooting"]
+    BOT ==> DS["posit-dev/data-sources"]
+    BOT --> DR["posit-dev/doc-reviewer"]
+    BOT ==> DOCS["rstudio/docs.rstudio.com"]
+    BOT ==> PPM["rstudio/package-manager"]
+```
+
+## Usage
+
+```bash
+just setup
+just preview posit-dev
+just up posit-dev
+just preview rstudio
+just up rstudio
+```
+
+## Setting secret values
+
+Pulumi creates the org-level secret resources and manages repo sharing.
+Secret *values* are set via `gh secret set` to avoid storing credentials
+in Pulumi state or git history:
+
+```bash
+gh secret set CONNECT_BOT_APP_ID --org posit-dev --body "<app-id>"
+gh secret set CONNECT_BOT_APP_PRIVATE_KEY --org posit-dev < key.pem
+```
+
+The naming convention is `{APP_NAME}_{SECRET_NAME}`, e.g., `CONNECT_BOT_APP_ID`.
+
+Run `pulumi up` first to create the resources, then `gh secret set` to
+populate the values.
+
+## Adding a new app
+
+1. Create the GitHub App in the GitHub UI
+2. Install it on the target org(s)
+3. Add the app config to `Pulumi.{org}.yaml` with the `installationId`
+4. Run `just up {org}`
+5. Set secret values via `gh secret set`

--- a/pulumi/github/github-apps/__main__.py
+++ b/pulumi/github/github-apps/__main__.py
@@ -1,0 +1,4 @@
+from github_apps.deploy import deploy
+
+if __name__ == "__main__":
+    deploy()

--- a/pulumi/github/github-apps/github_apps/apps.py
+++ b/pulumi/github/github-apps/github_apps/apps.py
@@ -1,0 +1,87 @@
+"""GitHub App definitions for the Posit container image ecosystem.
+
+Each app is defined once. Per-org repository lists specify where the app
+is installed and whether secrets are shared. Installation IDs come from
+stack config since they differ per org.
+
+To add a repo:  add it to the appropriate org's repositories or dispatch_only list.
+To add an app:  add a new top-level entry following the existing pattern.
+To add an org:  add a new key under orgs for the relevant apps.
+"""
+
+APPS: dict[str, dict] = {
+    # ------------------------------------------------------------------ #
+    # Product bots — one per product, owns the dispatch chain from
+    # product release through image build to helm chart update.
+    # ------------------------------------------------------------------ #
+    "connect-bot": {
+        "secrets": ["APP_ID", "APP_PRIVATE_KEY"],
+        "orgs": {
+            "posit-dev": {
+                "repositories": ["connect", "images-connect"],
+            },
+            "rstudio": {
+                # No secrets — images-connect uses posit-dev org secrets
+                # with actions/create-github-app-token (owner: rstudio)
+                # to generate a token scoped to rstudio/helm.
+                "dispatch_only": ["helm"],
+            },
+        },
+    },
+    "workbench-bot": {
+        "secrets": ["APP_ID", "APP_PRIVATE_KEY"],
+        "orgs": {
+            "posit-dev": {
+                "repositories": ["images-workbench"],
+            },
+            "rstudio": {
+                "repositories": ["rstudio-pro"],
+                "dispatch_only": ["helm"],
+            },
+        },
+    },
+    "ppm-bot": {
+        "secrets": ["APP_ID", "APP_PRIVATE_KEY"],
+        "orgs": {
+            "posit-dev": {
+                "repositories": ["images-package-manager"],
+            },
+            "rstudio": {
+                "repositories": ["package-manager"],
+                "dispatch_only": ["helm"],
+            },
+        },
+    },
+    # ------------------------------------------------------------------ #
+    # Platform bot — platform team operations (scheduled rebuilds, cache
+    # cleanup). Centralized dispatch is a future option.
+    # ------------------------------------------------------------------ #
+    "platform-bot": {
+        "secrets": ["APP_ID", "APP_PRIVATE_KEY"],
+        "orgs": {
+            "posit-dev": {
+                "repositories": ["images-shared"],
+            },
+            "rstudio": {
+                "repositories": ["helm"],
+            },
+        },
+    },
+    # ------------------------------------------------------------------ #
+    # Posit Docs — runs the doc-reviewer skill on PRs. Secrets use the
+    # POSIT_DOCS_ prefix to match existing org secret names.
+    # ------------------------------------------------------------------ #
+    "posit-docs": {
+        "secret_prefix": "POSIT_DOCS",
+        "secrets": ["APP_ID", "PEM"],
+        "orgs": {
+            "posit-dev": {
+                "repositories": ["connect", "troubleshooting", "data-sources"],
+                "dispatch_only": ["doc-reviewer"],
+            },
+            "rstudio": {
+                "repositories": ["docs.rstudio.com", "package-manager"],
+            },
+        },
+    },
+}

--- a/pulumi/github/github-apps/github_apps/deploy.py
+++ b/pulumi/github/github-apps/github_apps/deploy.py
@@ -1,0 +1,30 @@
+import pulumi
+
+from github_apps.resources import AppConfig, manage_app
+from github_apps.apps import APPS
+
+
+def deploy():
+    github_config = pulumi.Config("github")
+    owner = github_config.require("owner")
+
+    # Installation IDs are the only per-org config. They live in stack
+    # config because they're assigned by GitHub when the app is installed.
+    config = pulumi.Config("github-apps")
+    installation_ids: dict[str, str] = config.get_object("installationIds") or {}
+
+    for app_name, app_def in APPS.items():
+        org_config = app_def.get("orgs", {}).get(owner)
+        if org_config is None:
+            continue
+
+        manage_app(
+            AppConfig(
+                name=app_name,
+                installation_id=installation_ids.get(app_name, ""),
+                secret_prefix=app_def.get("secret_prefix", ""),
+                secrets=app_def.get("secrets", []),
+                repositories=org_config.get("repositories", []),
+                dispatch_only=org_config.get("dispatch_only", []),
+            )
+        )

--- a/pulumi/github/github-apps/github_apps/resources.py
+++ b/pulumi/github/github-apps/github_apps/resources.py
@@ -1,0 +1,88 @@
+from dataclasses import dataclass, field
+
+import pulumi
+from pulumi import ResourceOptions
+from pulumi_github import (
+    AppInstallationRepositories,
+    ActionsOrganizationSecret,
+    ActionsOrganizationSecretRepositories,
+    get_repository,
+)
+
+
+@dataclass
+class AppConfig:
+    """Configuration for a GitHub App and its installations."""
+
+    name: str
+    installation_id: str
+    secret_prefix: str = ""
+    secrets: list[str] = field(default_factory=list)
+    repositories: list[str] = field(default_factory=list)
+    dispatch_only: list[str] = field(default_factory=list)
+
+
+def manage_app(app: AppConfig):
+    """Manage a GitHub App's repository installations and secret sharing.
+
+    For each app:
+    1. Install the app on the specified repositories.
+    2. For each secret the app declares, ensure an org-level secret exists
+       with visibility=selected and share it with the app's repositories.
+    """
+    if not app.installation_id:
+        pulumi.warn(
+            f"Skipping {app.name}: no installationId configured. "
+            f"Create the GitHub App and set the installation ID in the stack config."
+        )
+        return
+
+    # Install the app on all repos (both secret-sharing and dispatch-only).
+    all_repos = app.repositories + app.dispatch_only
+    if not all_repos:
+        pulumi.warn(f"Skipping {app.name}: no repositories or dispatchOnly configured.")
+        return
+
+    AppInstallationRepositories(
+        f"{app.name}-repos",
+        installation_id=app.installation_id,
+        selected_repositories=all_repos,
+    )
+
+    if not app.secrets or not app.repositories:
+        return
+
+    # Resolve repository IDs for secret sharing (excludes dispatch-only repos).
+    repo_ids = []
+    for repo_name in app.repositories:
+        repo = get_repository(name=repo_name)
+        repo_ids.append(repo.repo_id)
+
+    prefix = app.secret_prefix or _secret_prefix(app.name)
+    for secret_name in app.secrets:
+        org_secret_name = f"{prefix}_{secret_name}"
+
+        # Pulumi manages the resource and repo sharing. The actual value
+        # is set out-of-band via gh secret set to avoid storing secrets
+        # in Pulumi state or git history.
+        secret = ActionsOrganizationSecret(
+            f"{app.name}-secret-{secret_name}",
+            secret_name=org_secret_name,
+            visibility="selected",
+            plaintext_value="CHANGE_ME",
+            opts=ResourceOptions(
+                ignore_changes=["plaintext_value", "encrypted_value"],
+            ),
+        )
+
+        ActionsOrganizationSecretRepositories(
+            f"{app.name}-secret-{secret_name}-repos",
+            secret_name=org_secret_name,
+            selected_repository_ids=repo_ids,
+            opts=ResourceOptions(depends_on=[secret]),
+        )
+
+
+def _secret_prefix(app_name: str) -> str:
+    """Convert an app name like 'connect-bot' to 'CONNECT_BOT'."""
+    return app_name.upper().replace("-", "_")

--- a/pulumi/github/github-apps/justfile
+++ b/pulumi/github/github-apps/justfile
@@ -1,0 +1,19 @@
+#!/usr/bin/env just --justfile
+
+setup:
+  uv sync
+
+_set-stack org:
+  pulumi stack select platform-github-apps/{{org}} 2>/dev/null || pulumi stack init platform-github-apps/{{org}}
+
+preview org:
+  just _set-stack {{org}}
+  uv run pulumi preview --diff
+
+up org:
+  just _set-stack {{org}}
+  uv run pulumi up
+
+destroy org:
+  just _set-stack {{org}}
+  uv run pulumi destroy

--- a/pulumi/github/github-apps/pyproject.toml
+++ b/pulumi/github/github-apps/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "github-apps"
+version = "0.1.0"
+description = "Manage GitHub App installations and org-level secret sharing."
+requires-python = ">=3.10,<4"
+dependencies = [
+    "pulumi>=3.64.0,<4",
+    "pulumi-github>=6.0.0,<7",
+]
+
+[tool.hatch.build.targets.sdist]
+include = ["github_apps"]
+
+[tool.hatch.build.targets.wheel]
+include = ["github_apps"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"


### PR DESCRIPTION
## Summary

- Pulumi program to manage GitHub App installations and org-level secret sharing
- Each bot defined once in `apps.py` with per-org repository lists
- Stack config holds only `github:owner` and `installationIds`
- Bots: connect-bot, workbench-bot, ppm-bot, platform-bot, posit-docs

## Test plan

- [ ] `pulumi preview posit-dev` succeeds
- [ ] `pulumi preview rstudio` succeeds