### PR TITLE
Add Workbench dailies release branch override

### DIFF
--- a/posit-bakery/docs/configuration.qmd
+++ b/posit-bakery/docs/configuration.qmd
@@ -540,6 +540,24 @@ A GossOption represents options for `dgoss` tests against an image target.
 | `command`<br/>*string*             | The command to run within the `dgoss` container. This can be used to start a service in the container for testing.                                            | `sleep infinity`                                                                                                   | `start-server`   |
 | `wait`<br/>*int*                   | The number of seconds to wait after container startup before running tests. Useful if there is a service that needs to complete its startup prior to testing. | `0`                                                                                                                | `30`             |
 
+## Environment Variables
+
+The following environment variables can be used to configure Bakery behavior at runtime when building a project targeting Workbench Daily builds.
+
+| Variable | Description | Default |
+|---|---|---|
+| `BAKERY_WORKBENCH_RELEASE_BRANCH` | Override the Workbench dailies release branch used when fetching daily build artifacts. Workbench tracks multiple release branches (e.g., `globemaster-allium`, `apple-blossom`) for daily builds. Set this variable to build a daily development version from a previous release's branch instead of the latest. | `latest` |
+
+### Example Usage
+
+```bash
+# Build the latest daily (default behavior)
+bakery build --dev-versions only
+
+# Build a daily from the "globemaster-allium" release branch
+BAKERY_WORKBENCH_RELEASE_BRANCH=globemaster-allium bakery build --dev-versions only
+```
+
 ## See Also
 
 - [Templating Documentation](templating.qmd) — Jinja2 macros and variables available in image templates

--- a/posit-bakery/posit_bakery/config/image/posit_product/const.py
+++ b/posit-bakery/posit_bakery/config/image/posit_product/const.py
@@ -52,10 +52,5 @@ class ReleaseStreamEnum(str, Enum):
 PRODUCT_RELEASE_STREAM_SUPPORT_MAP = {
     ProductEnum.CONNECT: [ReleaseStreamEnum.RELEASE, ReleaseStreamEnum.DAILY],
     ProductEnum.PACKAGE_MANAGER: [ReleaseStreamEnum.RELEASE, ReleaseStreamEnum.PREVIEW, ReleaseStreamEnum.DAILY],
-    ProductEnum.WORKBENCH: [
-        ReleaseStreamEnum.RELEASE,
-        # FIXME: This stream seems out of date
-        # ReleaseStreamEnum.PREVIEW,
-        ReleaseStreamEnum.DAILY,
-    ],
+    ProductEnum.WORKBENCH: [ReleaseStreamEnum.RELEASE, ReleaseStreamEnum.DAILY],
 }

--- a/posit-bakery/posit_bakery/config/image/posit_product/const.py
+++ b/posit-bakery/posit_bakery/config/image/posit_product/const.py
@@ -1,3 +1,4 @@
+import os
 import re
 from enum import Enum
 
@@ -26,7 +27,9 @@ URL_WITH_ENV_VARS_REGEX_PATTERN = re.compile(
     rf"(?:#(?:{_QUERY_FRAGMENT}|{_ENV_VAR})*)?$"
 )
 
-WORKBENCH_DAILY_URL = "https://dailies.rstudio.com/rstudio/latest/index.json"
+WORKBENCH_DAILY_URL = (
+    f"https://dailies.rstudio.com/rstudio/{os.getenv('BAKERY_WORKBENCH_RELEASE_BRANCH', 'latest')}/index.json"
+)
 PACKAGE_MANAGER_DAILY_URL = "https://cdn.posit.co/package-manager/deb/amd64/rstudio-pm-main-latest.txt"
 PACKAGE_MANAGER_PREVIEW_URL = "https://cdn.posit.co/package-manager/deb/amd64/rstudio-pm-rc-latest.txt"
 CONNECT_DAILY_URL = "https://cdn.posit.co/connect/latest-packages.json"

--- a/posit-bakery/posit_bakery/config/image/posit_product/main.py
+++ b/posit-bakery/posit_bakery/config/image/posit_product/main.py
@@ -147,18 +147,6 @@ product_release_stream_url_map = {
                 ),
             },
         ),
-        # FIXME: This stream seems out of date
-        # ReleaseStreamEnum.PREVIEW: ReleaseStreamPath(
-        #     DOWNLOADS_JSON_URL,
-        #     {
-        #         "version": resolvers.StringMapPathResolver(
-        #             ["rstudio", "pro", "preview", "server", "installer", "{download_json_os}", "version"]
-        #         ),
-        #         "download_url": resolvers.StringMapPathResolver(
-        #             ["rstudio", "pro", "preview", "server", "installer", "{download_json_os}", "url"]
-        #         ),
-        #     },
-        # ),
         ReleaseStreamEnum.DAILY: ReleaseStreamPath(
             WORKBENCH_DAILY_URL,
             {
@@ -183,18 +171,6 @@ product_release_stream_url_map = {
                 ),
             },
         ),
-        # FIXME: This stream seems out of date
-        # ReleaseStreamEnum.PREVIEW: ReleaseStreamPath(
-        #     DOWNLOADS_JSON_URL,
-        #     {
-        #         "version": resolvers.StringMapPathResolver(
-        #             ["rstudio", "pro", "preview", "session", "installer", "{download_json_os}", "version"]
-        #         ),
-        #         "download_url": resolvers.StringMapPathResolver(
-        #             ["rstudio", "pro", "preview", "session", "installer", "{download_json_os}", "url"]
-        #         ),
-        #     },
-        # ),
         ReleaseStreamEnum.DAILY: ReleaseStreamPath(
             WORKBENCH_DAILY_URL,
             {

--- a/posit-bakery/test/config/conftest.py
+++ b/posit-bakery/test/config/conftest.py
@@ -82,7 +82,7 @@ def patch_testdata_response(url: str):
     elif url == product_const.PACKAGE_MANAGER_DAILY_URL:
         mock_response.json.side_effect = FakeJSONDecodeError
         mock_response.text = PACKAGE_MANAGER_DAILY.read_text()
-    elif url == product_const.WORKBENCH_DAILY_URL:
+    elif url.startswith("https://dailies.rstudio.com/rstudio/") and url.endswith("/index.json"):
         mock_response.json.return_value = json.loads(WORKBENCH_DAILY.read_text())
     # Default mock response for unknown URLs
     else:

--- a/posit-bakery/test/config/image/posit_products/test_const.py
+++ b/posit-bakery/test/config/image/posit_products/test_const.py
@@ -1,0 +1,43 @@
+import importlib
+
+import pytest
+
+import posit_bakery.config.image.posit_product.const as product_const
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.config,
+    pytest.mark.product_version,
+]
+
+
+class TestWorkbenchDailyUrl:
+    """Test that WORKBENCH_DAILY_URL is constructed from the BAKERY_WORKBENCH_RELEASE_BRANCH env var."""
+
+    def test_default_url(self, monkeypatch):
+        """When BAKERY_WORKBENCH_RELEASE_BRANCH is not set, the URL defaults to 'latest'."""
+        monkeypatch.delenv("BAKERY_WORKBENCH_RELEASE_BRANCH", raising=False)
+        importlib.reload(product_const)
+
+        assert product_const.WORKBENCH_DAILY_URL == "https://dailies.rstudio.com/rstudio/latest/index.json"
+
+    @pytest.mark.parametrize(
+        "branch",
+        [
+            pytest.param("globemaster-allium", id="globemaster-allium"),
+            pytest.param("apple-blossom", id="apple-blossom"),
+        ],
+    )
+    def test_custom_release_branch(self, monkeypatch, branch):
+        """When BAKERY_WORKBENCH_RELEASE_BRANCH is set, the URL uses the branch name."""
+        monkeypatch.setenv("BAKERY_WORKBENCH_RELEASE_BRANCH", branch)
+        importlib.reload(product_const)
+
+        assert product_const.WORKBENCH_DAILY_URL == f"https://dailies.rstudio.com/rstudio/{branch}/index.json"
+
+    def test_empty_string_uses_empty_path(self, monkeypatch):
+        """When BAKERY_WORKBENCH_RELEASE_BRANCH is set to an empty string, the empty value is used."""
+        monkeypatch.setenv("BAKERY_WORKBENCH_RELEASE_BRANCH", "")
+        importlib.reload(product_const)
+
+        assert product_const.WORKBENCH_DAILY_URL == "https://dailies.rstudio.com/rstudio//index.json"


### PR DESCRIPTION
# Summary

- Remove existing commented out references to Workbench preview release stream
- Add `BAKERY_WORKBENCH_RELEASE_BRANCH` environment variable to override the targeted release branch for daily development version builds of Workbench

Closes #237

# Test plan

- [ ] `BAKERY_WORKBENCH_RELEASE_BRANCH="apple-blossom" bakery ci matrix --dev-versions only` resolves workbench dev version builds for the apple-blossom release 
- [ ] Existing daily stream continues to resolve from `latest` endpoint unchanged