### PR TITLE
Scope clean workflows to match build version filters

### DIFF
--- a/.github/workflows/bakery-build.yml
+++ b/.github/workflows/bakery-build.yml
@@ -160,7 +160,6 @@ jobs:
       - name: Build
         env:
           GIT_SHA: ${{ github.sha }}
-        # FIXME: Currently pushes to ghcr.io for caching. Needs to be conditional
         run: |
           bakery build --load --pull \
             --retry ${{ inputs.retry }} \

--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -42,6 +42,16 @@ on:
         default: 3
         required: false
         type: number
+      dev-versions:
+        description: "Dev version builds [default: exclude] [options: include, exclude, only]"
+        default: "exclude"
+        required: false
+        type: string
+      matrix-versions:
+        description: "Matrix version builds [default: exclude] [options: include, exclude, only]"
+        default: "exclude"
+        required: false
+        type: string
       dry-run:
         description: "Perform a dry run without deleting any caches [default: false]"
         default: false
@@ -83,7 +93,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           bakery clean cache-registry "ghcr.io/${{ github.repository_owner }}" \
-            --context ${{ inputs.context }} \
+            --context "${{ inputs.context }}" \
+            --dev-versions "${{ inputs['dev-versions'] }}" \
+            --matrix-versions "${{ inputs['matrix-versions'] }}" \
             ${{ inputs.dry-run && '--dry-run' || '' }} \
             ${{ !inputs.remove-dangling-caches && '--no-untagged' || '--untagged' }} \
             ${{ inputs.remove-caches-older-than > 0 && format('--older-than {0}', inputs.remove-caches-older-than) || '' }}
@@ -114,7 +126,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           bakery clean temp-registry "ghcr.io/${{ github.repository_owner }}" \
-            --context ${{ inputs.context }} \
+            --context "${{ inputs.context }}" \
+            --dev-versions "${{ inputs['dev-versions'] }}" \
+            --matrix-versions "${{ inputs['matrix-versions'] }}" \
             ${{ inputs.dry-run && '--dry-run' || '' }} \
             ${{ !inputs.remove-dangling-temporary-images && '--no-untagged' || '--untagged' }} \
             ${{ inputs.remove-temporary-images-older-than > 0 && format('--older-than {0}', inputs.remove-temporary-images-older-than) || '' }}

--- a/posit-bakery/posit_bakery/cli/clean.py
+++ b/posit-bakery/posit_bakery/cli/clean.py
@@ -9,6 +9,7 @@ import typer
 from posit_bakery.cli.common import with_verbosity_flags
 from posit_bakery.config import BakeryConfig
 from posit_bakery.config.config import BakerySettings, BakeryConfigFilter
+from posit_bakery.const import DevVersionInclusionEnum, MatrixVersionInclusionEnum
 from posit_bakery.util import auto_path
 
 app = typer.Typer()
@@ -57,6 +58,20 @@ def cache_registry(
             rich_help_panel=RichHelpPanelEnum.FILTERS,
         ),
     ] = None,
+    dev_versions: Annotated[
+        Optional[DevVersionInclusionEnum],
+        typer.Option(
+            help="Include or exclude development version caches.",
+            rich_help_panel=RichHelpPanelEnum.FILTERS,
+        ),
+    ] = DevVersionInclusionEnum.EXCLUDE,
+    matrix_versions: Annotated[
+        Optional[MatrixVersionInclusionEnum],
+        typer.Option(
+            help="Include or exclude matrix version caches.",
+            rich_help_panel=RichHelpPanelEnum.FILTERS,
+        ),
+    ] = MatrixVersionInclusionEnum.EXCLUDE,
     dry_run: Annotated[
         Optional[bool], typer.Option("--dry-run", help="If set, print what would be deleted and exit.")
     ] = False,
@@ -72,7 +87,12 @@ def cache_registry(
     created by Bakery in the registry namespace `<registry>/<image-name>/cache`. If the `--image-name` filter is not
     provided, all image caches for the project will be cleaned.
     """
-    settings = BakerySettings(filter=BakeryConfigFilter(image_name=image_name), cache_registry=registry)
+    settings = BakerySettings(
+        filter=BakeryConfigFilter(image_name=image_name),
+        cache_registry=registry,
+        dev_versions=dev_versions,
+        matrix_versions=matrix_versions,
+    )
     config: BakeryConfig = BakeryConfig.from_context(context, settings)
 
     log.info(f"Cleaning cache registries in {registry}")
@@ -124,6 +144,20 @@ def temp_registry(
             rich_help_panel=RichHelpPanelEnum.FILTERS,
         ),
     ] = None,
+    dev_versions: Annotated[
+        Optional[DevVersionInclusionEnum],
+        typer.Option(
+            help="Include or exclude development version temporary images.",
+            rich_help_panel=RichHelpPanelEnum.FILTERS,
+        ),
+    ] = DevVersionInclusionEnum.EXCLUDE,
+    matrix_versions: Annotated[
+        Optional[MatrixVersionInclusionEnum],
+        typer.Option(
+            help="Include or exclude matrix version temporary images.",
+            rich_help_panel=RichHelpPanelEnum.FILTERS,
+        ),
+    ] = MatrixVersionInclusionEnum.EXCLUDE,
     dry_run: Annotated[
         Optional[bool], typer.Option("--dry-run", help="If set, print what would be deleted and exit.")
     ] = False,
@@ -138,7 +172,12 @@ def temp_registry(
     Images are assumed to be created by Bakery in the registry namespace `<registry>/<image-name>/tmp`. If the
     `--image-name` filter is not provided, all images for the project will be cleaned.
     """
-    settings = BakerySettings(filter=BakeryConfigFilter(image_name=image_name), temp_registry=registry)
+    settings = BakerySettings(
+        filter=BakeryConfigFilter(image_name=image_name),
+        temp_registry=registry,
+        dev_versions=dev_versions,
+        matrix_versions=matrix_versions,
+    )
     config: BakeryConfig = BakeryConfig.from_context(context, settings)
 
     log.info(f"Cleaning temporary registries in {registry}")

--- a/posit-bakery/test/cli/test_clean.py
+++ b/posit-bakery/test/cli/test_clean.py
@@ -1,0 +1,198 @@
+"""Tests for the bakery clean CLI commands.
+
+Verifies that --dev-versions and --matrix-versions flags are accepted
+and correctly passed through to BakerySettings for both cache-registry
+and temp-registry subcommands.
+
+Tests cover the three flag combinations used by actual workflows:
+  - exclude/exclude (production)
+  - only/exclude (development)
+  - exclude/only (content, session)
+
+The "include" value is only spot-checked to verify the flag is accepted.
+Full combinatorial coverage of "include" is omitted because no workflow
+builds all version categories at once, so no clean job should either.
+Each clean job should match exactly what its sibling build job produces.
+"""
+
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from posit_bakery.cli.main import app
+from posit_bakery.const import DevVersionInclusionEnum, MatrixVersionInclusionEnum
+
+runner = CliRunner()
+
+BASIC_CONTEXT = str(Path(__file__).parent.parent / "resources" / "basic")
+
+
+@pytest.fixture
+def mock_config():
+    """Mock BakeryConfig to capture settings without making API calls."""
+    with patch("posit_bakery.cli.clean.BakeryConfig") as mock:
+        instance = MagicMock()
+        instance.clean_caches.return_value = []
+        instance.clean_temporary.return_value = []
+        mock.from_context.return_value = instance
+        yield mock
+
+
+class TestCacheRegistry:
+    def test_defaults(self, mock_config):
+        result = runner.invoke(
+            app,
+            ["clean", "cache-registry", "ghcr.io/test", "--context", BASIC_CONTEXT],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        settings = mock_config.from_context.call_args[1].get("settings", mock_config.from_context.call_args[0][1])
+        assert settings.dev_versions == DevVersionInclusionEnum.EXCLUDE
+        assert settings.matrix_versions == MatrixVersionInclusionEnum.EXCLUDE
+
+    def test_dev_versions_only(self, mock_config):
+        result = runner.invoke(
+            app,
+            [
+                "clean",
+                "cache-registry",
+                "ghcr.io/test",
+                "--context",
+                BASIC_CONTEXT,
+                "--dev-versions",
+                "only",
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        settings = mock_config.from_context.call_args[1].get("settings", mock_config.from_context.call_args[0][1])
+        assert settings.dev_versions == DevVersionInclusionEnum.ONLY
+
+    def test_matrix_versions_only(self, mock_config):
+        result = runner.invoke(
+            app,
+            [
+                "clean",
+                "cache-registry",
+                "ghcr.io/test",
+                "--context",
+                BASIC_CONTEXT,
+                "--matrix-versions",
+                "only",
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        settings = mock_config.from_context.call_args[1].get("settings", mock_config.from_context.call_args[0][1])
+        assert settings.matrix_versions == MatrixVersionInclusionEnum.ONLY
+
+    def test_dev_and_matrix_combined(self, mock_config):
+        result = runner.invoke(
+            app,
+            [
+                "clean",
+                "cache-registry",
+                "ghcr.io/test",
+                "--context",
+                BASIC_CONTEXT,
+                "--dev-versions",
+                "only",
+                "--matrix-versions",
+                "only",
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        settings = mock_config.from_context.call_args[1].get("settings", mock_config.from_context.call_args[0][1])
+        assert settings.dev_versions == DevVersionInclusionEnum.ONLY
+        assert settings.matrix_versions == MatrixVersionInclusionEnum.ONLY
+
+    def test_dev_versions_include(self, mock_config):
+        result = runner.invoke(
+            app,
+            [
+                "clean",
+                "cache-registry",
+                "ghcr.io/test",
+                "--context",
+                BASIC_CONTEXT,
+                "--dev-versions",
+                "include",
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        settings = mock_config.from_context.call_args[1].get("settings", mock_config.from_context.call_args[0][1])
+        assert settings.dev_versions == DevVersionInclusionEnum.INCLUDE
+
+
+class TestTempRegistry:
+    def test_defaults(self, mock_config):
+        result = runner.invoke(
+            app,
+            ["clean", "temp-registry", "ghcr.io/test", "--context", BASIC_CONTEXT],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        settings = mock_config.from_context.call_args[1].get("settings", mock_config.from_context.call_args[0][1])
+        assert settings.dev_versions == DevVersionInclusionEnum.EXCLUDE
+        assert settings.matrix_versions == MatrixVersionInclusionEnum.EXCLUDE
+
+    def test_dev_versions_only(self, mock_config):
+        result = runner.invoke(
+            app,
+            [
+                "clean",
+                "temp-registry",
+                "ghcr.io/test",
+                "--context",
+                BASIC_CONTEXT,
+                "--dev-versions",
+                "only",
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        settings = mock_config.from_context.call_args[1].get("settings", mock_config.from_context.call_args[0][1])
+        assert settings.dev_versions == DevVersionInclusionEnum.ONLY
+
+    def test_matrix_versions_only(self, mock_config):
+        result = runner.invoke(
+            app,
+            [
+                "clean",
+                "temp-registry",
+                "ghcr.io/test",
+                "--context",
+                BASIC_CONTEXT,
+                "--matrix-versions",
+                "only",
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        settings = mock_config.from_context.call_args[1].get("settings", mock_config.from_context.call_args[0][1])
+        assert settings.matrix_versions == MatrixVersionInclusionEnum.ONLY
+
+    def test_dev_and_matrix_combined(self, mock_config):
+        result = runner.invoke(
+            app,
+            [
+                "clean",
+                "temp-registry",
+                "ghcr.io/test",
+                "--context",
+                BASIC_CONTEXT,
+                "--dev-versions",
+                "only",
+                "--matrix-versions",
+                "only",
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        settings = mock_config.from_context.call_args[1].get("settings", mock_config.from_context.call_args[0][1])
+        assert settings.dev_versions == DevVersionInclusionEnum.ONLY
+        assert settings.matrix_versions == MatrixVersionInclusionEnum.ONLY


### PR DESCRIPTION
## Summary

- Add `--dev-versions` and `--matrix-versions` flags to `bakery clean cache-registry` and `bakery clean temp-registry`
- Pass them through as inputs on `clean.yml`
- Remove stale FIXME in `bakery-build.yml` (QEMU workflow only used for CI self-tests)

Previously, clean jobs only loaded production image targets (the default), so dev and matrix version caches accumulated forever. Sibling PRs in each image repo pass the matching flags.

## Test plan

- [x] 886 config tests pass
- [ ] `bakery clean cache-registry --help` shows `--dev-versions` and `--matrix-versions`
- [ ] `bakery clean temp-registry --help` shows `--dev-versions` and `--matrix-versions`