### PR TITLE
feat: add install_jupyterlab_workbench macros for Posit Workbench images

### DIFF
--- a/posit-bakery/posit_bakery/config/templating/macros/python.j2
+++ b/posit-bakery/posit_bakery/config/templating/macros/python.j2
@@ -155,3 +155,40 @@ ln -s {{ get_version_directory(version) }} {{ target }}
 {% macro symlink_binary(version, bin_name, target) -%}
 ln -s {{ get_version_directory(version) }}/bin/{{ bin_name }} {{ target }}
 {%- endmacro %}
+
+{# Generates commands to install jupyterlab, notebook, and pwb_jupyterlab to a new virtual environment and symlinks jupyter to the system PATH
+
+:param python_version: The Python version to install JupyterLab's virtual environment with, e.g. "3.12.11"
+:param jupyter_venv_name: The name of the virtual environment to create for JupyterLab. Defaults to "jupyter".
+:param jupyterlab_version_pin: An optional version specifier to pin the jupyterlab version to, e.g. "<5"
+:param pwb_jupyterlab_version_pin: An optional version specifier to pin the pwb_jupyterlab version to, e.g. "<2"
+:param extra_packages: A list of additional packages to install in the JupyterLab virtual environment, e.g. ["numpy", "pandas"]. Optional.
+:param strip_tests: Whether to remove the jupyterlab tests directory after installation. Defaults to True.
+:param strip_staging: Whether to remove the jupyterlab staging yarn.lock file after installation. Defaults to True.
+#}
+{% macro install_jupyterlab_workbench(python_version, jupyter_venv_name = "jupyter", jupyterlab_version_pin = "", pwb_jupyterlab_version_pin = "", extra_packages = [], strip_tests = True, strip_staging = True) -%}
+{{ get_version_directory(python_version) }}/bin/python -m venv {{ get_version_directory(jupyter_venv_name) }} && \
+{{ get_version_directory(jupyter_venv_name) }}/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \
+{{ install_packages(jupyter_venv_name, ["jupyterlab" + jupyterlab_version_pin, "notebook", "pwb_jupyterlab" + pwb_jupyterlab_version_pin] + extra_packages, None, False) }} && \
+{% if strip_tests -%}
+bash -O failglob -c 'rm -rf {{ get_version_directory(jupyter_venv_name) }}/lib/python*/site-packages/jupyterlab/tests' && \
+{% endif -%}
+{% if strip_staging -%}
+bash -O failglob -c 'rm -f {{ get_version_directory(jupyter_venv_name) }}/lib/python*/site-packages/jupyterlab/staging/yarn.lock' && \
+{% endif -%}
+{{ symlink_binary(jupyter_venv_name, "jupyter", "/usr/local/bin/jupyter") }}
+{%- endmacro %}
+
+{# Install JupyterLab and associated packages to a new virtual environment for use with Posit Workbench
+
+:param python_version: The Python version to install JupyterLab's virtual environment with, e.g. "3.12.11"
+:param jupyter_venv_name: The name of the virtual environment to create for JupyterLab. Defaults to "jupyter".
+:param jupyterlab_version_pin: An optional version specifier to pin the jupyterlab version to, e.g. "<5"
+:param pwb_jupyterlab_version_pin: An optional version specifier to pin the pwb_jupyterlab version to, e.g. "<2"
+:param extra_packages: A list of additional packages to install in the JupyterLab virtual environment, e.g. ["numpy", "pandas"]. Optional.
+:param strip_tests: Whether to remove the jupyterlab tests directory after installation. Defaults to True.
+:param strip_staging: Whether to remove the jupyterlab staging yarn.lock file after installation. Defaults to True.
+#}
+{% macro run_install_jupyterlab_workbench(python_version, jupyter_venv_name = "jupyter", jupyterlab_version_pin = "", pwb_jupyterlab_version_pin = "", extra_packages = [], strip_tests = True, strip_staging = True) -%}
+RUN {{ install_jupyterlab_workbench(python_version, jupyter_venv_name, jupyterlab_version_pin, pwb_jupyterlab_version_pin, extra_packages, strip_tests, strip_staging) | indent(4) }}
+{%- endmacro %}

--- a/posit-bakery/posit_bakery/config/templating/macros/python.j2
+++ b/posit-bakery/posit_bakery/config/templating/macros/python.j2
@@ -175,6 +175,7 @@ ln -s {{ get_version_directory(version) }}/bin/{{ bin_name }} {{ target }}
 {{ install_packages(jupyter_venv_name, ["\"jupyterlab" + jupyterlab_version_pin + "\"", "notebook", "\"pwb_jupyterlab" + pwb_jupyterlab_version_pin + "\""] + extra_packages, break_system_packages=False) }} && \
 {% if strip_tests -%}
 rm -rf {{ get_version_directory(jupyter_venv_name) }}/lib/python*/site-packages/jupyterlab/tests && \
+rm -rf {{ get_version_directory(jupyter_venv_name) }}/lib/python*/site-packages/jupyterlab/galata && \
 {% endif -%}
 {% if strip_staging -%}
 rm -f {{ get_version_directory(jupyter_venv_name) }}/lib/python*/site-packages/jupyterlab/staging/yarn.lock && \

--- a/posit-bakery/posit_bakery/config/templating/macros/python.j2
+++ b/posit-bakery/posit_bakery/config/templating/macros/python.j2
@@ -171,10 +171,10 @@ ln -s {{ get_version_directory(version) }}/bin/{{ bin_name }} {{ target }}
 {{ get_version_directory(jupyter_venv_name) }}/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \
 {{ install_packages(jupyter_venv_name, ["jupyterlab" + jupyterlab_version_pin, "notebook", "pwb_jupyterlab" + pwb_jupyterlab_version_pin] + extra_packages, None, False) }} && \
 {% if strip_tests -%}
-bash -O failglob -c 'rm -rf {{ get_version_directory(jupyter_venv_name) }}/lib/python*/site-packages/jupyterlab/tests' && \
+rm -rf {{ get_version_directory(jupyter_venv_name) }}/lib/python*/site-packages/jupyterlab/tests && \
 {% endif -%}
 {% if strip_staging -%}
-bash -O failglob -c 'rm -f {{ get_version_directory(jupyter_venv_name) }}/lib/python*/site-packages/jupyterlab/staging/yarn.lock' && \
+rm -f {{ get_version_directory(jupyter_venv_name) }}/lib/python*/site-packages/jupyterlab/staging/yarn.lock && \
 {% endif -%}
 {{ symlink_binary(jupyter_venv_name, "jupyter", "/usr/local/bin/jupyter") }}
 {%- endmacro %}

--- a/posit-bakery/posit_bakery/config/templating/macros/python.j2
+++ b/posit-bakery/posit_bakery/config/templating/macros/python.j2
@@ -167,9 +167,12 @@ ln -s {{ get_version_directory(version) }}/bin/{{ bin_name }} {{ target }}
 :param strip_staging: Whether to remove the jupyterlab staging yarn.lock file after installation. Defaults to True.
 #}
 {% macro install_jupyterlab_workbench(python_version, jupyter_venv_name = "jupyter", jupyterlab_version_pin = "", pwb_jupyterlab_version_pin = "", extra_packages = [], strip_tests = True, strip_staging = True) -%}
+{%- if python_version is sequence and python_version is not string -%}
+{%- set python_version = python_version.0 -%}
+{%- endif -%}
 {{ get_version_directory(python_version) }}/bin/python -m venv {{ get_version_directory(jupyter_venv_name) }} && \
 {{ get_version_directory(jupyter_venv_name) }}/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \
-{{ install_packages(jupyter_venv_name, ["jupyterlab" + jupyterlab_version_pin, "notebook", "pwb_jupyterlab" + pwb_jupyterlab_version_pin] + extra_packages, None, False) }} && \
+{{ install_packages(jupyter_venv_name, ["\"jupyterlab" + jupyterlab_version_pin + "\"", "notebook", "\"pwb_jupyterlab" + pwb_jupyterlab_version_pin + "\""] + extra_packages, break_system_packages=False) }} && \
 {% if strip_tests -%}
 rm -rf {{ get_version_directory(jupyter_venv_name) }}/lib/python*/site-packages/jupyterlab/tests && \
 {% endif -%}

--- a/posit-bakery/test/config/templating/test_macros.py
+++ b/posit-bakery/test/config/templating/test_macros.py
@@ -1441,6 +1441,227 @@ class TestPythonMacros:
         rendered = environment_with_macros.from_string(template).render()
         assert rendered == expected
 
+    def test_install_jupyterlab_workbench_default(self, environment_with_macros):
+        template = textwrap.dedent(
+            """\
+            {%- import "python.j2" as python -%}
+            {{ python.install_jupyterlab_workbench("3.12.11") }}
+            """
+        )
+        expected = textwrap.dedent(
+            """\
+            /opt/python/3.12.11/bin/python -m venv /opt/python/jupyter && \\
+            /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \\
+            /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade --break-system-packages \\
+                jupyterlab \\
+                notebook \\
+                pwb_jupyterlab && \\
+            bash -O failglob -c 'rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests' && \\
+            bash -O failglob -c 'rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock' && \\
+            ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter
+            """
+        )
+        rendered = environment_with_macros.from_string(template).render()
+        assert rendered == expected
+
+    def test_install_jupyterlab_workbench_version_pins(self, environment_with_macros):
+        template = textwrap.dedent(
+            """\
+            {%- import "python.j2" as python -%}
+            {{ python.install_jupyterlab_workbench("3.12.11", jupyterlab_version_pin="<5", pwb_jupyterlab_version_pin="<2") }}
+            """
+        )
+        expected = textwrap.dedent(
+            """\
+            /opt/python/3.12.11/bin/python -m venv /opt/python/jupyter && \\
+            /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \\
+            /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade --break-system-packages \\
+                jupyterlab<5 \\
+                notebook \\
+                pwb_jupyterlab<2 && \\
+            bash -O failglob -c 'rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests' && \\
+            bash -O failglob -c 'rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock' && \\
+            ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter
+            """
+        )
+        rendered = environment_with_macros.from_string(template).render()
+        assert rendered == expected
+
+    def test_install_jupyterlab_workbench_extra_packages(self, environment_with_macros):
+        template = textwrap.dedent(
+            """\
+            {%- import "python.j2" as python -%}
+            {{ python.install_jupyterlab_workbench("3.12.11", extra_packages=["numpy", "pandas"]) }}
+            """
+        )
+        expected = textwrap.dedent(
+            """\
+            /opt/python/3.12.11/bin/python -m venv /opt/python/jupyter && \\
+            /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \\
+            /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade --break-system-packages \\
+                jupyterlab \\
+                notebook \\
+                pwb_jupyterlab \\
+                numpy \\
+                pandas && \\
+            bash -O failglob -c 'rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests' && \\
+            bash -O failglob -c 'rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock' && \\
+            ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter
+            """
+        )
+        rendered = environment_with_macros.from_string(template).render()
+        assert rendered == expected
+
+    def test_install_jupyterlab_workbench_custom_venv_name(self, environment_with_macros):
+        template = textwrap.dedent(
+            """\
+            {%- import "python.j2" as python -%}
+            {{ python.install_jupyterlab_workbench("3.12.11", jupyter_venv_name="lab") }}
+            """
+        )
+        expected = textwrap.dedent(
+            """\
+            /opt/python/3.12.11/bin/python -m venv /opt/python/lab && \\
+            /opt/python/lab/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \\
+            /opt/python/lab/bin/pip install --no-cache-dir --upgrade --break-system-packages \\
+                jupyterlab \\
+                notebook \\
+                pwb_jupyterlab && \\
+            bash -O failglob -c 'rm -rf /opt/python/lab/lib/python*/site-packages/jupyterlab/tests' && \\
+            bash -O failglob -c 'rm -f /opt/python/lab/lib/python*/site-packages/jupyterlab/staging/yarn.lock' && \\
+            ln -s /opt/python/lab/bin/jupyter /usr/local/bin/jupyter
+            """
+        )
+        rendered = environment_with_macros.from_string(template).render()
+        assert rendered == expected
+
+    @pytest.mark.parametrize(
+        "strip_tests,strip_staging,expected",
+        [
+            pytest.param(
+                True,
+                True,
+                textwrap.dedent(
+                    """\
+                    /opt/python/3.12.11/bin/python -m venv /opt/python/jupyter && \\
+                    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \\
+                    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade --break-system-packages \\
+                        jupyterlab \\
+                        notebook \\
+                        pwb_jupyterlab && \\
+                    bash -O failglob -c 'rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests' && \\
+                    bash -O failglob -c 'rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock' && \\
+                    ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter
+                    """
+                ),
+                id="strip-both",
+            ),
+            pytest.param(
+                True,
+                False,
+                textwrap.dedent(
+                    """\
+                    /opt/python/3.12.11/bin/python -m venv /opt/python/jupyter && \\
+                    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \\
+                    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade --break-system-packages \\
+                        jupyterlab \\
+                        notebook \\
+                        pwb_jupyterlab && \\
+                    bash -O failglob -c 'rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests' && \\
+                    ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter
+                    """
+                ),
+                id="strip-tests-only",
+            ),
+            pytest.param(
+                False,
+                True,
+                textwrap.dedent(
+                    """\
+                    /opt/python/3.12.11/bin/python -m venv /opt/python/jupyter && \\
+                    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \\
+                    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade --break-system-packages \\
+                        jupyterlab \\
+                        notebook \\
+                        pwb_jupyterlab && \\
+                    bash -O failglob -c 'rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock' && \\
+                    ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter
+                    """
+                ),
+                id="strip-staging-only",
+            ),
+            pytest.param(
+                False,
+                False,
+                textwrap.dedent(
+                    """\
+                    /opt/python/3.12.11/bin/python -m venv /opt/python/jupyter && \\
+                    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \\
+                    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade --break-system-packages \\
+                        jupyterlab \\
+                        notebook \\
+                        pwb_jupyterlab && \\
+                    ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter
+                    """
+                ),
+                id="strip-neither",
+            ),
+        ],
+    )
+    def test_install_jupyterlab_workbench_strip_toggles(self, environment_with_macros, strip_tests, strip_staging, expected):
+        template = textwrap.dedent(
+            f"""\
+            {{%- import "python.j2" as python -%}}
+            {{{{ python.install_jupyterlab_workbench("3.12.11", strip_tests={strip_tests}, strip_staging={strip_staging}) }}}}
+            """
+        )
+        rendered = environment_with_macros.from_string(template).render()
+        assert rendered == expected
+
+    def test_run_install_jupyterlab_workbench_default(self, environment_with_macros):
+        template = textwrap.dedent(
+            """\
+            {%- import "python.j2" as python -%}
+            {{ python.run_install_jupyterlab_workbench("3.12.11") }}
+            """
+        )
+        expected = textwrap.dedent(
+            """\
+            RUN /opt/python/3.12.11/bin/python -m venv /opt/python/jupyter && \\
+                /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \\
+                /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade --break-system-packages \\
+                    jupyterlab \\
+                    notebook \\
+                    pwb_jupyterlab && \\
+                bash -O failglob -c 'rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests' && \\
+                bash -O failglob -c 'rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock' && \\
+                ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter
+            """
+        )
+        rendered = environment_with_macros.from_string(template).render()
+        assert rendered == expected
+
+    def test_run_install_jupyterlab_workbench_passes_args_through(self, environment_with_macros):
+        template = textwrap.dedent(
+            """\
+            {%- import "python.j2" as python -%}
+            {{ python.run_install_jupyterlab_workbench("3.12.11", jupyter_venv_name="lab", jupyterlab_version_pin="<5", strip_tests=False, strip_staging=False) }}
+            """
+        )
+        expected = textwrap.dedent(
+            """\
+            RUN /opt/python/3.12.11/bin/python -m venv /opt/python/lab && \\
+                /opt/python/lab/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \\
+                /opt/python/lab/bin/pip install --no-cache-dir --upgrade --break-system-packages \\
+                    jupyterlab<5 \\
+                    notebook \\
+                    pwb_jupyterlab && \\
+                ln -s /opt/python/lab/bin/jupyter /usr/local/bin/jupyter
+            """
+        )
+        rendered = environment_with_macros.from_string(template).render()
+        assert rendered == expected
+
 
 class TestQuartoMacros:
     def test_declare_build_arg_default(self, environment_with_macros):

--- a/posit-bakery/test/config/templating/test_macros.py
+++ b/posit-bakery/test/config/templating/test_macros.py
@@ -1452,12 +1452,13 @@ class TestPythonMacros:
             """\
             /opt/python/3.12.11/bin/python -m venv /opt/python/jupyter && \\
             /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \\
-            /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade --break-system-packages \\
-                jupyterlab \\
+            /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade \\
+                "jupyterlab" \\
                 notebook \\
-                pwb_jupyterlab && \\
-            bash -O failglob -c 'rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests' && \\
-            bash -O failglob -c 'rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock' && \\
+                "pwb_jupyterlab" && \\
+            rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests && \\
+            rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/galata && \\
+            rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock && \\
             ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter
             """
         )
@@ -1475,12 +1476,13 @@ class TestPythonMacros:
             """\
             /opt/python/3.12.11/bin/python -m venv /opt/python/jupyter && \\
             /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \\
-            /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade --break-system-packages \\
-                jupyterlab<5 \\
+            /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade \\
+                "jupyterlab<5" \\
                 notebook \\
-                pwb_jupyterlab<2 && \\
-            bash -O failglob -c 'rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests' && \\
-            bash -O failglob -c 'rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock' && \\
+                "pwb_jupyterlab<2" && \\
+            rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests && \\
+            rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/galata && \\
+            rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock && \\
             ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter
             """
         )
@@ -1498,14 +1500,15 @@ class TestPythonMacros:
             """\
             /opt/python/3.12.11/bin/python -m venv /opt/python/jupyter && \\
             /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \\
-            /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade --break-system-packages \\
-                jupyterlab \\
+            /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade \\
+                "jupyterlab" \\
                 notebook \\
-                pwb_jupyterlab \\
+                "pwb_jupyterlab" \\
                 numpy \\
                 pandas && \\
-            bash -O failglob -c 'rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests' && \\
-            bash -O failglob -c 'rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock' && \\
+            rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests && \\
+            rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/galata && \\
+            rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock && \\
             ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter
             """
         )
@@ -1523,12 +1526,13 @@ class TestPythonMacros:
             """\
             /opt/python/3.12.11/bin/python -m venv /opt/python/lab && \\
             /opt/python/lab/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \\
-            /opt/python/lab/bin/pip install --no-cache-dir --upgrade --break-system-packages \\
-                jupyterlab \\
+            /opt/python/lab/bin/pip install --no-cache-dir --upgrade \\
+                "jupyterlab" \\
                 notebook \\
-                pwb_jupyterlab && \\
-            bash -O failglob -c 'rm -rf /opt/python/lab/lib/python*/site-packages/jupyterlab/tests' && \\
-            bash -O failglob -c 'rm -f /opt/python/lab/lib/python*/site-packages/jupyterlab/staging/yarn.lock' && \\
+                "pwb_jupyterlab" && \\
+            rm -rf /opt/python/lab/lib/python*/site-packages/jupyterlab/tests && \\
+            rm -rf /opt/python/lab/lib/python*/site-packages/jupyterlab/galata && \\
+            rm -f /opt/python/lab/lib/python*/site-packages/jupyterlab/staging/yarn.lock && \\
             ln -s /opt/python/lab/bin/jupyter /usr/local/bin/jupyter
             """
         )
@@ -1545,12 +1549,13 @@ class TestPythonMacros:
                     """\
                     /opt/python/3.12.11/bin/python -m venv /opt/python/jupyter && \\
                     /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \\
-                    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade --break-system-packages \\
-                        jupyterlab \\
+                    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade \\
+                        "jupyterlab" \\
                         notebook \\
-                        pwb_jupyterlab && \\
-                    bash -O failglob -c 'rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests' && \\
-                    bash -O failglob -c 'rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock' && \\
+                        "pwb_jupyterlab" && \\
+                    rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests && \\
+                    rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/galata && \\
+                    rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock && \\
                     ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter
                     """
                 ),
@@ -1563,11 +1568,12 @@ class TestPythonMacros:
                     """\
                     /opt/python/3.12.11/bin/python -m venv /opt/python/jupyter && \\
                     /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \\
-                    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade --break-system-packages \\
-                        jupyterlab \\
+                    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade \\
+                        "jupyterlab" \\
                         notebook \\
-                        pwb_jupyterlab && \\
-                    bash -O failglob -c 'rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests' && \\
+                        "pwb_jupyterlab" && \\
+                    rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests && \\
+                    rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/galata && \\
                     ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter
                     """
                 ),
@@ -1580,11 +1586,11 @@ class TestPythonMacros:
                     """\
                     /opt/python/3.12.11/bin/python -m venv /opt/python/jupyter && \\
                     /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \\
-                    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade --break-system-packages \\
-                        jupyterlab \\
+                    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade \\
+                        "jupyterlab" \\
                         notebook \\
-                        pwb_jupyterlab && \\
-                    bash -O failglob -c 'rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock' && \\
+                        "pwb_jupyterlab" && \\
+                    rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock && \\
                     ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter
                     """
                 ),
@@ -1597,10 +1603,10 @@ class TestPythonMacros:
                     """\
                     /opt/python/3.12.11/bin/python -m venv /opt/python/jupyter && \\
                     /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \\
-                    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade --break-system-packages \\
-                        jupyterlab \\
+                    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade \\
+                        "jupyterlab" \\
                         notebook \\
-                        pwb_jupyterlab && \\
+                        "pwb_jupyterlab" && \\
                     ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter
                     """
                 ),
@@ -1629,12 +1635,13 @@ class TestPythonMacros:
             """\
             RUN /opt/python/3.12.11/bin/python -m venv /opt/python/jupyter && \\
                 /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \\
-                /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade --break-system-packages \\
-                    jupyterlab \\
+                /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade \\
+                    "jupyterlab" \\
                     notebook \\
-                    pwb_jupyterlab && \\
-                bash -O failglob -c 'rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests' && \\
-                bash -O failglob -c 'rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock' && \\
+                    "pwb_jupyterlab" && \\
+                rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests && \\
+                rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/galata && \\
+                rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock && \\
                 ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter
             """
         )
@@ -1652,10 +1659,10 @@ class TestPythonMacros:
             """\
             RUN /opt/python/3.12.11/bin/python -m venv /opt/python/lab && \\
                 /opt/python/lab/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \\
-                /opt/python/lab/bin/pip install --no-cache-dir --upgrade --break-system-packages \\
-                    jupyterlab<5 \\
+                /opt/python/lab/bin/pip install --no-cache-dir --upgrade \\
+                    "jupyterlab<5" \\
                     notebook \\
-                    pwb_jupyterlab && \\
+                    "pwb_jupyterlab" && \\
                 ln -s /opt/python/lab/bin/jupyter /usr/local/bin/jupyter
             """
         )


### PR DESCRIPTION
## Summary

- Adds `install_jupyterlab_workbench` and `run_install_jupyterlab_workbench` macros to `posit-bakery/posit_bakery/config/templating/macros/python.j2`
- Creates a dedicated venv at `/opt/python/{jupyter_venv_name}`, installs `jupyterlab` / `notebook` / `pwb_jupyterlab` into it, and symlinks `jupyter` onto the system PATH
- Supports configurable `jupyter_venv_name`, `jupyterlab_version_pin`, `pwb_jupyterlab_version_pin`, `extra_packages`, and `strip_tests` / `strip_staging` toggles (to remove the jupyterlab tests dir and staging `yarn.lock` post-install)
- Adds tests in `test/config/templating/test_macros.py` covering defaults, version pins, extra packages, custom venv name, the 4-way strip-toggle matrix, and the `RUN` wrapper

## Test plan

- [x] `just test` passes (1329 passed)
- [x] New macro tests (10) pass — verified one correctly fails when the `jupyter_venv_name` plumbing is regressed
- [ ] Wire up a downstream consumer in `images-workbench` (`workbench-session`) and confirm the rendered Dockerfile builds and `jupyter --version` works in the resulting image

🤖 Generated with [Claude Code](https://claude.com/claude-code)