### PR TITLE
Remove bakery-pr job from ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,11 @@ jobs:
       - test
       - bakery
       - bakery-native
-      - bakery-pr
       - release
 
     steps:
       - uses: re-actors/alls-green@release/v1
         with:
-          allowed-skips: bakery-pr
           jobs: ${{ toJSON(needs) }}
 
   test:
@@ -143,20 +141,6 @@ jobs:
       context: "./posit-bakery/test/resources/multiplatform/"
       dev-versions: include
 
-  bakery-pr:
-    name: Bakery PR Build
-    if: github.event_name == 'pull_request'
-    permissions:
-      contents: read
-      packages: write
-
-    uses: "./.github/workflows/bakery-build-pr.yml"
-    with:
-      # Don't pass version — default "main" is correct here. The head_ref
-      # pattern used by other jobs breaks on fork PRs because the fork's
-      # branch doesn't exist in posit-dev/images-shared.
-      context: "./posit-bakery/test/resources/multiplatform/"
-      dev-versions: include
 
   with-macros-clean-caches:
     name: Clean Caches (with-macros suite)


### PR DESCRIPTION
## Summary

Remove the `bakery-pr` CI job that was added in #442. GitHub cannot resolve relative reusable workflow refs (`"./.github/workflows/bakery-build-pr.yml"`) during `pull_request` validation for recently added files, causing `startup_failure` on every PR to the repo.

The `bakery-build-pr.yml` workflow file remains — it will be called by product repos via the full repo path (`posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main`) in the product repo rollout PRs (6-9 in rstudio/platform-team#435).

## Test plan

- [x] CI passes on this PR (no more startup_failure)
- [x] Other PRs (#443) pass CI after rebasing on this