### PR TITLE
Use POSIT_PLATFORM secrets for app token

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -18,8 +18,8 @@ jobs:
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v3.0.0
         id: app-token
         with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.POSIT_PLATFORM_APP_ID }}
+          private-key: ${{ secrets.POSIT_PLATFORM_PEM }}
 
       - name: Add to Platform Carbon Project
         uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e  # v1.0.2


### PR DESCRIPTION
## Summary

Replace the generic `APP_ID` / `APP_PRIVATE_KEY` secrets with the app-specific
`POSIT_PLATFORM_APP_ID` / `POSIT_PLATFORM_PEM` secrets provisioned by
[rstudio/github-iac](https://github.com/rstudio/github-iac).

The `posit-platform` GitHub App is already installed on this repo and its
credentials are already shared with it via the Pulumi config, so this is a
drop-in rename with no infrastructure changes required.

## Test plan

- [ ] Trigger the issue automation workflow (open a test issue) and confirm
      the run still succeeds
- [ ] Confirm the bot actor on the resulting label / project-add events is
      still `posit-platform[bot]`