### PR TITLE
Disable uv cache in setup-bakery action

### DIFF
--- a/setup-bakery/action.yml
+++ b/setup-bakery/action.yml
@@ -16,6 +16,8 @@ runs:
   steps:
     - name: Setup uv
       uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
+      with:
+        enable-cache: false
 
     - name: Setup Python
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0


### PR DESCRIPTION
## Summary

- Disables the default dependency cache in `astral-sh/setup-uv` within the `setup-bakery` composite action
- Product image repos (images-connect, images-workbench, images-package-manager) don't have Python dependency files, so the cache never gets invalidated and emits a warning on every CI run
- Since these repos only use `uv tool install` to install bakery, the cache provides no benefit

## Test plan

- [ ] Verify CI passes on this PR
- [ ] Confirm the "No file matched" cache warning no longer appears in product image repo CI runs after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)