### PR TITLE
Re-add bakery-pr CI job using full repo path

### DIFF
--- a/.github/workflows/bakery-build-pr.yml
+++ b/.github/workflows/bakery-build-pr.yml
@@ -73,6 +73,7 @@ jobs:
 
   matrix:
     name: Image Matrix
+    needs: detect
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -93,11 +94,17 @@ jobs:
       - name: Images by Version/Platform
         id: images-by-platform
         env:
+          IS_FORK: ${{ needs.detect.outputs.is-fork }}
           DEV_VERSIONS: ${{ inputs.dev-versions }}
           MATRIX_VERSIONS: ${{ inputs.matrix-versions }}
           BAKERY_CONTEXT: ${{ inputs.context }}
         run: |
-          echo "platform_matrix=$(bakery ci matrix --quiet --dev-versions "$DEV_VERSIONS" --matrix-versions "$MATRIX_VERSIONS" --context "$BAKERY_CONTEXT" | jq --compact-output .)" >> "$GITHUB_OUTPUT"
+          FULL_MATRIX=$(bakery ci matrix --quiet --dev-versions "$DEV_VERSIONS" --matrix-versions "$MATRIX_VERSIONS" --context "$BAKERY_CONTEXT" | jq --compact-output .)
+          if [ "$IS_FORK" = "true" ]; then
+            # Skip arm64 for fork PRs — paid runners may not be available
+            FULL_MATRIX=$(echo "$FULL_MATRIX" | jq --compact-output '[.[] | select(.platform != "linux/arm64")]')
+          fi
+          echo "platform_matrix=$FULL_MATRIX" >> "$GITHUB_OUTPUT"
 
       - name: Images by Version
         id: images-by-version
@@ -122,8 +129,6 @@ jobs:
       matrix:
         img: ${{ fromJson(needs.matrix.outputs.platform-matrix) }}
     runs-on: ${{ matrix.img.platform == 'linux/arm64' && inputs.arm64-builder || inputs.amd64-builder }}
-    # Skip arm64 for fork PRs — paid runners may not be available
-    if: needs.detect.outputs.is-fork != 'true' || matrix.img.platform != 'linux/arm64'
 
     steps:
       - name: Checkout

--- a/.github/workflows/bakery-build-pr.yml
+++ b/.github/workflows/bakery-build-pr.yml
@@ -60,6 +60,7 @@ jobs:
   detect:
     name: Detect Fork
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions: {}
     outputs:
       is-fork: ${{ steps.check.outputs.is-fork }}
@@ -73,6 +74,7 @@ jobs:
   matrix:
     name: Image Matrix
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     outputs:
@@ -81,7 +83,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install
         uses: "posit-dev/images-shared/setup-bakery@main"
@@ -111,6 +113,7 @@ jobs:
     needs:
       - detect
       - matrix
+    timeout-minutes: 120
     permissions:
       contents: read
       packages: write
@@ -124,7 +127,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup bakery
         uses: "posit-dev/images-shared/setup-bakery@main"
@@ -135,7 +138,7 @@ jobs:
         uses: "posit-dev/images-shared/setup-goss@main"
 
       - name: Set up Docker
-        uses: docker/setup-docker-action@v5
+        uses: docker/setup-docker-action@1a6edb0ba9ac496f6850236981f15d8f9a82254d  # v5.0.0
         with:
           daemon-config: |
             {
@@ -145,14 +148,14 @@ jobs:
             }
 
       - name: Setup docker buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
 
       - name: Setup ORAS CLI
-        uses: oras-project/setup-oras@v1
+        uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3  # v2.0.0
 
       - name: Login to GitHub Container Registry
         if: needs.detect.outputs.is-fork != 'true'
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
+    uses: "./.github/workflows/bakery-build-pr.yml"
     with:
       context: "./posit-bakery/test/resources/multiplatform/"
       dev-versions: include

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,12 +28,14 @@ jobs:
       - test
       - bakery
       - bakery-native
+      - bakery-pr
       - release
       - zizmor
 
     steps:
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe  # v1.2.2
         with:
+          allowed-skips: bakery-pr
           jobs: ${{ toJSON(needs) }}
 
   test:
@@ -143,6 +145,17 @@ jobs:
       context: "./posit-bakery/test/resources/multiplatform/"
       dev-versions: include
 
+
+  bakery-pr:
+    name: Bakery PR Build
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      packages: write
+    uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
+    with:
+      context: "./posit-bakery/test/resources/multiplatform/"
+      dev-versions: include
 
   zizmor:
     name: Zizmor


### PR DESCRIPTION
## Summary

Re-add the `bakery-pr` test job to `ci.yml` using the full repo path (`posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main`) instead of a relative path. The relative path caused `startup_failure` on PRs because GitHub couldn't resolve recently-added workflow files.

Depends on #449.

## Test plan

- [x] CI passes (no startup_failure)
- [x] `bakery-pr` job runs on pull_request events
- [x] `bakery-pr` job skips on push/tag events (allowed-skips)