### PR TITLE
Fix --template-pattern filter in bakery update files

### DIFF
--- a/posit-bakery/posit_bakery/config/image/matrix.py
+++ b/posit-bakery/posit_bakery/config/image/matrix.py
@@ -452,10 +452,9 @@ class ImageMatrix(BakeryPathMixin, BakeryYAMLModel):
                 tpl_full_path = (Path(root) / file).resolve()
                 tpl_rel_path = str(tpl_full_path.relative_to(self.parent.template_path))
 
-                for regex in regex_filters or []:
-                    if not re.match(regex, tpl_rel_path):
-                        log.debug(f"Skipping template [bright_black]{tpl_rel_path}[/] due to filter [bold]{regex}[/]")
-                        continue
+                if regex_filters and not any(re.match(regex, tpl_rel_path) for regex in regex_filters):
+                    log.debug(f"Skipping template [bright_black]{tpl_rel_path}[/] due to filter patterns")
+                    continue
 
                 # Check if this is a Jinja2 template file
                 is_jinja2_template = any(tpl_rel_path.endswith(ext) for ext in JINJA2_TEMPLATE_EXTENSIONS)

--- a/posit-bakery/posit_bakery/config/image/version.py
+++ b/posit-bakery/posit_bakery/config/image/version.py
@@ -395,10 +395,9 @@ class ImageVersion(BakeryPathMixin, BakeryYAMLModel):
                 tpl_full_path = (Path(root) / file).resolve()
                 tpl_rel_path = str(tpl_full_path.relative_to(self.parent.template_path))
 
-                for regex in regex_filters or []:
-                    if not re.match(regex, tpl_rel_path):
-                        log.debug(f"Skipping template [bright_black]{tpl_rel_path}[/] due to filter [bold]{regex}[/]")
-                        continue
+                if regex_filters and not any(re.match(regex, tpl_rel_path) for regex in regex_filters):
+                    log.debug(f"Skipping template [bright_black]{tpl_rel_path}[/] due to filter patterns")
+                    continue
 
                 # Check if this is a Jinja2 template file
                 is_jinja2_template = any(tpl_rel_path.endswith(ext) for ext in JINJA2_TEMPLATE_EXTENSIONS)

--- a/posit-bakery/test/config/test_config.py
+++ b/posit-bakery/test/config/test_config.py
@@ -1446,6 +1446,10 @@ class TestBakeryConfig:
 
         assert version.path.exists()
         assert_directories_match(version.path / "deps", get_context("basic") / image.name / version.name / "deps")
+        # Non-matching files should not be rendered
+        assert not (version.path / "Containerfile.ubuntu2204.std").exists()
+        assert not (version.path / "Containerfile.ubuntu2204.min").exists()
+        assert not (version.path / "test").exists()
 
     def test_target_generation_matrix(self, get_tmpcontext):
         config = BakeryConfig(


### PR DESCRIPTION
## Summary

- Fix the `--template-pattern` regex filter which had no effect due to a `continue` targeting the inner regex loop instead of the outer file loop
- Replace broken nested loop with `any()` check that correctly skips files not matching any provided pattern
- Add test assertions verifying non-matching files are excluded when a filter is applied

Closes #289

## Test plan

- [x] Existing `test_rerender_files_with_regex` passes with strengthened assertions
- [x] Full config test suite passes (112 tests)
- [x] Manual verification: `bakery update files --template-pattern "Containerfile.*"` renders only Containerfile templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)