### PR TITLE
Add --dev-stream filter option for dev version builds

### DIFF
--- a/posit-bakery/posit_bakery/cli/build.py
+++ b/posit-bakery/posit_bakery/cli/build.py
@@ -10,6 +10,7 @@ import typer
 from posit_bakery.cli.common import with_verbosity_flags, with_temporary_storage
 from posit_bakery.config import BakeryConfig
 from posit_bakery.config.config import BakeryConfigFilter, BakerySettings
+from posit_bakery.config.image.posit_product.const import ReleaseStreamEnum
 from posit_bakery.const import DevVersionInclusionEnum, MatrixVersionInclusionEnum
 from posit_bakery.error import BakeryBuildErrorGroup, BakeryToolRuntimeError
 from posit_bakery.image import ImageBuildStrategy
@@ -179,6 +180,13 @@ def build(
             rich_help_panel=RichHelpPanelEnum.FILTERS,
         ),
     ] = DevVersionInclusionEnum.EXCLUDE,
+    dev_stream: Annotated[
+        Optional[ReleaseStreamEnum],
+        typer.Option(
+            help="Filter development versions to a specific release stream.",
+            rich_help_panel=RichHelpPanelEnum.FILTERS,
+        ),
+    ] = None,
     matrix_versions: Annotated[
         Optional[MatrixVersionInclusionEnum],
         typer.Option(
@@ -205,6 +213,7 @@ def build(
             image_platform=image_platform or [],
         ),
         dev_versions=dev_versions,
+        dev_stream=dev_stream,
         matrix_versions=matrix_versions,
         clean_temporary=clean,
         cache_registry=cache_registry,

--- a/posit-bakery/posit_bakery/cli/ci.py
+++ b/posit-bakery/posit_bakery/cli/ci.py
@@ -11,6 +11,7 @@ import typer
 from posit_bakery.cli.common import with_verbosity_flags
 from posit_bakery.config import BakeryConfig
 from posit_bakery.config.config import BakerySettings, BakeryConfigFilter
+from posit_bakery.config.image.posit_product.const import ReleaseStreamEnum
 from posit_bakery.const import DevVersionInclusionEnum, MatrixVersionInclusionEnum
 from posit_bakery.log import stderr_console, stdout_console
 from posit_bakery.registry_management.dockerhub.readme import push_readmes
@@ -42,6 +43,13 @@ def matrix(
             help="Include or exclude development versions defined in config.", rich_help_panel=RichHelpPanelEnum.FILTERS
         ),
     ] = DevVersionInclusionEnum.EXCLUDE,
+    dev_stream: Annotated[
+        Optional[ReleaseStreamEnum],
+        typer.Option(
+            help="Filter development versions to a specific release stream.",
+            rich_help_panel=RichHelpPanelEnum.FILTERS,
+        ),
+    ] = None,
     matrix_versions: Annotated[
         Optional[MatrixVersionInclusionEnum],
         typer.Option(
@@ -88,6 +96,7 @@ def matrix(
         settings = BakerySettings(
             filter=BakeryConfigFilter(image_name=image_name),
             dev_versions=dev_versions,
+            dev_stream=dev_stream,
         )
         c = BakeryConfig.from_context(context=context, settings=settings)
         images = [i for i in c.model.images]
@@ -145,6 +154,13 @@ def merge(
     dry_run: Annotated[
         bool, typer.Option(help="If set, the merged images will not be pushed to the registry.")
     ] = False,
+    dev_stream: Annotated[
+        Optional[ReleaseStreamEnum],
+        typer.Option(
+            help="Filter development versions to a specific release stream.",
+            rich_help_panel="Build Configuration & Outputs",
+        ),
+    ] = None,
 ):
     """Merges multiple metadata files with single-platform images into a single multi-platform image by UID.
     This command is intended for use in CI workflows that utilize native builders for multiplatform builds.
@@ -164,6 +180,7 @@ def merge(
     """
     settings = BakerySettings(
         dev_versions=DevVersionInclusionEnum.INCLUDE,
+        dev_stream=dev_stream,
         matrix_versions=MatrixVersionInclusionEnum.INCLUDE,
         clean_temporary=False,
         temp_registry=temp_registry,
@@ -238,6 +255,13 @@ def readme(
             rich_help_panel=RichHelpPanelEnum.FILTERS,
         ),
     ] = DevVersionInclusionEnum.INCLUDE,
+    dev_stream: Annotated[
+        Optional[ReleaseStreamEnum],
+        typer.Option(
+            help="Filter development versions to a specific release stream.",
+            rich_help_panel=RichHelpPanelEnum.FILTERS,
+        ),
+    ] = None,
     matrix_versions: Annotated[
         Optional[MatrixVersionInclusionEnum],
         typer.Option(
@@ -258,6 +282,7 @@ def readme(
     """
     settings = BakerySettings(
         dev_versions=dev_versions,
+        dev_stream=dev_stream,
         matrix_versions=matrix_versions,
     )
     config: BakeryConfig = BakeryConfig.from_context(context, settings)

--- a/posit-bakery/posit_bakery/cli/ci.py
+++ b/posit-bakery/posit_bakery/cli/ci.py
@@ -118,6 +118,9 @@ def matrix(
                     continue
                 if not ver.isDevelopmentVersion and dev_versions == DevVersionInclusionEnum.ONLY:
                     continue
+                if dev_stream is not None and ver.isDevelopmentVersion:
+                    if ver.metadata.get("release_stream") != dev_stream:
+                        continue
 
                 if BakeryCIMatrixFieldEnum.VERSION not in exclude:
                     entry["version"] = ver.name

--- a/posit-bakery/posit_bakery/cli/clean.py
+++ b/posit-bakery/posit_bakery/cli/clean.py
@@ -9,6 +9,7 @@ import typer
 from posit_bakery.cli.common import with_verbosity_flags
 from posit_bakery.config import BakeryConfig
 from posit_bakery.config.config import BakerySettings, BakeryConfigFilter
+from posit_bakery.config.image.posit_product.const import ReleaseStreamEnum
 from posit_bakery.const import DevVersionInclusionEnum, MatrixVersionInclusionEnum
 from posit_bakery.util import auto_path
 
@@ -65,6 +66,13 @@ def cache_registry(
             rich_help_panel=RichHelpPanelEnum.FILTERS,
         ),
     ] = DevVersionInclusionEnum.EXCLUDE,
+    dev_stream: Annotated[
+        Optional[ReleaseStreamEnum],
+        typer.Option(
+            help="Filter development versions to a specific release stream.",
+            rich_help_panel=RichHelpPanelEnum.FILTERS,
+        ),
+    ] = None,
     matrix_versions: Annotated[
         Optional[MatrixVersionInclusionEnum],
         typer.Option(
@@ -91,6 +99,7 @@ def cache_registry(
         filter=BakeryConfigFilter(image_name=image_name),
         cache_registry=registry,
         dev_versions=dev_versions,
+        dev_stream=dev_stream,
         matrix_versions=matrix_versions,
     )
     config: BakeryConfig = BakeryConfig.from_context(context, settings)
@@ -151,6 +160,13 @@ def temp_registry(
             rich_help_panel=RichHelpPanelEnum.FILTERS,
         ),
     ] = DevVersionInclusionEnum.EXCLUDE,
+    dev_stream: Annotated[
+        Optional[ReleaseStreamEnum],
+        typer.Option(
+            help="Filter development versions to a specific release stream.",
+            rich_help_panel=RichHelpPanelEnum.FILTERS,
+        ),
+    ] = None,
     matrix_versions: Annotated[
         Optional[MatrixVersionInclusionEnum],
         typer.Option(
@@ -176,6 +192,7 @@ def temp_registry(
         filter=BakeryConfigFilter(image_name=image_name),
         temp_registry=registry,
         dev_versions=dev_versions,
+        dev_stream=dev_stream,
         matrix_versions=matrix_versions,
     )
     config: BakeryConfig = BakeryConfig.from_context(context, settings)

--- a/posit-bakery/posit_bakery/cli/get.py
+++ b/posit-bakery/posit_bakery/cli/get.py
@@ -8,6 +8,7 @@ import typer
 
 from posit_bakery.cli.common import with_verbosity_flags
 from posit_bakery.config.config import BakerySettings, BakeryConfigFilter, BakeryConfig
+from posit_bakery.config.image.posit_product.const import ReleaseStreamEnum
 from posit_bakery.const import DevVersionInclusionEnum, GetTagsOutputFormat, MatrixVersionInclusionEnum
 from posit_bakery.log import stderr_console, stdout_console
 from posit_bakery.util import auto_path
@@ -65,6 +66,13 @@ def tags(
             rich_help_panel="Filters",
         ),
     ] = DevVersionInclusionEnum.EXCLUDE,
+    dev_stream: Annotated[
+        Optional[ReleaseStreamEnum],
+        typer.Option(
+            help="Filter development versions to a specific release stream.",
+            rich_help_panel="Filters",
+        ),
+    ] = None,
     matrix_versions: Annotated[
         Optional[MatrixVersionInclusionEnum],
         typer.Option(
@@ -102,6 +110,7 @@ def tags(
                 image_os=image_os,
             ),
             dev_versions=dev_versions,
+            dev_stream=dev_stream,
             matrix_versions=matrix_versions,
         )
         config: BakeryConfig = BakeryConfig.from_context(context, settings)

--- a/posit-bakery/posit_bakery/cli/run.py
+++ b/posit-bakery/posit_bakery/cli/run.py
@@ -10,6 +10,7 @@ import typer
 from posit_bakery.cli.common import with_verbosity_flags
 from posit_bakery.config import BakeryConfig
 from posit_bakery.config.config import BakeryConfigFilter, BakerySettings
+from posit_bakery.config.image.posit_product.const import ReleaseStreamEnum
 from posit_bakery.const import DevVersionInclusionEnum, MatrixVersionInclusionEnum
 from posit_bakery.log import stderr_console
 from posit_bakery.plugins.registry import get_plugin
@@ -90,6 +91,13 @@ def dgoss(
             rich_help_panel=RichHelpPanelEnum.FILTERS,
         ),
     ] = DevVersionInclusionEnum.EXCLUDE,
+    dev_stream: Annotated[
+        Optional[ReleaseStreamEnum],
+        typer.Option(
+            help="Filter development versions to a specific release stream.",
+            rich_help_panel=RichHelpPanelEnum.FILTERS,
+        ),
+    ] = None,
     matrix_versions: Annotated[
         Optional[MatrixVersionInclusionEnum],
         typer.Option(
@@ -147,6 +155,7 @@ def dgoss(
             image_platform=[image_platform],
         ),
         dev_versions=dev_versions,
+        dev_stream=dev_stream,
         matrix_versions=matrix_versions,
         clean_temporary=clean,
     )

--- a/posit-bakery/posit_bakery/config/config.py
+++ b/posit-bakery/posit_bakery/config/config.py
@@ -25,6 +25,7 @@ from posit_bakery.config.repository import Repository
 from posit_bakery.config.shared import BakeryPathMixin, BakeryYAMLModel
 from posit_bakery.config.templating import TPL_CONTAINERFILE, TPL_BAKERY_CONFIG_YAML
 from posit_bakery.config.templating.render import jinja2_env
+from posit_bakery.config.image.posit_product.const import ReleaseStreamEnum
 from posit_bakery.const import DEFAULT_BASE_IMAGE, DevVersionInclusionEnum, MatrixVersionInclusionEnum
 from posit_bakery.error import (
     BakeryError,
@@ -279,6 +280,13 @@ class BakerySettings(BaseModel):
             default=DevVersionInclusionEnum.EXCLUDE,
         ),
     ]
+    dev_stream: Annotated[
+        ReleaseStreamEnum | None,
+        Field(
+            default=None,
+            description="Filter development versions to a specific release stream.",
+        ),
+    ]
     matrix_versions: Annotated[
         MatrixVersionInclusionEnum,
         Field(
@@ -328,6 +336,12 @@ class BakeryConfig:
         except pydantic.ValidationError as e:
             log.error(f"Failed to load configuration from {str(self.config_file)}")
             raise e
+
+        if self.settings.dev_stream is not None and self.settings.dev_versions == DevVersionInclusionEnum.EXCLUDE:
+            log.warning(
+                "--dev-stream has no effect when development versions are excluded. "
+                "Use --dev-versions include or --dev-versions only to enable dev stream filtering."
+            )
 
         if self.settings.dev_versions in [DevVersionInclusionEnum.ONLY, DevVersionInclusionEnum.INCLUDE]:
             for image in self.model.images:
@@ -791,6 +805,21 @@ class BakeryConfig:
                             f"development version."
                         )
                     continue
+                if settings.dev_stream is not None and version.isDevelopmentVersion:
+                    version_release_stream = version.metadata.get("release_stream")
+                    if version_release_stream != settings.dev_stream:
+                        if version_filter_matched:
+                            log.warning(
+                                f"Version '{version.name}' in image '{image.name}' matches --image-version filter "
+                                f"but is being skipped: dev stream '{version_release_stream}' does not match "
+                                f"--dev-stream '{settings.dev_stream.value}'"
+                            )
+                        else:
+                            log.debug(
+                                f"Skipping dev version '{version.name}' in image '{image.name}': "
+                                f"dev stream '{version_release_stream}' does not match --dev-stream '{settings.dev_stream.value}'"
+                            )
+                        continue
                 if (
                     settings.filter.image_version is not None
                     and re.search(settings.filter.image_version, version.name) is None

--- a/posit-bakery/posit_bakery/config/image/dev_version/base.py
+++ b/posit-bakery/posit_bakery/config/image/dev_version/base.py
@@ -6,6 +6,7 @@ from typing import Annotated, Self
 from pydantic import Field, field_validator, model_validator
 
 from posit_bakery.config.image.build_os import DEFAULT_PLATFORMS
+from posit_bakery.config.image.posit_product.const import ReleaseStreamEnum
 from posit_bakery.config.image.version import ImageVersion
 from posit_bakery.config.image.version_os import ImageVersionOS
 from posit_bakery.config.registry import BaseRegistry, Registry
@@ -209,6 +210,13 @@ class BaseImageDevelopmentVersion(BakeryYAMLModel, abc.ABC):
         """
         raise NotImplementedError("Subclasses must implement get_url method.")
 
+    def get_release_stream(self) -> ReleaseStreamEnum | None:
+        """Return the release stream for this development version, if known.
+
+        :return: The ReleaseStreamEnum value, or None if not applicable.
+        """
+        return None
+
     @model_validator(mode="after")
     def add_os_url(self) -> "BaseImageDevelopmentVersion":
         """Add the URL to each OS in the os list.
@@ -223,6 +231,10 @@ class BaseImageDevelopmentVersion(BakeryYAMLModel, abc.ABC):
 
     def as_image_version(self):
         """Convert this development version to a standard image version."""
+        metadata = {}
+        release_stream = self.get_release_stream()
+        if release_stream is not None:
+            metadata["release_stream"] = release_stream
         return ImageVersion(
             name=self.get_version(),
             subpath=f".dev-{self.get_version()}".replace(" ", "-").lower(),
@@ -235,4 +247,5 @@ class BaseImageDevelopmentVersion(BakeryYAMLModel, abc.ABC):
             dependencies=self.parent.resolve_dependency_versions(),
             ephemeral=True,
             isDevelopmentVersion=True,
+            metadata=metadata,
         )

--- a/posit-bakery/posit_bakery/config/image/dev_version/env.py
+++ b/posit-bakery/posit_bakery/config/image/dev_version/env.py
@@ -5,6 +5,7 @@ from pydantic import Field, field_validator
 from pydantic_core.core_schema import ValidationInfo
 
 from posit_bakery.config.image.dev_version.base import BaseImageDevelopmentVersion
+from posit_bakery.config.image.posit_product.const import ReleaseStreamEnum
 from posit_bakery.config.templating import jinja2_env
 
 
@@ -31,6 +32,10 @@ class ImageDevelopmentVersionFromEnv(BaseImageDevelopmentVersion):
     sourceType: Literal["env"] = "env"
     versionEnvVar: Annotated[str, Field(description="The environment variable that contains the image version name.")]
     urlEnvVar: Annotated[str, Field(description="The environment variable that contains the image URL.")]
+    stream: Annotated[
+        ReleaseStreamEnum | None,
+        Field(default=None, description="Optional release stream to associate with this environment-sourced version."),
+    ]
 
     @field_validator("versionEnvVar", "urlEnvVar", mode="after")
     def validate_env_vars(cls, v: str, info: ValidationInfo):
@@ -82,6 +87,13 @@ class ImageDevelopmentVersionFromEnv(BaseImageDevelopmentVersion):
             d[_os.name] = rendered_url
 
         return d
+
+    def get_release_stream(self) -> ReleaseStreamEnum | None:
+        """Return the release stream for this env development version, if configured.
+
+        :return: The configured ReleaseStreamEnum value, or None.
+        """
+        return self.stream
 
     def __repr__(self) -> str:
         """Generate a unique representation for this development version configuration.

--- a/posit-bakery/posit_bakery/config/image/dev_version/stream.py
+++ b/posit-bakery/posit_bakery/config/image/dev_version/stream.py
@@ -52,5 +52,12 @@ class ImageDevelopmentVersionFromProductStream(BaseImageDevelopmentVersion):
 
         return url_by_os
 
+    def get_release_stream(self) -> ReleaseStreamEnum:
+        """Return the release stream for this product stream development version.
+
+        :return: The configured ReleaseStreamEnum value.
+        """
+        return self.stream
+
     def __repr__(self):
         return f'devVersion(sourceType="stream", product="{self.product}", stream="{self.stream}")'

--- a/posit-bakery/posit_bakery/config/image/version.py
+++ b/posit-bakery/posit_bakery/config/image/version.py
@@ -110,6 +110,14 @@ class ImageVersion(BakeryPathMixin, BakeryYAMLModel):
         str | None,
         Field(default=None, description="Target build stage for the Docker --target flag."),
     ]
+    metadata: Annotated[
+        dict[str, Any],
+        Field(
+            exclude=True,
+            default_factory=dict,
+            description="Private metadata store for internal use. Not settable via bakery.yaml.",
+        ),
+    ]
 
     @field_validator("extraRegistries", "overrideRegistries", mode="after")
     @classmethod

--- a/posit-bakery/test/config/image/dev_version/test_env.py
+++ b/posit-bakery/test/config/image/dev_version/test_env.py
@@ -8,6 +8,7 @@ from pydantic import ValidationError
 from posit_bakery.config import Image, BaseRegistry
 from posit_bakery.config.image.dev_version import ImageDevelopmentVersionFromEnv
 from posit_bakery.config.image.dev_version.env import _get_value_from_env
+from posit_bakery.config.image.posit_product.const import ReleaseStreamEnum
 
 pytestmark = [
     pytest.mark.unit,
@@ -268,3 +269,63 @@ class TestImageDevelopmentVersionFromEnv:
         assert len(i.all_registries) == 2
         for registry in override_registries:
             assert registry in i.all_registries
+
+    def test_get_release_stream_returns_none_by_default(self, monkeypatch):
+        """Test that get_release_stream returns None when no stream configured."""
+        monkeypatch.setenv("TEST_VERSION", "1.0.0")
+        monkeypatch.setenv("TEST_URL", "https://example.com/download")
+        dev_version = ImageDevelopmentVersionFromEnv(
+            sourceType="env",
+            versionEnvVar="TEST_VERSION",
+            urlEnvVar="TEST_URL",
+            os=[{"name": "Ubuntu 24.04", "primary": True}],
+        )
+        assert dev_version.get_release_stream() is None
+
+    def test_get_release_stream_returns_configured_stream(self, monkeypatch):
+        """Test that get_release_stream returns the configured stream."""
+        monkeypatch.setenv("TEST_VERSION", "1.0.0")
+        monkeypatch.setenv("TEST_URL", "https://example.com/download")
+        dev_version = ImageDevelopmentVersionFromEnv(
+            sourceType="env",
+            versionEnvVar="TEST_VERSION",
+            urlEnvVar="TEST_URL",
+            stream=ReleaseStreamEnum.DAILY,
+            os=[{"name": "Ubuntu 24.04", "primary": True}],
+        )
+        assert dev_version.get_release_stream() == ReleaseStreamEnum.DAILY
+
+    def test_as_image_version_metadata_empty_when_no_stream(self, monkeypatch):
+        """Test that as_image_version metadata has no release_stream when stream is None."""
+        monkeypatch.setenv("TEST_VERSION", "1.0.0")
+        monkeypatch.setenv("TEST_URL", "https://example.com/download")
+        mock_parent = MagicMock(spec=Image)
+        mock_parent.path = Path("/tmp/path")
+        mock_parent.resolve_dependency_versions.return_value = []
+        dev_version = ImageDevelopmentVersionFromEnv(
+            sourceType="env",
+            versionEnvVar="TEST_VERSION",
+            urlEnvVar="TEST_URL",
+            os=[{"name": "Ubuntu 24.04", "primary": True}],
+        )
+        dev_version.parent = mock_parent
+        image_version = dev_version.as_image_version()
+        assert "release_stream" not in image_version.metadata
+
+    def test_as_image_version_metadata_contains_stream_when_configured(self, monkeypatch):
+        """Test that as_image_version metadata contains release_stream when stream is set."""
+        monkeypatch.setenv("TEST_VERSION", "1.0.0")
+        monkeypatch.setenv("TEST_URL", "https://example.com/download")
+        mock_parent = MagicMock(spec=Image)
+        mock_parent.path = Path("/tmp/path")
+        mock_parent.resolve_dependency_versions.return_value = []
+        dev_version = ImageDevelopmentVersionFromEnv(
+            sourceType="env",
+            versionEnvVar="TEST_VERSION",
+            urlEnvVar="TEST_URL",
+            stream=ReleaseStreamEnum.DAILY,
+            os=[{"name": "Ubuntu 24.04", "primary": True}],
+        )
+        dev_version.parent = mock_parent
+        image_version = dev_version.as_image_version()
+        assert image_version.metadata == {"release_stream": ReleaseStreamEnum.DAILY}

--- a/posit-bakery/test/config/image/dev_version/test_stream.py
+++ b/posit-bakery/test/config/image/dev_version/test_stream.py
@@ -268,6 +268,31 @@ class TestImageDevelopmentVersionFromProductStream:
         for registry in override_registries:
             assert registry in i.all_registries
 
+    def test_get_release_stream_returns_stream(self, patch_requests_get):
+        """Test that get_release_stream returns the configured stream."""
+        dev_version = ImageDevelopmentVersionFromProductStream(
+            sourceType="stream",
+            product=ProductEnum.PACKAGE_MANAGER,
+            stream=ReleaseStreamEnum.DAILY,
+            os=[{"name": "Ubuntu 24.04", "primary": True}],
+        )
+        assert dev_version.get_release_stream() == ReleaseStreamEnum.DAILY
+
+    def test_as_image_version_metadata_contains_release_stream(self, patch_requests_get):
+        """Test that as_image_version populates metadata with release_stream."""
+        mock_parent = MagicMock(spec=Image)
+        mock_parent.path = Path("/tmp/path")
+        mock_parent.resolve_dependency_versions.return_value = []
+        dev_version = ImageDevelopmentVersionFromProductStream(
+            sourceType="stream",
+            product=ProductEnum.PACKAGE_MANAGER,
+            stream=ReleaseStreamEnum.PREVIEW,
+            os=[{"name": "Ubuntu 24.04", "primary": True}],
+        )
+        dev_version.parent = mock_parent
+        image_version = dev_version.as_image_version()
+        assert image_version.metadata == {"release_stream": ReleaseStreamEnum.PREVIEW}
+
     @pytest.mark.parametrize(
         "download_url,generalize_architecture,expected_url",
         [

--- a/posit-bakery/test/config/image/test_version.py
+++ b/posit-bakery/test/config/image/test_version.py
@@ -507,6 +507,23 @@ class TestImageVersion:
         assert "{{ Image.Name }}" in content
         assert "This is a static file that should be copied verbatim." in content
 
+    def test_metadata_defaults_to_empty_dict(self):
+        """Test that metadata defaults to an empty dict."""
+        i = ImageVersion(name="1.0.0")
+        assert i.metadata == {}
+
+    def test_metadata_excluded_from_serialization(self):
+        """Test that metadata is excluded from model_dump output."""
+        i = ImageVersion(name="1.0.0", metadata={"release_stream": "daily"})
+        dump = i.model_dump()
+        assert "metadata" not in dump
+
+    def test_metadata_stores_arbitrary_values(self):
+        """Test that metadata can store arbitrary key-value pairs."""
+        i = ImageVersion(name="1.0.0", metadata={"release_stream": "daily", "custom_key": 42})
+        assert i.metadata["release_stream"] == "daily"
+        assert i.metadata["custom_key"] == 42
+
     def test_render_files_preserves_directory_structure(self, get_tmpcontext, common_image_variants_objects):
         """Test that render_files preserves directory structure for non-template files."""
         context = get_tmpcontext("basic")

--- a/posit-bakery/test/config/test_config.py
+++ b/posit-bakery/test/config/test_config.py
@@ -12,6 +12,7 @@ from pydantic import ValidationError
 import posit_bakery
 from posit_bakery.config.config import BakeryConfigDocument, BakeryConfig, BakeryConfigFilter, BakerySettings
 from posit_bakery.config.dependencies import PythonDependencyConstraint, RDependencyVersions
+from posit_bakery.config.image.posit_product.const import ReleaseStreamEnum
 from posit_bakery.const import DevVersionInclusionEnum, MatrixVersionInclusionEnum
 from posit_bakery.image.image_metadata import BuildMetadata
 from test.config.conftest import CONFIG_TESTDATA_DIR
@@ -223,6 +224,58 @@ class TestBakeryConfig:
                 for version in dev_versions:
                     assert version.name in expected_versions
                     assert len(version.os) == 2
+
+    @pytest.mark.parametrize(
+        "dev_stream,expected_dev_version_count",
+        [
+            pytest.param(None, 2, id="no-filter-includes-all-dev-versions"),
+            pytest.param(ReleaseStreamEnum.PREVIEW, 1, id="preview-filter"),
+            pytest.param(ReleaseStreamEnum.DAILY, 1, id="daily-filter"),
+            pytest.param(ReleaseStreamEnum.RELEASE, 0, id="release-filter-no-match"),
+        ],
+    )
+    @patch("atexit.register")
+    def test_dev_stream_filter(
+        self,
+        mock_atexit_register,
+        dev_stream,
+        expected_dev_version_count,
+        testdata_path,
+        patch_requests_get,
+    ):
+        """Test that dev_stream filters development versions by release stream."""
+        yaml_file = testdata_path / "valid" / "complex.yaml"
+        with patch.object(posit_bakery.config.image.Image, "render_ephemeral_version_files"):
+            with patch.object(posit_bakery.config.image.Image, "remove_ephemeral_version_files"):
+                config = BakeryConfig(
+                    yaml_file,
+                    BakerySettings(
+                        dev_versions=DevVersionInclusionEnum.ONLY,
+                        dev_stream=dev_stream,
+                        clean_temporary=False,
+                    ),
+                )
+                dev_targets = [t for t in config.targets if t.image_version.isDevelopmentVersion]
+                # package-manager has 2 variants and each dev version has 2 OSes = 4 targets per dev version
+                assert len(dev_targets) == expected_dev_version_count * 4
+
+    def test_dev_stream_warning_when_dev_versions_excluded(
+        self,
+        caplog,
+        testdata_path,
+        patch_requests_get,
+    ):
+        """Test that a warning is emitted when --dev-stream is set but dev versions are excluded."""
+        yaml_file = testdata_path / "valid" / "complex.yaml"
+        BakeryConfig(
+            yaml_file,
+            BakerySettings(
+                dev_versions=DevVersionInclusionEnum.EXCLUDE,
+                dev_stream=ReleaseStreamEnum.DAILY,
+            ),
+        )
+        assert "WARNING" in caplog.text
+        assert "--dev-stream" in caplog.text
 
     @pytest.mark.parametrize(
         "include_matrix_versions,expected_uids",


### PR DESCRIPTION
## Summary

- Adds a generic `metadata` field (`dict[str, Any]`, `exclude=True`) to `ImageVersion` for internal use, not settable via `bakery.yaml`
- Propagates release stream info (`release_stream` key) from dev version sources into `ImageVersion.metadata` during `as_image_version()` conversion
- Adds `--dev-stream` CLI filter option (values: `release`, `preview`, `daily`) to all 8 commands that have `--dev-versions`, filtering dev version targets to a specific release stream
- Adds optional `stream` field to `ImageDevelopmentVersionFromEnv` so env-sourced dev versions can also be tagged with a release stream

## Test plan
- [x] `uv run pytest test/ -m "not slow and not image_build"` passes (1315 tests, all green)
- [x] `bakery build --dev-versions only --dev-stream daily` only builds daily dev versions
- [x] `bakery build --dev-versions only --dev-stream preview` only builds preview dev versions
- [x] `bakery build --dev-stream daily` (without `--dev-versions`) emits a warning that `--dev-stream` has no effect
- [x] `bakery ci matrix --dev-versions only --dev-stream daily` generates matrix entries for daily dev versions only

🤖 Generated with [Claude Code](https://claude.com/claude-code)