### PR TITLE
Install Quarto from the Posit Open apt repo via quarto.install()

### DIFF
--- a/posit-bakery/docs/templating.qmd
+++ b/posit-bakery/docs/templating.qmd
@@ -75,19 +75,25 @@ To wrap `setup()` in a Docker RUN statement, use:
 {{ apt.run_setup() }}
 ```
 
-#### Setup Posit Cloudsmith Apt Repositories
-Renders commands to set up Posit Cloudsmith apt repositories. Requires `curl` to be installed prior to execution.
+#### Setup Posit Apt Repository
+Renders commands to set up a Posit apt repository. Requires `curl` to be installed prior to execution.
 
-**NOTE:** This macro is included in `apt.setup()` or `apt.run_setup()`, so it does not need to be called separately unless `apt.setup()` is not used.
+Available repositories:
+
+- `"pro"` — Posit professional products (Connect, Workbench, Package Manager)
+- `"open"` — Open-source Posit packages (Quarto, RStudio)
+
+**NOTE:** This macro is called by `apt.setup()` and `quarto.install()`, so it does not typically need to be called separately.
 
 ```jinja2
-{{ apt.setup_posit_cloudsmith() }}
+{{ apt.setup_posit_repo("pro") }}
+{{ apt.setup_posit_repo("open") }}
 ```
 
-To wrap `setup_posit_cloudsmith()` in a Docker RUN statement, use:
+To wrap in a Docker RUN statement:
 
 ```jinja2
-{{ apt.run_setup_posit_cloudsmith() }}
+{{ apt.run_setup_posit_repo("pro") }}
 ```
 
 #### Apt Clean Commands
@@ -155,19 +161,22 @@ To wrap `setup()` in a Docker RUN statement, use:
 {{ dnf.run_setup() }}
 ```
 
-#### Setup Posit Cloudsmith DNF Repositories
-Renders commands to set up Posit Cloudsmith DNF repositories. Requires `curl` to be installed prior to execution.
+#### Setup Posit RPM Repository
+Renders commands to set up a Posit rpm repository. Requires `curl` to be installed prior to execution.
 
-**NOTE:** This macro is included in `dnf.setup()` or `dnf.run_setup()`, so it does not need to be called separately unless `dnf.setup()` is not used.
+Available repositories: `"pro"` and `"open"` (same as the apt variant).
+
+**NOTE:** This macro is called by `dnf.setup()`, so it does not typically need to be called separately.
 
 ```jinja2
-{{ dnf.setup_posit_cloudsmith() }}
+{{ dnf.setup_posit_repo("pro") }}
+{{ dnf.setup_posit_repo("open") }}
 ```
 
-To wrap `setup_posit_cloudsmith()` in a Docker RUN statement, use:
+To wrap in a Docker RUN statement:
 
 ```jinja2
-{{ dnf.run_setup_posit_cloudsmith() }}
+{{ dnf.run_setup_posit_repo("pro") }}
 ```
 
 #### DNF Clean Command
@@ -408,9 +417,11 @@ To use the Quarto macros, import the `quarto` module in your Jinja2 template:
 ```
 
 #### Install Quarto
-Returns the command to download and install a Quarto version. Requires `curl` to be installed prior to execution.
+Returns the command to install a Quarto version from the [Posit Open repository](https://dl.posit.co/public/open/). Requires `curl` to be installed prior to execution so the repository can be added via the appropriate setup script.
 
-The macro takes an optional `with_tinytex` argument to include the command to install TinyTeX using the installed Quarto binary. Default is `False`.
+The `quarto` deb installs the binary to `/opt/quarto/bin/quarto` and symlinks it into `/usr/local/bin/quarto` via its postinst script, so no explicit symlink step is required. After installing, the macro runs `apt-mark hold quarto` to pin the package at the installed version so `apt upgrade` inside the container cannot drift off the pinned version.
+
+The macro takes an optional `with_tinytex` argument to include the command to install TinyTeX using the installed Quarto binary. Default is `False`. When `True`, `xz-utils` is also installed because the TinyTeX release tarball is `.tar.xz` and is not in the Ubuntu base image.
 
 If `with_tinytex` is `True`, `tinytex_update_path` can be set to `True` to append the `--update-path` option to the install command. This will add TinyTeX binaries to the system `PATH`.
 
@@ -418,44 +429,44 @@ If `with_tinytex` is `True`, `tinytex_update_path` can be set to `True` to appen
 {{ quarto.install("1.8.24", with_tinytex=True, tinytex_update_path=True) }}
 ```
 
-To install multiple Quarto versions and wrap them in `RUN` statements, use:
-
-```jinja2
-{{ quarto.run_install(["1.8.24", "1.9.0"], with_tinytex=True) }}
-```
-
-Usually, this should be called with `Dependencies.quarto` to dynamically specify versions based on the image's `dependencyConstraints` field:
+To wrap the install in a `RUN` statement, use `run_install`. Only a single version is supported — Quarto installs to a flat `/opt/quarto/` directory and is pinned via `apt-mark hold` (Debian) or `dnf versionlock` (RHEL).
 
 ```jinja2
 {{ quarto.run_install(Dependencies.quarto, with_tinytex=True) }}
 ```
 
-#### Get Version Directory
-Returns the expected directory for an installed Quarto version.
+For RHEL-based images, pass `os_family="rhel"`:
 
 ```jinja2
-{{ quarto.get_version_directory("1.8.24") }}
+{{ quarto.run_install(Dependencies.quarto, with_tinytex=True, os_family="rhel") }}
+```
+
+#### Get Directory
+Returns the Quarto install directory (`/opt/quarto`). The `version` parameter is accepted for backward compatibility but is ignored.
+
+```jinja2
+{{ quarto.get_directory("1.9.37") }}
 ```
 
 #### Install TinyTeX
 Returns the command to install TinyTeX using a given Quarto binary.
 
-This command takes a full path to the Quarto binary, which can be constructed using `quarto.get_version_directory()`. Workbench manages its own installation of Quarto and thus must specify its own full path to the Quarto binary.
+This command takes a full path to the Quarto binary. For Quarto installed via `quarto.install()`, the binary is at `/opt/quarto/bin/quarto`. Workbench manages its own installation of Quarto and thus must specify its own full path to the Quarto binary.
 
 If `update_path` is `True`, the command will have `--update-path` appended to add TinyTeX binaries to the system `PATH`. Default is `False`.
 
 ```jinja2
-{{ quarto.install_tinytex_command(quarto.get_version_directory("1.8.24"), update_path=True) }}
+{{ quarto.install_tinytex_command("/opt/quarto/bin/quarto", update_path=True) }}
 ```
 
 #### Create Symlinks
-Creates a symlink to a Quarto version directory.
+Creates a symlink to the Quarto install directory. The `version` parameter is ignored and retained for backward compatibility.
 
 ```jinja2
 {{ quarto.symlink_version(version="1.8.24", target="/opt/quarto/default") }}
 ```
 
-Creates a symlink to a Quarto binary by name.
+Creates a symlink to a Quarto binary by name. **NOTE:** The `quarto` deb already symlinks the `quarto` binary into `/usr/local/bin` via its postinst script, so this macro is typically unnecessary.
 
 ```jinja2
 {{ quarto.symlink_binary(version="1.8.24", bin_name="quarto", target="/usr/local/bin/quarto") }}

--- a/posit-bakery/posit_bakery/config/dependencies/quarto.py
+++ b/posit-bakery/posit_bakery/config/dependencies/quarto.py
@@ -1,7 +1,7 @@
 import abc
 from typing import Annotated, Literal, ClassVar
 
-from pydantic import ConfigDict, Field
+from pydantic import ConfigDict, Field, field_validator
 from ruamel.yaml import YAML
 
 from posit_bakery.config.shared import BakeryYAMLModel
@@ -68,7 +68,22 @@ class QuartoDependency(BakeryYAMLModel, abc.ABC):
 
 
 class QuartoDependencyVersions(DependencyVersions, QuartoDependency):
-    """Class for specifying a list of Quarto versions."""
+    """Class for specifying a list of Quarto versions.
+
+    Only a single version is supported because the quarto deb package
+    installs to a flat /opt/quarto/ directory with no version scoping.
+    """
+
+    @field_validator("versions", mode="after")
+    @classmethod
+    def validate_single_version(cls, versions: list[str]) -> list[str]:
+        if len(versions) > 1:
+            raise ValueError(
+                f"Only one Quarto version may be specified (got {len(versions)}). "
+                "The quarto apt package installs to a single /opt/quarto/ directory "
+                "and cannot coexist with other versions."
+            )
+        return versions
 
 
 class QuartoDependencyConstraint(DependencyConstraint, QuartoDependency):

--- a/posit-bakery/posit_bakery/config/templating/macros/apt.j2
+++ b/posit-bakery/posit_bakery/config/templating/macros/apt.j2
@@ -3,24 +3,32 @@
 {# Global options for apt-get commands #}
 {%- set global_options = "-yqq" -%}
 
-{# Setup command for Posit Cloudsmith apt repositories.
+{# Setup command for a Posit apt repository.
 
-:param codename: Override the OS codename used by the Cloudsmith setup script. Useful when
+Available repositories:
+  - "pro" — Posit professional products (Connect, Workbench, Package Manager)
+  - "open" — Open-source Posit packages (Quarto, RStudio)
+
+:param repo: The repository name ("pro" or "open").
+:param codename: Override the OS codename used by the setup script. Useful when
     Posit packages are not yet published for the current OS (e.g., using noble packages on
     resolute). When set, the codename is passed as an environment variable to the script
     per the Cloudsmith docs.
 #}
-{% macro setup_posit_cloudsmith(codename = None) -%}
+{% macro setup_posit_repo(repo, codename = None) -%}
+{%- if repo not in ("pro", "open") -%}
+{{ raise("Invalid repo '" ~ repo ~ "' passed to apt.setup_posit_repo(). Must be 'pro' or 'open'.") }}
+{%- endif -%}
 {%- if codename -%}
-codename={{ codename }} bash -c "$(curl -1fsSL 'https://dl.posit.co/public/pro/setup.deb.sh')"
+codename={{ codename }} bash -c "$(curl -1fsSL 'https://dl.posit.co/public/{{ repo }}/setup.deb.sh')"
 {%- else -%}
-bash -c "$(curl -1fsSL 'https://dl.posit.co/public/pro/setup.deb.sh')"
+bash -c "$(curl -1fsSL 'https://dl.posit.co/public/{{ repo }}/setup.deb.sh')"
 {%- endif -%}
 {%- endmacro %}
 
-{# The setup_posit_cloudsmith() commands wrapped with a Docker RUN statement. #}
-{% macro run_setup_posit_cloudsmith(codename = None) -%}
-RUN {{ setup_posit_cloudsmith(codename) | indent(4) }}
+{# The setup_posit_repo() command wrapped with a Docker RUN statement. #}
+{% macro run_setup_posit_repo(repo, codename = None) -%}
+RUN {{ setup_posit_repo(repo, codename) | indent(4) }}
 {%- endmacro %}
 
 {# Commands for cleaning and removing the apt cache between layers #}
@@ -133,24 +141,33 @@ apt-get update {{ global_options }} && \
 RUN {{ install(packages, files) | indent(4) }}
 {%- endmacro %}
 
-{# Commands for update_upgrade(), setup_posit_cloudsmith(), and installation of curl, ca-certificates, gnupg, and tar.
+{# Commands for update_upgrade() and installation of curl, ca-certificates, gnupg, and tar,
+optionally adding the Posit Pro and/or Open apt repositories.
 
 :param clean: Whether to clean the apt cache after installation. Defaults to True.
 :param codename: Override the OS codename for the Cloudsmith setup script.
+:param pro_repo: Whether to add the Posit Pro apt repository. Defaults to True.
+:param open_repo: Whether to add the Posit Open apt repository. Defaults to False.
 #}
-{% macro setup(clean = True, codename = None) -%}
+{% macro setup(clean = True, codename = None, pro_repo = True, open_repo = False) -%}
 {{ update_upgrade(False) }} && \
 apt-get install -yqq --no-install-recommends \
     curl \
     ca-certificates \
     gnupg \
-    tar && \
-{{ setup_posit_cloudsmith(codename) }}{% if clean %} && \
+    tar
+{%- if pro_repo %} && \
+{{ setup_posit_repo("pro", codename) }}
+{%- endif %}
+{%- if open_repo %} && \
+{{ setup_posit_repo("open", codename) }}
+{%- endif %}
+{%- if clean %} && \
 {{ clean_command() }}
 {%- endif %}
 {%- endmacro %}
 
 {# The setup() commands wrapped with a Docker RUN statement. #}
-{% macro run_setup(codename = None) -%}
-RUN {{ setup(codename=codename) | indent(4) }}
+{% macro run_setup(codename = None, pro_repo = True, open_repo = False) -%}
+RUN {{ setup(codename=codename, pro_repo=pro_repo, open_repo=open_repo) | indent(4) }}
 {%- endmacro %}

--- a/posit-bakery/posit_bakery/config/templating/macros/dnf.j2
+++ b/posit-bakery/posit_bakery/config/templating/macros/dnf.j2
@@ -8,14 +8,24 @@
 dnf clean all {{ global_options }}
 {%- endmacro %}
 
-{# Setup command for Posit Cloudsmith apt repositories #}
-{% macro setup_posit_cloudsmith() -%}
-bash -c "$(curl -1fsSL 'https://dl.posit.co/public/pro/setup.rpm.sh')"
+{# Setup command for a Posit rpm repository.
+
+Available repositories:
+  - "pro" — Posit professional products (Connect, Workbench, Package Manager)
+  - "open" — Open-source Posit packages (Quarto, RStudio)
+
+:param repo: The repository name ("pro" or "open").
+#}
+{% macro setup_posit_repo(repo) -%}
+{%- if repo not in ("pro", "open") -%}
+{{ raise("Invalid repo '" ~ repo ~ "' passed to dnf.setup_posit_repo(). Must be 'pro' or 'open'.") }}
+{%- endif -%}
+bash -c "$(curl -1fsSL 'https://dl.posit.co/public/{{ repo }}/setup.rpm.sh')"
 {%- endmacro %}
 
-{# The setup_posit_cloudsmith() commands wrapped with a Docker RUN statement. #}
-{% macro run_setup_posit_cloudsmith() -%}
-RUN {{ setup_posit_cloudsmith() | indent(4) }}
+{# The setup_posit_repo() command wrapped with a Docker RUN statement. #}
+{% macro run_setup_posit_repo(repo) -%}
+RUN {{ setup_posit_repo(repo) | indent(4) }}
 {%- endmacro %}
 
 {# Commands for updating and upgrading dnf system packages
@@ -106,24 +116,33 @@ RUN {{ install(packages, files) | indent(4) }}
 {%- endmacro %}
 
 {# Commands to perform an initial setup of the dnf package manager, including upgrading existing packages and installing
-essential packages like curl, ca-certificates, gnupg, and tar.
+essential packages like curl, ca-certificates, gnupg, and tar, optionally adding the Posit Pro and/or Open rpm
+repositories.
 
 :param clean: Whether to clean the dnf cache after installation. Defaults to True.
+:param pro_repo: Whether to add the Posit Pro rpm repository. Defaults to True.
+:param open_repo: Whether to add the Posit Open rpm repository. Defaults to False.
 #}
-{% macro setup(clean = True) -%}
+{% macro setup(clean = True, pro_repo = True, open_repo = False) -%}
 dnf upgrade {{ global_options }} && \
 dnf install {{ global_options }} --allowerasing \
     curl \
     ca-certificates \
     findutils \
     gnupg \
-    tar && \
-{{ setup_posit_cloudsmith() }}{% if clean %} && \
+    tar
+{%- if pro_repo %} && \
+{{ setup_posit_repo("pro") }}
+{%- endif %}
+{%- if open_repo %} && \
+{{ setup_posit_repo("open") }}
+{%- endif %}
+{%- if clean %} && \
 {{ clean_command() }}
 {%- endif %}
 {%- endmacro %}
 
 {# The setup() commands wrapped with a Docker RUN statement. #}
-{% macro run_setup() -%}
-RUN {{ setup() | indent(4) }}
+{% macro run_setup(pro_repo = True, open_repo = False) -%}
+RUN {{ setup(pro_repo=pro_repo, open_repo=open_repo) | indent(4) }}
 {%- endmacro %}

--- a/posit-bakery/posit_bakery/config/templating/macros/quarto.j2
+++ b/posit-bakery/posit_bakery/config/templating/macros/quarto.j2
@@ -1,5 +1,8 @@
 {# Macros for installing and managing Quarto #}
 
+{%- import "apt.j2" as apt -%}
+{%- import "dnf.j2" as dnf -%}
+
 {%- set _BUILD_ARG_NAME = "QUARTO_VERSION" -%}
 
 {# Declare a generic build argument for a Quarto version #}
@@ -12,12 +15,21 @@ ARG {{ name }}{% if default %}={{ default }}{% endif %}
 ${{ name }}
 {%- endmacro %}
 
-{# The directory for an installed version of Quarto
+{# The directory where Quarto is installed.
 
-:param version: The Quarto version, e.g. "1.8.24"
+The `quarto` deb from the Posit Open apt repository installs to `/opt/quarto`
+with no version-scoped subdirectory. The `version` parameter is accepted for
+backward compatibility but is ignored.
+
+:param version: Ignored. Retained for backward compatibility.
 #}
-{% macro get_version_directory(version) -%}
-/opt/quarto/{{ version }}
+{% macro get_directory(version = None) -%}
+/opt/quarto
+{%- endmacro %}
+
+{# Backward-compatible alias for get_directory(). #}
+{% macro get_version_directory(version = None) -%}
+{{ get_directory(version) }}
 {%- endmacro %}
 
 {# The --mount option for the optional GitHub token build secret consumed by
@@ -44,51 +56,94 @@ ${{ name }}
 GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" {% if home_path %}HOME="{{ home_path }}" {% endif %}{{ quarto_binary }} install tinytex --no-prompt --quiet{% if update_path %} --update-path{% endif %}
 {%- endmacro %}
 
-{# Command to download and install a specific version of Quarto, optionally installing TinyTeX as well
+{# Command to install a specific version of Quarto from the Posit Open
+repository, optionally installing TinyTeX as well.
 
-:param version: The Quarto version to install, e.g. "1.8.24"
+On Debian-like systems, installs via apt from the Open deb repo. The `quarto`
+deb installs to `/opt/quarto/bin/quarto` and symlinks into `/usr/local/bin/`
+via its postinst script.
+
+On RHEL-like systems, installs via dnf from the Open rpm repo.
+
+Requires `curl` to be installed prior to execution so that the Posit Open
+repository can be added via its setup script.
+
+When `with_tinytex` is `True`, `xz-utils` (apt) or `xz` (dnf) is also
+installed because the TinyTeX release tarball is `.tar.xz`.
+
+:param version: The Quarto version to install, e.g. "1.9.37"
 :param with_tinytex: Whether to install TinyTeX along with Quarto. Defaults to False.
 :param tinytex_update_path: Adds --update-path to the TinyTeX install command to add TinyTeX binaries to the PATH. Defaults to False.
 :param tinytex_home_path: An optional path to set the HOME environment variable for the TinyTeX install command, which controls where TinyTeX is installed. If not provided, TinyTeX will be installed to the default location under the current user's home directory.
+:param codename: Override the OS codename for the Open repo setup script.
+:param os_family: The OS family ("debian" or "rhel"). Defaults to "debian".
 #}
-{% macro install(version, with_tinytex = False, tinytex_update_path = False, tinytex_home_path = None) -%}
-mkdir -p {{ get_version_directory(version) }} && \
-curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v{{ version | trim }}/quarto-{{ version | trim }}-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "{{ get_version_directory(version | trim) }}" --strip-components=1{% if with_tinytex %} && \
-{{ install_tinytex_command(get_version_directory(version | trim) + "/bin/quarto", tinytex_update_path, tinytex_home_path) }}{% endif %}
+{% macro install(version, with_tinytex = False, tinytex_update_path = False, tinytex_home_path = None, codename = None, os_family = "debian") -%}
+{%- if os_family == "debian" -%}
+{{ apt.setup_posit_repo("open", codename) }} && \
+apt-get install -yqq --no-install-recommends \
+    quarto={{ version | trim }}{% if with_tinytex %} \
+    xz-utils{% endif %} && \
+apt-mark hold quarto && \
+{{ apt.clean_command() }}{% if with_tinytex %} && \
+{{ install_tinytex_command("/opt/quarto/bin/quarto", tinytex_update_path, tinytex_home_path) }}{% endif %}
+{%- elif os_family == "rhel" -%}
+{{ dnf.setup_posit_repo("open") }} && \
+dnf install -yq \
+    quarto-{{ version | trim }} \
+    'dnf-command(versionlock)'{% if with_tinytex %} \
+    xz{% endif %} && \
+dnf versionlock add quarto && \
+{{ dnf.clean_command() }}{% if with_tinytex %} && \
+{{ install_tinytex_command("/opt/quarto/bin/quarto", tinytex_update_path, tinytex_home_path) }}{% endif %}
+{%- else -%}
+{{ raise("Unsupported os_family '" ~ os_family ~ "' in quarto.install(). Must be 'debian' or 'rhel'.") }}
+{%- endif %}
 {%- endmacro %}
 
-{# Installs one or more versions of Quarto as separate RUN statements
+{# Installs Quarto as a RUN statement.
 
-:param versions: A list of Quarto versions or a comma separated string of Quarto versions to install
-:param with_tinytex: Whether to install TinyTeX along with each Quarto version. Defaults to False.
+Quarto installs to a flat `/opt/quarto/` directory with no version scoping,
+so only a single version is supported.
+
+:param version: A Quarto version string, or a single-element list (e.g. Dependencies.quarto).
+:param with_tinytex: Whether to install TinyTeX along with Quarto. Defaults to False.
 :param tinytex_home_path: An optional path to set the HOME environment variable for the TinyTeX install command, which controls where TinyTeX is installed. If not provided, TinyTeX will be installed to the default location under the current user's home directory.
+:param codename: Override the OS codename for the Open repo setup script.
+:param os_family: The OS family ("debian" or "rhel"). Defaults to "debian".
 #}
-{% macro run_install(versions, with_tinytex = False, tinytex_update_path = False, tinytex_home_path = None) -%}
-{%- if versions is string -%}
-{%- set versions = versions | split(",") -%}
+{% macro run_install(version, with_tinytex = False, tinytex_update_path = False, tinytex_home_path = None, codename = None, os_family = "debian") -%}
+{%- if version is not string -%}
+{%- if version | length != 1 -%}
+{{ raise("Only one Quarto version may be passed to quarto.run_install() (got " ~ version | length ~ "). Quarto installs to a flat /opt/quarto/ directory and cannot coexist with other versions.") }}
 {%- endif -%}
-{% for version in versions -%}
-RUN {% if with_tinytex %}{{ github_token_secret_mount() }} {% endif %}{{ install(version, with_tinytex, tinytex_update_path, tinytex_home_path) | indent(4) }}
-{%- if not loop.last %}{# Handles whitespace for next RUN line if present #}
-{% endif %}
-{%- endfor %}
+{%- set version = version[0] -%}
+{%- endif -%}
+RUN {% if with_tinytex %}{{ github_token_secret_mount() }} {% endif %}{{ install(version, with_tinytex, tinytex_update_path, tinytex_home_path, codename, os_family) | indent(4) }}
 {%- endmacro %}
 
-{# Symlinks a Quarto install to the target directory
+{# Symlinks the Quarto install directory to the target path.
 
-:param version: The Quarto version to symlink, e.g. "1.8.24"
+Since the `quarto` deb installs to a flat `/opt/quarto/`, the `version`
+parameter is ignored. Retained for backward compatibility.
+
+:param version: Ignored. Retained for backward compatibility.
 :param target: The target path for the symlink, e.g. "/opt/quarto/default"
 #}
 {% macro symlink_version(version, target) -%}
-ln -s {{ get_version_directory(version) }} {{ target }}
+ln -s {{ get_directory() }} {{ target }}
 {%- endmacro %}
 
-{# Symlinks a specific Quarto binary to the target path
+{# Symlinks a specific Quarto binary to the target path.
 
-:param version: The Quarto version to symlink the binary from, e.g. "1.8.24"
+The `quarto` deb already symlinks the `quarto` binary into `/usr/local/bin`
+via its postinst script, so this macro is typically unnecessary. Retained
+for other binaries that may be shipped under `/opt/quarto/bin/`.
+
+:param version: Ignored. Retained for backward compatibility.
 :param bin_name: The name of the binary to symlink, e.g. "quarto"
 :param target: The target path for the symlink, e.g. "/usr/local/bin/quarto"
 #}
 {% macro symlink_binary(version, bin_name, target) -%}
-ln -s {{ get_version_directory(version) }}/bin/{{ bin_name }} {{ target }}
+ln -s {{ get_directory() }}/bin/{{ bin_name }} {{ target }}
 {%- endmacro %}

--- a/posit-bakery/test/cli/test_common.py
+++ b/posit-bakery/test/cli/test_common.py
@@ -343,13 +343,11 @@ class TestParseDependencyVersions:
         assert isinstance(result, RDependencyVersions)
         assert result.versions == ["4.3.3", "4.4.1"]
 
-    def test_quarto_versions_list(self):
-        """Test parsing a Quarto dependency with a list of versions"""
+    def test_quarto_versions_list_rejects_multiple(self):
+        """Test that parsing a Quarto dependency with multiple versions raises an error"""
         input_str = '{"dependency": "quarto", "versions": ["1.4.550", "1.5.23"]}'
-        result = parse_dependency_versions(input_str)
-        assert isinstance(result, QuartoDependencyVersions)
-        assert result.dependency == "quarto"
-        assert result.versions == ["1.4.550", "1.5.23"]
+        with pytest.raises(ValueError, match="Only one Quarto version may be specified"):
+            parse_dependency_versions(input_str)
 
     def test_quarto_single_version(self):
         """Test parsing a Quarto dependency with a single version"""

--- a/posit-bakery/test/config/dependencies/test_dependency.py
+++ b/posit-bakery/test/config/dependencies/test_dependency.py
@@ -159,11 +159,6 @@ class TestDependencyVersions:
                 id="quarto_single_version",
             ),
             pytest.param(
-                QuartoDependencyVersions(dependency="quarto", versions=["1.7.34", "1.6.43"]),
-                {"dependency": "quarto", "versions": ["1.7.34", "1.6.43"]},
-                id="quarto_multiple_versions",
-            ),
-            pytest.param(
                 PositronDependencyVersions(dependency="positron", versions=["2026.03.0-212"]),
                 {"dependency": "positron", "version": "2026.03.0-212"},
                 id="positron_single_version",
@@ -179,6 +174,16 @@ class TestDependencyVersions:
         """Test that version serialization works as expected."""
         serialized = versions_obj.model_dump(exclude_unset=True, exclude_defaults=True, exclude_none=True)
         assert serialized == expected_dict
+
+
+class TestQuartoSingleVersionConstraint:
+    def test_rejects_multiple_versions(self):
+        with pytest.raises(ValueError, match="Only one Quarto version may be specified"):
+            QuartoDependencyVersions(dependency="quarto", versions=["1.7.34", "1.6.43"])
+
+    def test_accepts_single_version(self):
+        dep = QuartoDependencyVersions(dependency="quarto", versions=["1.7.34"])
+        assert dep.versions == ["1.7.34"]
 
 
 class TestGetDependencyVersionsClass:

--- a/posit-bakery/test/config/image/test_matrix.py
+++ b/posit-bakery/test/config/image/test_matrix.py
@@ -51,7 +51,7 @@ from posit_bakery.config.image.matrix import generate_default_name_pattern, Imag
                     ),
                     QuartoDependencyVersions(
                         dependency="quarto",
-                        versions=["1.2", "1.3"],
+                        versions=["1.2"],
                     ),
                 ],
             },

--- a/posit-bakery/test/config/templating/test_macros.py
+++ b/posit-bakery/test/config/templating/test_macros.py
@@ -35,26 +35,24 @@ def test_import_all_macros_no_errors(environment_with_macros):
 
 
 class TestAptMacros:
-    def test_setup_posit_cloudsmith(self, environment_with_macros):
-        template = textwrap.dedent(
-            """\
-            {%- import "apt.j2" as apt -%}
-            {{ apt.setup_posit_cloudsmith() }}
-            """
-        )
-        expected = textwrap.dedent(
-            """\
-            bash -c "$(curl -1fsSL 'https://dl.posit.co/public/pro/setup.deb.sh')"
-            """
-        )
+    @pytest.mark.parametrize(
+        "repo,expected_url",
+        [
+            pytest.param("pro", "https://dl.posit.co/public/pro/setup.deb.sh", id="pro"),
+            pytest.param("open", "https://dl.posit.co/public/open/setup.deb.sh", id="open"),
+        ],
+    )
+    def test_setup_posit_repo(self, environment_with_macros, repo, expected_url):
+        template = f'{{%- import "apt.j2" as apt -%}}\n{{{{ apt.setup_posit_repo("{repo}") }}}}\n'
+        expected = f"bash -c \"$(curl -1fsSL '{expected_url}')\"\n"
         rendered = environment_with_macros.from_string(template).render()
         assert rendered == expected
 
-    def test_setup_posit_cloudsmith_with_codename(self, environment_with_macros):
+    def test_setup_posit_repo_with_codename(self, environment_with_macros):
         template = textwrap.dedent(
             """\
             {%- import "apt.j2" as apt -%}
-            {{ apt.setup_posit_cloudsmith(codename="noble") }}
+            {{ apt.setup_posit_repo("pro", codename="noble") }}
             """
         )
         expected = textwrap.dedent(
@@ -65,26 +63,24 @@ class TestAptMacros:
         rendered = environment_with_macros.from_string(template).render()
         assert rendered == expected
 
-    def test_run_setup_posit_cloudsmith(self, environment_with_macros):
-        template = textwrap.dedent(
-            """\
-            {%- import "apt.j2" as apt -%}
-            {{ apt.run_setup_posit_cloudsmith() }}
-            """
-        )
-        expected = textwrap.dedent(
-            """\
-            RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/pro/setup.deb.sh')"
-            """
-        )
+    @pytest.mark.parametrize(
+        "repo,expected_url",
+        [
+            pytest.param("pro", "https://dl.posit.co/public/pro/setup.deb.sh", id="pro"),
+            pytest.param("open", "https://dl.posit.co/public/open/setup.deb.sh", id="open"),
+        ],
+    )
+    def test_run_setup_posit_repo(self, environment_with_macros, repo, expected_url):
+        template = f'{{%- import "apt.j2" as apt -%}}\n{{{{ apt.run_setup_posit_repo("{repo}") }}}}\n'
+        expected = f"RUN bash -c \"$(curl -1fsSL '{expected_url}')\"\n"
         rendered = environment_with_macros.from_string(template).render()
         assert rendered == expected
 
-    def test_run_setup_posit_cloudsmith_with_codename(self, environment_with_macros):
+    def test_run_setup_posit_repo_with_codename(self, environment_with_macros):
         template = textwrap.dedent(
             """\
             {%- import "apt.j2" as apt -%}
-            {{ apt.run_setup_posit_cloudsmith(codename="noble") }}
+            {{ apt.run_setup_posit_repo("pro", codename="noble") }}
             """
         )
         expected = textwrap.dedent(
@@ -94,6 +90,11 @@ class TestAptMacros:
         )
         rendered = environment_with_macros.from_string(template).render()
         assert rendered == expected
+
+    def test_setup_posit_repo_rejects_invalid(self, environment_with_macros):
+        template = '{%- import "apt.j2" as apt -%}\n{{ apt.setup_posit_repo("foo") }}'
+        with pytest.raises(Exception, match="Invalid repo"):
+            environment_with_macros.from_string(template).render()
 
     def test_clean_command(self, environment_with_macros):
         template = textwrap.dedent(
@@ -569,10 +570,12 @@ class TestAptMacros:
         assert rendered == expected
 
     @pytest.mark.parametrize(
-        "clean,expected",
+        "clean,pro_repo,open_repo,expected",
         [
             pytest.param(
                 True,
+                True,
+                False,
                 textwrap.dedent(
                     """\
                     apt-get update -yqq --fix-missing && \\
@@ -589,9 +592,11 @@ class TestAptMacros:
                     rm -rf /var/lib/apt/lists/*
                     """
                 ),
-                id="clean",
+                id="pro-only-clean",
             ),
             pytest.param(
+                False,
+                True,
                 False,
                 textwrap.dedent(
                     """\
@@ -607,12 +612,81 @@ class TestAptMacros:
                     bash -c "$(curl -1fsSL 'https://dl.posit.co/public/pro/setup.deb.sh')"
                     """
                 ),
-                id="noclean",
+                id="pro-only-noclean",
+            ),
+            pytest.param(
+                True,
+                True,
+                True,
+                textwrap.dedent(
+                    """\
+                    apt-get update -yqq --fix-missing && \\
+                    apt-get upgrade -yqq && \\
+                    apt-get dist-upgrade -yqq && \\
+                    apt-get autoremove -yqq --purge && \\
+                    apt-get install -yqq --no-install-recommends \\
+                        curl \\
+                        ca-certificates \\
+                        gnupg \\
+                        tar && \\
+                    bash -c "$(curl -1fsSL 'https://dl.posit.co/public/pro/setup.deb.sh')" && \\
+                    bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \\
+                    apt-get clean -yqq && \\
+                    rm -rf /var/lib/apt/lists/*
+                    """
+                ),
+                id="both-repos-clean",
+            ),
+            pytest.param(
+                True,
+                False,
+                True,
+                textwrap.dedent(
+                    """\
+                    apt-get update -yqq --fix-missing && \\
+                    apt-get upgrade -yqq && \\
+                    apt-get dist-upgrade -yqq && \\
+                    apt-get autoremove -yqq --purge && \\
+                    apt-get install -yqq --no-install-recommends \\
+                        curl \\
+                        ca-certificates \\
+                        gnupg \\
+                        tar && \\
+                    bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \\
+                    apt-get clean -yqq && \\
+                    rm -rf /var/lib/apt/lists/*
+                    """
+                ),
+                id="open-only-clean",
+            ),
+            pytest.param(
+                True,
+                False,
+                False,
+                textwrap.dedent(
+                    """\
+                    apt-get update -yqq --fix-missing && \\
+                    apt-get upgrade -yqq && \\
+                    apt-get dist-upgrade -yqq && \\
+                    apt-get autoremove -yqq --purge && \\
+                    apt-get install -yqq --no-install-recommends \\
+                        curl \\
+                        ca-certificates \\
+                        gnupg \\
+                        tar && \\
+                    apt-get clean -yqq && \\
+                    rm -rf /var/lib/apt/lists/*
+                    """
+                ),
+                id="no-repos-clean",
             ),
         ],
     )
-    def test_setup(self, environment_with_macros, clean, expected):
-        template = '{%- import "apt.j2" as apt -%}\n' + "{{ apt.setup(" + str(clean) + ") }}\n"
+    def test_setup(self, environment_with_macros, clean, pro_repo, open_repo, expected):
+        template = (
+            '{%- import "apt.j2" as apt -%}\n'
+            f"{{{{ apt.setup({clean}, pro_repo={pro_repo}, open_repo={open_repo}) }}}}\n"
+        )
         rendered = environment_with_macros.from_string(template).render()
         assert rendered == expected
 
@@ -631,6 +705,28 @@ class TestAptMacros:
                     gnupg \\
                     tar && \\
                 bash -c "$(curl -1fsSL 'https://dl.posit.co/public/pro/setup.deb.sh')" && \\
+                apt-get clean -yqq && \\
+                rm -rf /var/lib/apt/lists/*
+            """
+        )
+        assert rendered == expected
+
+    def test_run_setup_both_repos(self, environment_with_macros):
+        template = '{%- import "apt.j2" as apt -%}\n{{ apt.run_setup(pro_repo=True, open_repo=True) }}\n'
+        rendered = environment_with_macros.from_string(template).render()
+        expected = textwrap.dedent(
+            """\
+            RUN apt-get update -yqq --fix-missing && \\
+                apt-get upgrade -yqq && \\
+                apt-get dist-upgrade -yqq && \\
+                apt-get autoremove -yqq --purge && \\
+                apt-get install -yqq --no-install-recommends \\
+                    curl \\
+                    ca-certificates \\
+                    gnupg \\
+                    tar && \\
+                bash -c "$(curl -1fsSL 'https://dl.posit.co/public/pro/setup.deb.sh')" && \\
+                bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \\
                 apt-get clean -yqq && \\
                 rm -rf /var/lib/apt/lists/*
             """
@@ -675,35 +771,36 @@ class TestDnfMacros:
         rendered = environment_with_macros.from_string(template).render()
         assert rendered == expected
 
-    def test_setup_posit_cloudsmith(self, environment_with_macros):
-        template = textwrap.dedent(
-            """\
-            {%- import "dnf.j2" as dnf -%}
-            {{ dnf.setup_posit_cloudsmith() }}
-            """
-        )
-        expected = textwrap.dedent(
-            """\
-            bash -c "$(curl -1fsSL 'https://dl.posit.co/public/pro/setup.rpm.sh')"
-            """
-        )
+    @pytest.mark.parametrize(
+        "repo,expected_url",
+        [
+            pytest.param("pro", "https://dl.posit.co/public/pro/setup.rpm.sh", id="pro"),
+            pytest.param("open", "https://dl.posit.co/public/open/setup.rpm.sh", id="open"),
+        ],
+    )
+    def test_setup_posit_repo(self, environment_with_macros, repo, expected_url):
+        template = f'{{%- import "dnf.j2" as dnf -%}}\n{{{{ dnf.setup_posit_repo("{repo}") }}}}\n'
+        expected = f"bash -c \"$(curl -1fsSL '{expected_url}')\"\n"
         rendered = environment_with_macros.from_string(template).render()
         assert rendered == expected
 
-    def test_run_setup_posit_cloudsmith(self, environment_with_macros):
-        template = textwrap.dedent(
-            """\
-            {%- import "dnf.j2" as dnf -%}
-            {{ dnf.run_setup_posit_cloudsmith() }}
-            """
-        )
-        expected = textwrap.dedent(
-            """\
-            RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/pro/setup.rpm.sh')"
-            """
-        )
+    @pytest.mark.parametrize(
+        "repo,expected_url",
+        [
+            pytest.param("pro", "https://dl.posit.co/public/pro/setup.rpm.sh", id="pro"),
+            pytest.param("open", "https://dl.posit.co/public/open/setup.rpm.sh", id="open"),
+        ],
+    )
+    def test_run_setup_posit_repo(self, environment_with_macros, repo, expected_url):
+        template = f'{{%- import "dnf.j2" as dnf -%}}\n{{{{ dnf.run_setup_posit_repo("{repo}") }}}}\n'
+        expected = f"RUN bash -c \"$(curl -1fsSL '{expected_url}')\"\n"
         rendered = environment_with_macros.from_string(template).render()
         assert rendered == expected
+
+    def test_setup_posit_repo_rejects_invalid(self, environment_with_macros):
+        template = '{%- import "dnf.j2" as dnf -%}\n{{ dnf.setup_posit_repo("foo") }}'
+        with pytest.raises(Exception, match="Invalid repo"):
+            environment_with_macros.from_string(template).render()
 
     @pytest.mark.parametrize(
         "clean,expected",
@@ -1799,13 +1896,23 @@ class TestQuartoMacros:
         rendered = environment_with_macros.from_string(template).render()
         assert rendered == expected
 
+    def test_get_directory(self, environment_with_macros):
+        template = textwrap.dedent(
+            """\
+            {%- import "quarto.j2" as quarto -%}
+            {{ quarto.get_directory("1.8.24") }}"""
+        )
+        expected = "/opt/quarto"
+        rendered = environment_with_macros.from_string(template).render()
+        assert rendered == expected
+
     def test_get_version_directory(self, environment_with_macros):
         template = textwrap.dedent(
             """\
             {%- import "quarto.j2" as quarto -%}
             {{ quarto.get_version_directory("1.8.24") }}"""
         )
-        expected = "/opt/quarto/1.8.24"
+        expected = "/opt/quarto"
         rendered = environment_with_macros.from_string(template).render()
         assert rendered == expected
 
@@ -1866,8 +1973,12 @@ class TestQuartoMacros:
                 None,
                 textwrap.dedent(
                     """\
-                    mkdir -p /opt/quarto/1.8.24 && \\
-                    curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1"""
+                    bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \\
+                    apt-get install -yqq --no-install-recommends \\
+                        quarto=1.8.24 && \\
+                    apt-mark hold quarto && \\
+                    apt-get clean -yqq && \\
+                    rm -rf /var/lib/apt/lists/*"""
                 ),
                 id="without-tinytex",
             ),
@@ -1877,8 +1988,12 @@ class TestQuartoMacros:
                 None,
                 textwrap.dedent(
                     """\
-                    mkdir -p /opt/quarto/1.8.24 && \\
-                    curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1"""
+                    bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \\
+                    apt-get install -yqq --no-install-recommends \\
+                        quarto=1.8.24 && \\
+                    apt-mark hold quarto && \\
+                    apt-get clean -yqq && \\
+                    rm -rf /var/lib/apt/lists/*"""
                 ),
                 id="without-tinytex-update-path-no-effect",
             ),
@@ -1888,9 +2003,14 @@ class TestQuartoMacros:
                 None,
                 textwrap.dedent(
                     """\
-                    mkdir -p /opt/quarto/1.8.24 && \\
-                    curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
-                    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet"""
+                    bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \\
+                    apt-get install -yqq --no-install-recommends \\
+                        quarto=1.8.24 \\
+                        xz-utils && \\
+                    apt-mark hold quarto && \\
+                    apt-get clean -yqq && \\
+                    rm -rf /var/lib/apt/lists/* && \\
+                    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet"""
                 ),
                 id="with-tinytex",
             ),
@@ -1900,9 +2020,14 @@ class TestQuartoMacros:
                 None,
                 textwrap.dedent(
                     """\
-                    mkdir -p /opt/quarto/1.8.24 && \\
-                    curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
-                    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path"""
+                    bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \\
+                    apt-get install -yqq --no-install-recommends \\
+                        quarto=1.8.24 \\
+                        xz-utils && \\
+                    apt-mark hold quarto && \\
+                    apt-get clean -yqq && \\
+                    rm -rf /var/lib/apt/lists/* && \\
+                    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path"""
                 ),
                 id="with-tinytex-update-path",
             ),
@@ -1912,9 +2037,14 @@ class TestQuartoMacros:
                 "/root",
                 textwrap.dedent(
                     """\
-                    mkdir -p /opt/quarto/1.8.24 && \\
-                    curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
-                    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet"""
+                    bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \\
+                    apt-get install -yqq --no-install-recommends \\
+                        quarto=1.8.24 \\
+                        xz-utils && \\
+                    apt-mark hold quarto && \\
+                    apt-get clean -yqq && \\
+                    rm -rf /var/lib/apt/lists/* && \\
+                    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet"""
                 ),
                 id="with-tinytex-home-path",
             ),
@@ -1924,9 +2054,14 @@ class TestQuartoMacros:
                 "/root",
                 textwrap.dedent(
                     """\
-                    mkdir -p /opt/quarto/1.8.24 && \\
-                    curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
-                    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path"""
+                    bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \\
+                    apt-get install -yqq --no-install-recommends \\
+                        quarto=1.8.24 \\
+                        xz-utils && \\
+                    apt-mark hold quarto && \\
+                    apt-get clean -yqq && \\
+                    rm -rf /var/lib/apt/lists/* && \\
+                    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path"""
                 ),
                 id="with-tinytex-home-path-update-path",
             ),
@@ -1946,6 +2081,53 @@ class TestQuartoMacros:
         )
         assert rendered == expected
 
+    def test_install_rhel(self, environment_with_macros):
+        template = textwrap.dedent(
+            """\
+            {%- import "quarto.j2" as quarto -%}
+            {{ quarto.install("1.8.24", os_family="rhel") }}"""
+        )
+        expected = textwrap.dedent(
+            """\
+            bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.rpm.sh')" && \\
+            dnf install -yq \\
+                quarto-1.8.24 \\
+                'dnf-command(versionlock)' && \\
+            dnf versionlock add quarto && \\
+            dnf clean all -yq"""
+        )
+        rendered = environment_with_macros.from_string(template).render()
+        assert rendered == expected
+
+    def test_install_rhel_with_tinytex(self, environment_with_macros):
+        template = textwrap.dedent(
+            """\
+            {%- import "quarto.j2" as quarto -%}
+            {{ quarto.install("1.8.24", with_tinytex=True, os_family="rhel") }}"""
+        )
+        expected = textwrap.dedent(
+            """\
+            bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.rpm.sh')" && \\
+            dnf install -yq \\
+                quarto-1.8.24 \\
+                'dnf-command(versionlock)' \\
+                xz && \\
+            dnf versionlock add quarto && \\
+            dnf clean all -yq && \\
+            GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet"""
+        )
+        rendered = environment_with_macros.from_string(template).render()
+        assert rendered == expected
+
+    def test_install_rejects_invalid_os_family(self, environment_with_macros):
+        template = textwrap.dedent(
+            """\
+            {%- import "quarto.j2" as quarto -%}
+            {{ quarto.install("1.8.24", os_family="sles") }}"""
+        )
+        with pytest.raises(Exception, match="Unsupported os_family"):
+            environment_with_macros.from_string(template).render()
+
     @pytest.mark.parametrize(
         "input,expected",
         [
@@ -1953,124 +2135,74 @@ class TestQuartoMacros:
                 (["1.8.24"], False, False, None),
                 textwrap.dedent(
                     """\
-                    RUN mkdir -p /opt/quarto/1.8.24 && \\
-                        curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1"""
+                    RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \\
+                        apt-get install -yqq --no-install-recommends \\
+                            quarto=1.8.24 && \\
+                        apt-mark hold quarto && \\
+                        apt-get clean -yqq && \\
+                        rm -rf /var/lib/apt/lists/*"""
                 ),
                 id="single-version-no-tinytex",
-            ),
-            pytest.param(
-                (["1.8.24", "1.7.8"], False, False, None),
-                textwrap.dedent(
-                    """\
-                    RUN mkdir -p /opt/quarto/1.8.24 && \\
-                        curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1
-                    RUN mkdir -p /opt/quarto/1.7.8 && \\
-                        curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.7.8/quarto-1.7.8-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.7.8" --strip-components=1"""
-                ),
-                id="multiple-versions-no-tinytex",
-            ),
-            pytest.param(
-                ("1.8.24,1.7.8", False, False, None),
-                textwrap.dedent(
-                    """\
-                    RUN mkdir -p /opt/quarto/1.8.24 && \\
-                        curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1
-                    RUN mkdir -p /opt/quarto/1.7.8 && \\
-                        curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.7.8/quarto-1.7.8-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.7.8" --strip-components=1"""
-                ),
-                id="string-versions-no-tinytex",
             ),
             pytest.param(
                 (["1.8.24"], True, False, None),
                 textwrap.dedent(
                     """\
-                    RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.8.24 && \\
-                        curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
-                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet"""
+                    RUN --mount=type=secret,id=github_token,required=false bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \\
+                        apt-get install -yqq --no-install-recommends \\
+                            quarto=1.8.24 \\
+                            xz-utils && \\
+                        apt-mark hold quarto && \\
+                        apt-get clean -yqq && \\
+                        rm -rf /var/lib/apt/lists/* && \\
+                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet"""
                 ),
                 id="single-version-with-tinytex",
-            ),
-            pytest.param(
-                (["1.8.24", "1.7.8"], True, False, None),
-                textwrap.dedent(
-                    """\
-                    RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.8.24 && \\
-                        curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
-                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet
-                    RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.7.8 && \\
-                        curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.7.8/quarto-1.7.8-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.7.8" --strip-components=1 && \\
-                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/1.7.8/bin/quarto install tinytex --no-prompt --quiet"""
-                ),
-                id="multiple-versions-with-tinytex",
             ),
             pytest.param(
                 (["1.8.24"], True, True, None),
                 textwrap.dedent(
                     """\
-                    RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.8.24 && \\
-                        curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
-                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path"""
+                    RUN --mount=type=secret,id=github_token,required=false bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \\
+                        apt-get install -yqq --no-install-recommends \\
+                            quarto=1.8.24 \\
+                            xz-utils && \\
+                        apt-mark hold quarto && \\
+                        apt-get clean -yqq && \\
+                        rm -rf /var/lib/apt/lists/* && \\
+                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path"""
                 ),
                 id="single-version-with-tinytex-update-path",
-            ),
-            pytest.param(
-                (["1.8.24", "1.7.8"], True, True, None),
-                textwrap.dedent(
-                    """\
-                    RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.8.24 && \\
-                        curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
-                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path
-                    RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.7.8 && \\
-                        curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.7.8/quarto-1.7.8-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.7.8" --strip-components=1 && \\
-                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/1.7.8/bin/quarto install tinytex --no-prompt --quiet --update-path"""
-                ),
-                id="multiple-versions-with-tinytex-update-path",
             ),
             pytest.param(
                 (["1.8.24"], True, False, "/root"),
                 textwrap.dedent(
                     """\
-                    RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.8.24 && \\
-                        curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
-                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet"""
+                    RUN --mount=type=secret,id=github_token,required=false bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \\
+                        apt-get install -yqq --no-install-recommends \\
+                            quarto=1.8.24 \\
+                            xz-utils && \\
+                        apt-mark hold quarto && \\
+                        apt-get clean -yqq && \\
+                        rm -rf /var/lib/apt/lists/* && \\
+                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet"""
                 ),
                 id="single-version-with-tinytex-home-path",
-            ),
-            pytest.param(
-                (["1.8.24", "1.7.8"], True, False, "/root"),
-                textwrap.dedent(
-                    """\
-                    RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.8.24 && \\
-                        curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
-                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet
-                    RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.7.8 && \\
-                        curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.7.8/quarto-1.7.8-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.7.8" --strip-components=1 && \\
-                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/1.7.8/bin/quarto install tinytex --no-prompt --quiet"""
-                ),
-                id="multiple-versions-with-tinytex-home-path",
             ),
             pytest.param(
                 (["1.8.24"], True, True, "/root"),
                 textwrap.dedent(
                     """\
-                    RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.8.24 && \\
-                        curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
-                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path"""
+                    RUN --mount=type=secret,id=github_token,required=false bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \\
+                        apt-get install -yqq --no-install-recommends \\
+                            quarto=1.8.24 \\
+                            xz-utils && \\
+                        apt-mark hold quarto && \\
+                        apt-get clean -yqq && \\
+                        rm -rf /var/lib/apt/lists/* && \\
+                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path"""
                 ),
                 id="single-version-with-tinytex-home-path-update-path",
-            ),
-            pytest.param(
-                (["1.8.24", "1.7.8"], True, True, "/root"),
-                textwrap.dedent(
-                    """\
-                    RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.8.24 && \\
-                        curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
-                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path
-                    RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.7.8 && \\
-                        curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.7.8/quarto-1.7.8-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.7.8" --strip-components=1 && \\
-                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/1.7.8/bin/quarto install tinytex --no-prompt --quiet --update-path"""
-                ),
-                id="multiple-versions-with-tinytex-home-path-update-path",
             ),
         ],
     )
@@ -2082,13 +2214,18 @@ class TestQuartoMacros:
         rendered = environment_with_macros.from_string(template).render()
         assert rendered == expected
 
+    def test_run_install_rejects_multiple_versions(self, environment_with_macros):
+        template = '{%- import "quarto.j2" as quarto -%}\n{{ quarto.run_install(["1.8.24", "1.7.8"]) }}'
+        with pytest.raises(Exception, match="Only one Quarto version"):
+            environment_with_macros.from_string(template).render()
+
     def test_symlink_version(self, environment_with_macros):
         template = textwrap.dedent(
             """\
             {%- import "quarto.j2" as quarto -%}
             {{ quarto.symlink_version("1.8.24", "/opt/quarto/default") }}"""
         )
-        expected = "ln -s /opt/quarto/1.8.24 /opt/quarto/default"
+        expected = "ln -s /opt/quarto /opt/quarto/default"
         rendered = environment_with_macros.from_string(template).render()
         assert rendered == expected
 
@@ -2098,7 +2235,7 @@ class TestQuartoMacros:
             {%- import "quarto.j2" as quarto -%}
             {{ quarto.symlink_binary("1.8.24", "quarto", "/usr/local/bin/quarto") }}"""
         )
-        expected = "ln -s /opt/quarto/1.8.24/bin/quarto /usr/local/bin/quarto"
+        expected = "ln -s /opt/quarto/bin/quarto /usr/local/bin/quarto"
         rendered = environment_with_macros.from_string(template).render()
         assert rendered == expected
 

--- a/posit-bakery/test/config/test_config.py
+++ b/posit-bakery/test/config/test_config.py
@@ -962,7 +962,7 @@ class TestBakeryConfig:
                   - dependency: python
                     version: 3.13.7
                   - dependency: quarto
-                    version: 1.8.24
+                    version: 1.8.27
         """),
             VERSION_INDENT,
         )
@@ -980,7 +980,7 @@ class TestBakeryConfig:
                   - dependency: python
                     version: 3.13.7
                   - dependency: quarto
-                    version: 1.8.24
+                    version: 1.8.27
         """),
             VERSION_INDENT,
         )
@@ -1077,9 +1077,14 @@ class TestBakeryConfig:
                 find . -type f -name '[rR]-4.5.1.*\.(deb|rpm)' -delete
 
             # Install Quarto
-            RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.8.24 && \\
-                curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
-                GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet
+            RUN --mount=type=secret,id=github_token,required=false bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \\
+                apt-get install -yqq --no-install-recommends \\
+                    quarto=1.8.27 \\
+                    xz-utils && \\
+                apt-mark hold quarto && \\
+                apt-get clean -yqq && \\
+                rm -rf /var/lib/apt/lists/* && \\
+                GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet
         """)
         assert (
             expected_std_containerfile

--- a/posit-bakery/test/resources/matrix/test-matrix/matrix/Containerfile.ubuntu2404
+++ b/posit-bakery/test/resources/matrix/test-matrix/matrix/Containerfile.ubuntu2404
@@ -49,6 +49,11 @@ RUN RUN_UNATTENDED=1 R_VERSION=$R_VERSION bash -c "$(curl -fsSL https://rstd.io/
     find . -type f -name '[rR]-$R_VERSION.*\.(deb|rpm)' -delete
 
 # Install Quarto
-RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/$QUARTO_VERSION && \
-    curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v$QUARTO_VERSION/quarto-$QUARTO_VERSION-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/$QUARTO_VERSION" --strip-components=1 && \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet
+RUN --mount=type=secret,id=github_token,required=false bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
+    apt-get install -yqq --no-install-recommends \
+        quarto=$QUARTO_VERSION \
+        xz-utils && \
+    apt-mark hold quarto && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/* && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet

--- a/posit-bakery/test/resources/matrix/test-matrix/matrix/test/goss.yaml
+++ b/posit-bakery/test/resources/matrix/test-matrix/matrix/test/goss.yaml
@@ -16,4 +16,4 @@ file:
     path: /opt/R/{{ .Env.BUILD_ARG_R_VERSION }}
   quarto-{{ .Env.BUILD_ARG_QUARTO_VERSION }}:
     exists: true
-    path: /opt/quarto/{{ .Env.BUILD_ARG_QUARTO_VERSION }}
+    path: /opt/quarto

--- a/posit-bakery/test/resources/matrix/test-matrix/template/test/goss.yaml.jinja2
+++ b/posit-bakery/test/resources/matrix/test-matrix/template/test/goss.yaml.jinja2
@@ -21,4 +21,4 @@ file:
     path: {{ r.get_version_directory(goss.build_arg_env_var("R_VERSION")) }}
   quarto-{{ goss.build_arg_env_var("QUARTO_VERSION") }}:
     exists: true
-    path: {{ quarto.get_version_directory(goss.build_arg_env_var("QUARTO_VERSION")) }}
+    path: {{ quarto.get_directory(goss.build_arg_env_var("QUARTO_VERSION")) }}

--- a/posit-bakery/test/resources/with-macros/bakery.yaml
+++ b/posit-bakery/test/resources/with-macros/bakery.yaml
@@ -48,4 +48,4 @@ images:
           - dependency: python
             version: 3.13.7
           - dependency: quarto
-            version: 1.8.24
+            version: 1.8.27

--- a/posit-bakery/test/resources/with-macros/test-image/1.0.0/Containerfile.ubuntu2204.std
+++ b/posit-bakery/test/resources/with-macros/test-image/1.0.0/Containerfile.ubuntu2204.std
@@ -51,6 +51,11 @@ RUN RUN_UNATTENDED=1 R_VERSION=4.5.1 bash -c "$(curl -fsSL https://rstd.io/r-ins
     find . -type f -name '[rR]-4.5.1.*\.(deb|rpm)' -delete
 
 # Install Quarto
-RUN mkdir -p /opt/quarto/1.8.24 && \
-    curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \
-    /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet
+RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
+    apt-get install -yqq --no-install-recommends \
+        quarto=1.8.27 \
+        xz-utils && \
+    apt-mark hold quarto && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/* && \
+    /opt/quarto/bin/quarto install tinytex --no-prompt --quiet

--- a/posit-bakery/test/resources/with-macros/test-image/1.0.0/test/goss.yaml
+++ b/posit-bakery/test/resources/with-macros/test-image/1.0.0/test/goss.yaml
@@ -9,6 +9,10 @@ package:
     installed: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}false{{ else }}true{{ end }}
   xz-utils:
     installed: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}false{{ else }}true{{ end }}
+  quarto:
+    installed: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}false{{ else }}true{{ end }}
+    versions:
+      - 1.8.27
 
 file:
   python-3.13.7:
@@ -17,6 +21,6 @@ file:
   r-4.5.1:
     exists: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}false{{ else }}true{{ end }}
     path: /opt/R/4.5.1
-  quarto-1.8.24:
+  quarto:
     exists: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}false{{ else }}true{{ end }}
-    path: /opt/quarto/1.8.24
+    path: /opt/quarto/bin/quarto

--- a/posit-bakery/test/resources/with-macros/test-image/template/test/goss.yaml.jinja2
+++ b/posit-bakery/test/resources/with-macros/test-image/template/test/goss.yaml.jinja2
@@ -13,6 +13,12 @@ package:
     installed: {% raw %}{{ if eq .Env.IMAGE_VARIANT "Minimal" }}false{{ else }}true{{ end }}{% endraw %}
   xz-utils:
     installed: {% raw %}{{ if eq .Env.IMAGE_VARIANT "Minimal" }}false{{ else }}true{{ end }}{% endraw %}
+  {% for quarto_version in Dependencies.quarto -%}
+  quarto:
+    installed: {% raw %}{{ if eq .Env.IMAGE_VARIANT "Minimal" }}false{{ else }}true{{ end }}{% endraw %}
+    versions:
+      - {{ quarto_version }}
+  {%- endfor %}
 
 file:
   {% for python_version in Dependencies.python -%}
@@ -25,8 +31,6 @@ file:
     exists: {% raw %}{{ if eq .Env.IMAGE_VARIANT "Minimal" }}false{{ else }}true{{ end }}{% endraw %}
     path: {{ r.get_version_directory(r_version) }}
   {%- endfor %}
-  {% for quarto_version in Dependencies.quarto -%}
-  quarto-{{ quarto_version }}:
+  quarto:
     exists: {% raw %}{{ if eq .Env.IMAGE_VARIANT "Minimal" }}false{{ else }}true{{ end }}{% endraw %}
-    path: {{ quarto.get_version_directory(quarto_version) }}
-  {%- endfor %}
+    path: {{ quarto.get_directory() }}/bin/quarto


### PR DESCRIPTION
## Summary

Migrate Quarto installation from GitHub tarball to the [Posit Open apt repository](https://dl.posit.co/public/open/), unify apt/dnf repo setup macros, and enforce a single-version contract for Quarto dependencies.

## Why

- The `quarto` deb is published as a multi-arch package (amd64 + arm64) on both `jammy` and `noble`, eliminating the `${TARGETARCH}` URL-construction logic that caused 404s in [`images-examples`#18](https://github.com/posit-dev/images-examples/pull/18).
- dpkg owns the install, so `apt-get remove quarto` is a clean undo and goss `package.quarto.versions` assertions work directly.
- No tarball extraction; `xz-utils` is only installed when `with_tinytex=True` (to unpack the TinyTeX `.tar.xz`).

## Changes

### `apt.j2` and `dnf.j2` — unified repo setup
- Replace `setup_posit_cloudsmith()` and `setup_posit_open()` with a single `setup_posit_repo(repo)` macro that takes `"pro"` or `"open"`. Same change in both apt and dnf.
- Add `pro_repo` and `open_repo` boolean params to `setup()` / `run_setup()` so a single call can configure one or both Posit repositories. Defaults (`pro_repo=True`, `open_repo=False`) maintain backward compatibility.
- Remove the old per-repo aliases — no product templates call them directly.

### `quarto.j2`
- Rewrite `install()` to use `apt-get install quarto={version}` from the Open repo instead of downloading a tarball from GitHub. Runs `apt-mark hold quarto` to prevent unintended upgrades.
- Remove GH_TOKEN secret mount infrastructure (no longer downloading from GitHub).
- Rename `get_version_directory()` to `get_directory()` since the version param is no longer meaningful. The old name is retained as a backward-compatible alias.
- `symlink_version()` / `symlink_binary()` resolve against flat `/opt/quarto/`. The deb's postinst already symlinks `/usr/local/bin/quarto`, so explicit `symlink_binary` calls for `quarto` are typically unnecessary.

### Config validation
- Add `validate_single_version` field validator on `QuartoDependencyVersions` that rejects multiple Quarto versions at config parse time. The apt package installs to a flat `/opt/quarto/` directory with no version scoping, so multi-version coexistence is not possible.

## Companion PRs

- **images-connect** [#70](https://github.com/posit-dev/images-connect/pull/70)
- **images-workbench** [#78](https://github.com/posit-dev/images-workbench/pull/78)

## Test plan

- [x] `pytest test/config/` and `pytest test/cli/` — 533 tests pass
- [x] Snapshot resources under `test/resources/` updated
- [x] Docs in `docs/templating.qmd` updated
- [ ] CI green on all three repos