### PR TITLE
Add checksum verification to composite actions

### DIFF
--- a/setup-goss/action.yml
+++ b/setup-goss/action.yml
@@ -25,18 +25,28 @@ runs:
         if [ -z "$arch" ]; then
           arch=$(uname -m)
         fi
-        
+
         # Map architecture names to goss naming conventions
         if [ "$arch" = "x86_64" ]; then
             arch="amd64"
         elif [ "$arch" = "aarch64" ]; then
             arch="arm64"
         fi
-        
-        curl -fsSL https://github.com/goss-org/goss/releases/${{ inputs.version }}/download/goss-linux-${arch} -o tools/goss
+
+        release_url="https://github.com/goss-org/goss/releases/${{ inputs.version }}/download"
+        binary="goss-linux-${arch}"
+
+        curl -fsSL "${release_url}/${binary}" -o "tools/${binary}"
+        curl -fsSL "${release_url}/${binary}.sha256" -o "tools/${binary}.sha256"
+        (cd tools && sha256sum -c "${binary}.sha256")
+        mv "tools/${binary}" tools/goss
         chmod +rx tools/goss
     - name: Install dgoss
       shell: bash
       run: |
-        curl -fsSL https://github.com/goss-org/goss/releases/${{ inputs.version }}/download/dgoss -o tools/dgoss
+        release_url="https://github.com/goss-org/goss/releases/${{ inputs.version }}/download"
+
+        curl -fsSL "${release_url}/dgoss" -o tools/dgoss
+        curl -fsSL "${release_url}/dgoss.sha256" -o tools/dgoss.sha256
+        (cd tools && sha256sum -c dgoss.sha256)
         chmod +rx tools/dgoss

--- a/setup-goss/action.yml
+++ b/setup-goss/action.yml
@@ -38,19 +38,9 @@ runs:
 
         curl -fsSL "${release_url}/${binary}" -o "tools/${binary}"
 
-        # Verify checksum when available, warn on 404, fail on other errors
-        http_code=$(curl -sSL -o "tools/${binary}.sha256" -w '%{http_code}' "${release_url}/${binary}.sha256") || true
-        if [ "$http_code" = "200" ]; then
-            (cd tools && sha256sum -c "${binary}.sha256")
-            rm -f "tools/${binary}.sha256"
-        elif [ "$http_code" = "404" ]; then
-            echo "::warning::No .sha256 checksum file available for ${binary}; skipping verification"
-            rm -f "tools/${binary}.sha256"
-        else
-            echo "::error::Failed to download checksum for ${binary} (HTTP ${http_code})"
-            rm -f "tools/${binary}.sha256"
-            exit 1
-        fi
+        curl -fsSL "${release_url}/${binary}.sha256" -o "tools/${binary}.sha256"
+        (cd tools && sha256sum -c "${binary}.sha256")
+        rm -f "tools/${binary}.sha256"
 
         mv "tools/${binary}" tools/goss
         chmod +rx tools/goss
@@ -61,18 +51,8 @@ runs:
 
         curl -fsSL "${release_url}/dgoss" -o tools/dgoss
 
-        # Verify checksum when available, warn on 404, fail on other errors
-        http_code=$(curl -sSL -o "tools/dgoss.sha256" -w '%{http_code}' "${release_url}/dgoss.sha256") || true
-        if [ "$http_code" = "200" ]; then
-            (cd tools && sha256sum -c dgoss.sha256)
-            rm -f tools/dgoss.sha256
-        elif [ "$http_code" = "404" ]; then
-            echo "::warning::No .sha256 checksum file available for dgoss; skipping verification"
-            rm -f tools/dgoss.sha256
-        else
-            echo "::error::Failed to download checksum for dgoss (HTTP ${http_code})"
-            rm -f tools/dgoss.sha256
-            exit 1
-        fi
+        curl -fsSL "${release_url}/dgoss.sha256" -o tools/dgoss.sha256
+        (cd tools && sha256sum -c dgoss.sha256)
+        rm -f tools/dgoss.sha256
 
         chmod +rx tools/dgoss

--- a/setup-goss/action.yml
+++ b/setup-goss/action.yml
@@ -37,8 +37,21 @@ runs:
         binary="goss-linux-${arch}"
 
         curl -fsSL "${release_url}/${binary}" -o "tools/${binary}"
-        curl -fsSL "${release_url}/${binary}.sha256" -o "tools/${binary}.sha256"
-        (cd tools && sha256sum -c "${binary}.sha256")
+
+        # Verify checksum when available, warn on 404, fail on other errors
+        http_code=$(curl -sSL -o "tools/${binary}.sha256" -w '%{http_code}' "${release_url}/${binary}.sha256") || true
+        if [ "$http_code" = "200" ]; then
+            (cd tools && sha256sum -c "${binary}.sha256")
+            rm -f "tools/${binary}.sha256"
+        elif [ "$http_code" = "404" ]; then
+            echo "::warning::No .sha256 checksum file available for ${binary}; skipping verification"
+            rm -f "tools/${binary}.sha256"
+        else
+            echo "::error::Failed to download checksum for ${binary} (HTTP ${http_code})"
+            rm -f "tools/${binary}.sha256"
+            exit 1
+        fi
+
         mv "tools/${binary}" tools/goss
         chmod +rx tools/goss
     - name: Install dgoss
@@ -47,6 +60,19 @@ runs:
         release_url="https://github.com/goss-org/goss/releases/${{ inputs.version }}/download"
 
         curl -fsSL "${release_url}/dgoss" -o tools/dgoss
-        curl -fsSL "${release_url}/dgoss.sha256" -o tools/dgoss.sha256
-        (cd tools && sha256sum -c dgoss.sha256)
+
+        # Verify checksum when available, warn on 404, fail on other errors
+        http_code=$(curl -sSL -o "tools/dgoss.sha256" -w '%{http_code}' "${release_url}/dgoss.sha256") || true
+        if [ "$http_code" = "200" ]; then
+            (cd tools && sha256sum -c dgoss.sha256)
+            rm -f tools/dgoss.sha256
+        elif [ "$http_code" = "404" ]; then
+            echo "::warning::No .sha256 checksum file available for dgoss; skipping verification"
+            rm -f tools/dgoss.sha256
+        else
+            echo "::error::Failed to download checksum for dgoss (HTTP ${http_code})"
+            rm -f tools/dgoss.sha256
+            exit 1
+        fi
+
         chmod +rx tools/dgoss

--- a/setup-hadolint/action.yml
+++ b/setup-hadolint/action.yml
@@ -48,12 +48,20 @@ runs:
         fi
 
         # .sha256 files are not published for all releases (e.g., v2.10.0
-        # and earlier lack them). Verify when available, warn otherwise.
-        if curl -fsSL "${release_url}/${binary}.sha256" -o "${dest}/${binary}.sha256" 2>/dev/null; then
+        # and earlier lack them). Verify when available, warn if absent,
+        # fail on transient errors so we don't silently skip verification.
+        checksum_url="${release_url}/${binary}.sha256"
+        http_code=$(curl -sSL -o "${dest}/${binary}.sha256" -w '%{http_code}' "$checksum_url") || true
+        if [ "$http_code" = "200" ]; then
             (cd "${dest}" && sha256sum -c "${binary}.sha256")
             rm -f "${dest}/${binary}.sha256"
-        else
+        elif [ "$http_code" = "404" ]; then
             echo "::warning::No .sha256 checksum file available for ${binary}; skipping verification"
+            rm -f "${dest}/${binary}.sha256"
+        else
+            echo "::error::Failed to download checksum for ${binary} (HTTP ${http_code})"
+            rm -f "${dest}/${binary}.sha256"
+            exit 1
         fi
 
         mv "${dest}/${binary}" "${dest}/hadolint"

--- a/setup-hadolint/action.yml
+++ b/setup-hadolint/action.yml
@@ -20,7 +20,7 @@ runs:
   steps:
     - name: Make tools directory
       shell: bash
-      run: mkdir -p tools
+      run: mkdir -p "${{ inputs.base_path }}/tools"
     - name: Install hadolint
       shell: bash
       run: |
@@ -38,11 +38,23 @@ runs:
         fi
 
         release_url="https://github.com/hadolint/hadolint/releases/${{ inputs.version }}/download"
-        binary="hadolint-linux-${arch}"
         dest="${{ inputs.base_path }}/tools"
 
-        curl -fsSL "${release_url}/${binary}" -o "${dest}/${binary}"
-        curl -fsSL "${release_url}/${binary}.sha256" -o "${dest}/${binary}.sha256"
-        (cd "${dest}" && sha256sum -c "${binary}.sha256")
+        # v2.13.0+ uses lowercase "linux"; older releases use "Linux"
+        binary="hadolint-linux-${arch}"
+        if ! curl -fsSL "${release_url}/${binary}" -o "${dest}/${binary}" 2>/dev/null; then
+            binary="hadolint-Linux-${arch}"
+            curl -fsSL "${release_url}/${binary}" -o "${dest}/${binary}"
+        fi
+
+        # .sha256 files are not published for all releases (e.g., v2.10.0
+        # and earlier lack them). Verify when available, warn otherwise.
+        if curl -fsSL "${release_url}/${binary}.sha256" -o "${dest}/${binary}.sha256" 2>/dev/null; then
+            (cd "${dest}" && sha256sum -c "${binary}.sha256")
+            rm -f "${dest}/${binary}.sha256"
+        else
+            echo "::warning::No .sha256 checksum file available for ${binary}; skipping verification"
+        fi
+
         mv "${dest}/${binary}" "${dest}/hadolint"
         chmod +rx "${dest}/hadolint"

--- a/setup-hadolint/action.yml
+++ b/setup-hadolint/action.yml
@@ -47,22 +47,9 @@ runs:
             curl -fsSL "${release_url}/${binary}" -o "${dest}/${binary}"
         fi
 
-        # .sha256 files are not published for all releases (e.g., v2.10.0
-        # and earlier lack them). Verify when available, warn if absent,
-        # fail on transient errors so we don't silently skip verification.
-        checksum_url="${release_url}/${binary}.sha256"
-        http_code=$(curl -sSL -o "${dest}/${binary}.sha256" -w '%{http_code}' "$checksum_url") || true
-        if [ "$http_code" = "200" ]; then
-            (cd "${dest}" && sha256sum -c "${binary}.sha256")
-            rm -f "${dest}/${binary}.sha256"
-        elif [ "$http_code" = "404" ]; then
-            echo "::warning::No .sha256 checksum file available for ${binary}; skipping verification"
-            rm -f "${dest}/${binary}.sha256"
-        else
-            echo "::error::Failed to download checksum for ${binary} (HTTP ${http_code})"
-            rm -f "${dest}/${binary}.sha256"
-            exit 1
-        fi
+        curl -fsSL "${release_url}/${binary}.sha256" -o "${dest}/${binary}.sha256"
+        (cd "${dest}" && sha256sum -c "${binary}.sha256")
+        rm -f "${dest}/${binary}.sha256"
 
         mv "${dest}/${binary}" "${dest}/hadolint"
         chmod +rx "${dest}/hadolint"

--- a/setup-hadolint/action.yml
+++ b/setup-hadolint/action.yml
@@ -20,7 +20,7 @@ runs:
   steps:
     - name: Make tools directory
       shell: bash
-      run: mkdir -p "${{ inputs.base_path }}/tools"
+      run: mkdir -p tools
     - name: Install hadolint
       shell: bash
       run: |
@@ -37,5 +37,12 @@ runs:
             arch="arm64"
         fi
 
-        curl -fsSL https://github.com/hadolint/hadolint/releases/${{ inputs.version }}/download/hadolint-linux-${arch} -o ${{ inputs.base_path }}/tools/hadolint
-        chmod +rx ${{ inputs.base_path }}/tools/hadolint
+        release_url="https://github.com/hadolint/hadolint/releases/${{ inputs.version }}/download"
+        binary="hadolint-linux-${arch}"
+        dest="${{ inputs.base_path }}/tools"
+
+        curl -fsSL "${release_url}/${binary}" -o "${dest}/${binary}"
+        curl -fsSL "${release_url}/${binary}.sha256" -o "${dest}/${binary}.sha256"
+        (cd "${dest}" && sha256sum -c "${binary}.sha256")
+        mv "${dest}/${binary}" "${dest}/hadolint"
+        chmod +rx "${dest}/hadolint"


### PR DESCRIPTION
## Summary

- Add SHA256 checksum verification to `setup-goss` for both `goss` and `dgoss` binary downloads
- Add SHA256 checksum verification to `setup-hadolint` with fallback handling: verifies when checksums are available (v2.13.0+)

Addresses binary integrity gaps identified in rstudio/platform-team#435.

## Test plan

- [x] CI passes (`ci.yml` uses `./setup-goss` and `./setup-hadolint`)
- [x] Verify checksum verification works for current goss/hadolint releases