### PR TITLE
Use directory globs in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,10 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/*"
+      - "/setup-*"
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
## Summary

Switch Dependabot from `directory` (singular) to `directories` with globs so it auto-discovers composite actions under `.github/actions/`.

## Test plan

- [ ] Dependabot opens grouped update PRs covering both workflows and composite actions