### PR TITLE
Propagate template file mode to rendered output

### DIFF
--- a/posit-bakery/posit_bakery/config/image/matrix.py
+++ b/posit-bakery/posit_bakery/config/image/matrix.py
@@ -522,9 +522,9 @@ class ImageMatrix(BakeryPathMixin, BakeryYAMLModel):
                                 )
                             )
                             continue
-                        with open(containerfile, "w") as f:
-                            log.debug(f"[bright_black]Rendering [bold]{containerfile}")
-                            f.write(rendered)
+                        log.debug(f"[bright_black]Rendering [bold]{containerfile}")
+                        copy2(tpl_full_path, containerfile)
+                        containerfile.write_text(rendered)
 
                 # Render other templates once
                 else:
@@ -549,9 +549,9 @@ class ImageMatrix(BakeryPathMixin, BakeryYAMLModel):
                             )
                         )
                         continue
-                    with open(output_file, "w") as f:
-                        log.debug(f"[bright_black]Rendering [bold]{output_file}")
-                        f.write(rendered)
+                    log.debug(f"[bright_black]Rendering [bold]{output_file}")
+                    copy2(tpl_full_path, output_file)
+                    output_file.write_text(rendered)
 
         if exceptions:
             if len(exceptions) == 1:

--- a/posit-bakery/posit_bakery/config/image/version.py
+++ b/posit-bakery/posit_bakery/config/image/version.py
@@ -473,9 +473,9 @@ class ImageVersion(BakeryPathMixin, BakeryYAMLModel):
                                 )
                             )
                             continue
-                        with open(containerfile, "w") as f:
-                            log.debug(f"[bright_black]Rendering [bold]{containerfile}")
-                            f.write(rendered)
+                        log.debug(f"[bright_black]Rendering [bold]{containerfile}")
+                        copy2(tpl_full_path, containerfile)
+                        containerfile.write_text(rendered)
 
                 # Render other templates once
                 else:
@@ -501,9 +501,9 @@ class ImageVersion(BakeryPathMixin, BakeryYAMLModel):
                             )
                         )
                         continue
-                    with open(output_file, "w") as f:
-                        log.debug(f"[bright_black]Rendering [bold]{output_file}")
-                        f.write(rendered)
+                    log.debug(f"[bright_black]Rendering [bold]{output_file}")
+                    copy2(tpl_full_path, output_file)
+                    output_file.write_text(rendered)
 
         if exceptions:
             if len(exceptions) == 1:

--- a/posit-bakery/test/config/image/test_matrix.py
+++ b/posit-bakery/test/config/image/test_matrix.py
@@ -1,3 +1,4 @@
+import stat
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -637,3 +638,43 @@ class TestImageMatrix:
         script_content = copied_script.read_text()
         assert "{{ Image.Name }}" in script_content  # Should be literal
         assert "#!/bin/bash" in script_content
+
+    def test_render_files_preserves_template_file_mode(self, tmp_path):
+        """Test that matrix render_files propagates the template file mode to rendered output."""
+        image_dir = tmp_path / "test-image"
+        template_dir = image_dir / "template"
+        scripts_dir = template_dir / "scripts"
+        scripts_dir.mkdir(parents=True)
+
+        # Executable Jinja2 template: rendered output should inherit the exec bit.
+        exec_tpl = scripts_dir / "startup.sh.jinja2"
+        exec_tpl.write_text("#!/bin/bash\necho {{ Image.Name }}\n")
+        exec_tpl.chmod(0o755)
+
+        # Non-executable Jinja2 template: rendered output should stay 0o644.
+        plain_tpl = scripts_dir / "config.sh.jinja2"
+        plain_tpl.write_text("# config for {{ Image.Name }}\n")
+        plain_tpl.chmod(0o644)
+
+        mock_config_parent = MagicMock(spec=BakeryConfigDocument)
+        mock_config_parent.path = tmp_path
+
+        mock_image_parent = MagicMock(spec=Image)
+        mock_image_parent.name = "test-image"
+        mock_image_parent.displayName = "Test Image"
+        mock_image_parent.path = image_dir
+        mock_image_parent.template_path = template_dir
+        mock_image_parent.parent = mock_config_parent
+
+        matrix = ImageMatrix(
+            parent=mock_image_parent,
+            values={"go_version": ["1.24"]},
+        )
+
+        matrix.render_files()
+
+        expected_path = image_dir / "matrix"
+        exec_out = expected_path / "scripts" / "startup.sh"
+        plain_out = expected_path / "scripts" / "config.sh"
+        assert exec_out.stat().st_mode & stat.S_IXUSR, "executable template should render to executable file"
+        assert not (plain_out.stat().st_mode & stat.S_IXUSR), "non-executable template should stay non-executable"

--- a/posit-bakery/test/config/image/test_version.py
+++ b/posit-bakery/test/config/image/test_version.py
@@ -1,3 +1,4 @@
+import stat
 import textwrap
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -551,3 +552,40 @@ class TestImageVersion:
         # The Jinja2 syntax should be preserved literally
         assert "{{ Image.Name }}" in content
         assert "#!/bin/bash" in content
+
+    def test_render_files_preserves_template_file_mode(self, get_tmpcontext, common_image_variants_objects):
+        """Test that render_files propagates the template file mode to rendered output."""
+        context = get_tmpcontext("basic")
+
+        # Executable Jinja2 template: rendered output should inherit the exec bit.
+        exec_tpl = context / "test-image" / "template" / "scripts" / "startup.sh.jinja2"
+        exec_tpl.parent.mkdir(parents=True, exist_ok=True)
+        exec_tpl.write_text("#!/bin/bash\necho {{ Image.Name }}\n")
+        exec_tpl.chmod(0o755)
+
+        # Non-executable Jinja2 template: rendered output should stay 0o644.
+        plain_tpl = context / "test-image" / "template" / "scripts" / "config.sh.jinja2"
+        plain_tpl.write_text("# config for {{ Image.Name }}\n")
+        plain_tpl.chmod(0o644)
+
+        mock_parent = MagicMock(spec=BakeryConfigDocument)
+        mock_parent.path = context
+        mock_parent.registries = [BaseRegistry(host="docker.io", namespace="posit")]
+
+        i = Image(
+            name="test-image", versions=[{"name": "1.0.0"}], variants=common_image_variants_objects, parent=mock_parent
+        )
+        new_version = ImageVersion(
+            parent=i,
+            name="2.0.0",
+            subpath="2.0",
+            os=[{"name": "Ubuntu 22.04", "primary": True}],
+        )
+
+        new_version.render_files(i.variants)
+
+        expected_path = context / "test-image" / "2.0"
+        exec_out = expected_path / "scripts" / "startup.sh"
+        plain_out = expected_path / "scripts" / "config.sh"
+        assert exec_out.stat().st_mode & stat.S_IXUSR, "executable template should render to executable file"
+        assert not (plain_out.stat().st_mode & stat.S_IXUSR), "non-executable template should stay non-executable"


### PR DESCRIPTION
## Summary

- Bakery's render path used `open(path, "w") + f.write(rendered)`, which created rendered files with the default mode (0o644 after umask). The exec bit on a template was never reflected in its rendered file — shell scripts rendered from `.sh.jinja2` templates had to be chmod +x'd manually each render.
- Swap to `copy2(tpl, out); out.write_text(rendered)`. `copy2` preserves source mode (and timestamps, which `write_text` then overwrites), mirroring the idiom already used on the verbatim non-template-copy branch (`version.py:410`). No new imports.
- Covers both the `ImageVersion` and `ImageMatrix` render paths (4 write sites total).

Backwards-compatible: a 0o644 template continues to render to a 0o644 output; only chmod +x templates change behavior.

This unblocks sibling-repo cleanup where the pre-commit `check-shebang-scripts-are-executable` hook flags rendered `.sh` files with shebangs that aren't executable. After this lands, marking a `.sh.jinja2` template +x is enough — re-render propagates.

## Test plan

- [x] New unit test `test_render_files_preserves_template_file_mode` asserts that a 0o755 template renders to a 0o755 file and a 0o644 template stays 0o644.
- [x] Existing render_files tests in `test_version.py` and `test_matrix.py` still pass.
- [x] Smoke test: in a sibling repo (e.g. images-package-manager), chmod +x `package-manager/template/scripts/*.jinja2`, run `bakery update files`, verify rendered `.sh` files come out executable.