### PR TITLE
Add Workbench preview release stream

### DIFF
--- a/posit-bakery/posit_bakery/config/image/posit_product/const.py
+++ b/posit-bakery/posit_bakery/config/image/posit_product/const.py
@@ -27,6 +27,7 @@ URL_WITH_ENV_VARS_REGEX_PATTERN = re.compile(
 )
 
 WORKBENCH_DAILY_URL = "https://dailies.rstudio.com/rstudio/latest/index.json"
+WORKBENCH_PREVIEW_URL = "https://dailies.rstudio.com/rstudio/{channel}/index.json"
 PACKAGE_MANAGER_DAILY_URL = "https://cdn.posit.co/package-manager/deb/amd64/rstudio-pm-main-latest.txt"
 PACKAGE_MANAGER_PREVIEW_URL = "https://cdn.posit.co/package-manager/deb/amd64/rstudio-pm-rc-latest.txt"
 CONNECT_DAILY_URL = "https://cdn.posit.co/connect/latest-packages.json"
@@ -51,8 +52,7 @@ PRODUCT_RELEASE_STREAM_SUPPORT_MAP = {
     ProductEnum.PACKAGE_MANAGER: [ReleaseStreamEnum.RELEASE, ReleaseStreamEnum.PREVIEW, ReleaseStreamEnum.DAILY],
     ProductEnum.WORKBENCH: [
         ReleaseStreamEnum.RELEASE,
-        # FIXME: This stream seems out of date
-        # ReleaseStreamEnum.PREVIEW,
+        ReleaseStreamEnum.PREVIEW,
         ReleaseStreamEnum.DAILY,
     ],
 }

--- a/posit-bakery/posit_bakery/config/image/posit_product/main.py
+++ b/posit-bakery/posit_bakery/config/image/posit_product/main.py
@@ -12,6 +12,7 @@ from posit_bakery.config.image.posit_product.const import (
     ProductEnum,
     ReleaseStreamEnum,
     WORKBENCH_DAILY_URL,
+    WORKBENCH_PREVIEW_URL,
     PACKAGE_MANAGER_DAILY_URL,
     PACKAGE_MANAGER_PREVIEW_URL,
     CONNECT_DAILY_URL,
@@ -154,18 +155,17 @@ product_release_stream_url_map = {
                 ),
             },
         ),
-        # FIXME: This stream seems out of date
-        # ReleaseStreamEnum.PREVIEW: ReleaseStreamPath(
-        #     DOWNLOADS_JSON_URL,
-        #     {
-        #         "version": resolvers.StringMapPathResolver(
-        #             ["rstudio", "pro", "preview", "server", "installer", "{download_json_os}", "version"]
-        #         ),
-        #         "download_url": resolvers.StringMapPathResolver(
-        #             ["rstudio", "pro", "preview", "server", "installer", "{download_json_os}", "url"]
-        #         ),
-        #     },
-        # ),
+        ReleaseStreamEnum.PREVIEW: ReleaseStreamPath(
+            WORKBENCH_PREVIEW_URL,
+            {
+                "version": resolvers.StringMapPathResolver(
+                    ["workbench", "platforms", "{download_json_os}-{arch_identifier}", "version"]
+                ),
+                "download_url": resolvers.StringMapPathResolver(
+                    ["workbench", "platforms", "{download_json_os}-{arch_identifier}", "link"]
+                ),
+            },
+        ),
         ReleaseStreamEnum.DAILY: ReleaseStreamPath(
             WORKBENCH_DAILY_URL,
             {
@@ -190,18 +190,17 @@ product_release_stream_url_map = {
                 ),
             },
         ),
-        # FIXME: This stream seems out of date
-        # ReleaseStreamEnum.PREVIEW: ReleaseStreamPath(
-        #     DOWNLOADS_JSON_URL,
-        #     {
-        #         "version": resolvers.StringMapPathResolver(
-        #             ["rstudio", "pro", "preview", "session", "installer", "{download_json_os}", "version"]
-        #         ),
-        #         "download_url": resolvers.StringMapPathResolver(
-        #             ["rstudio", "pro", "preview", "session", "installer", "{download_json_os}", "url"]
-        #         ),
-        #     },
-        # ),
+        ReleaseStreamEnum.PREVIEW: ReleaseStreamPath(
+            WORKBENCH_PREVIEW_URL,
+            {
+                "version": resolvers.StringMapPathResolver(
+                    ["session", "platforms", "{download_json_os}-{arch_identifier}", "version"]
+                ),
+                "download_url": resolvers.StringMapPathResolver(
+                    ["session", "platforms", "{download_json_os}-{arch_identifier}", "link"]
+                ),
+            },
+        ),
         ReleaseStreamEnum.DAILY: ReleaseStreamPath(
             WORKBENCH_DAILY_URL,
             {


### PR DESCRIPTION
## Summary

- Add `WORKBENCH_PREVIEW_URL` using the channel-based dailies endpoint (`https://dailies.rstudio.com/rstudio/{channel}/index.json`)
- Wire up `PREVIEW` stream entries for both `workbench` and `workbench-session` products
- The branch-specific JSON uses a flat structure (`workbench.platforms`) vs the `latest` endpoint's wrapped structure (`products.workbench.platforms`), so preview uses separate resolvers

The `{channel}` placeholder is resolved from `devVersion.values.channel` in `bakery.yaml`, overridable at dispatch time via `--dev-channel`.

Closes #237

Depends on: #436 (dev-stream/dev-channel plumbing)

Consumed by: https://github.com/posit-dev/images-workbench/pull/75 (adds preview devVersion to bakery.yaml)

## Test plan

- [ ] `bakery ci matrix --dev-versions only --dev-stream preview --value channel=apple-blossom` resolves workbench preview version
- [ ] Existing daily stream continues to resolve from `latest` endpoint unchanged