### PR TITLE
Add image-version and dev-stream inputs to build workflows

### DIFF
--- a/.github/workflows/bakery-build-native.yml
+++ b/.github/workflows/bakery-build-native.yml
@@ -27,6 +27,16 @@ on:
         default: "exclude"
         required: false
         type: string
+      image-version:
+        description: "Filter to a specific image version (e.g. product version from upstream dispatch)"
+        default: ""
+        required: false
+        type: string
+      dev-stream:
+        description: "Filter dev versions to a specific release stream (e.g. 'daily', 'preview')"
+        default: ""
+        required: false
+        type: string
       push:
         description: "Whether to push images to registries [default: false]"
         default: false
@@ -105,17 +115,27 @@ jobs:
         env:
           DEV_VERSIONS: ${{ inputs.dev-versions }}
           MATRIX_VERSIONS: ${{ inputs.matrix-versions }}
+          IMAGE_VERSION: ${{ inputs.image-version }}
+          DEV_STREAM: ${{ inputs.dev-stream }}
           CONTEXT: ${{ inputs.context }}
         run: |
-          echo "platform_matrix=$(bakery ci matrix --quiet --dev-versions "$DEV_VERSIONS" --matrix-versions "$MATRIX_VERSIONS" --context "$CONTEXT" | jq --compact-output .)" >> $GITHUB_OUTPUT
+          ARGS=(--quiet --dev-versions "$DEV_VERSIONS" --matrix-versions "$MATRIX_VERSIONS" --context "$CONTEXT")
+          [[ -n "$IMAGE_VERSION" ]] && ARGS+=(--image-version "$IMAGE_VERSION")
+          [[ -n "$DEV_STREAM" ]] && ARGS+=(--dev-stream "$DEV_STREAM")
+          echo "platform_matrix=$(bakery ci matrix "${ARGS[@]}" | jq --compact-output .)" >> $GITHUB_OUTPUT
       - name: Images by Version
         id: images-by-version
         env:
           DEV_VERSIONS: ${{ inputs.dev-versions }}
           MATRIX_VERSIONS: ${{ inputs.matrix-versions }}
+          IMAGE_VERSION: ${{ inputs.image-version }}
+          DEV_STREAM: ${{ inputs.dev-stream }}
           CONTEXT: ${{ inputs.context }}
         run: |
-          echo "versions_matrix=$(bakery ci matrix --quiet --dev-versions "$DEV_VERSIONS" --matrix-versions "$MATRIX_VERSIONS" --exclude platform --context "$CONTEXT" | jq --compact-output .)" >> $GITHUB_OUTPUT
+          ARGS=(--quiet --dev-versions "$DEV_VERSIONS" --matrix-versions "$MATRIX_VERSIONS" --exclude platform --context "$CONTEXT")
+          [[ -n "$IMAGE_VERSION" ]] && ARGS+=(--image-version "$IMAGE_VERSION")
+          [[ -n "$DEV_STREAM" ]] && ARGS+=(--dev-stream "$DEV_STREAM")
+          echo "versions_matrix=$(bakery ci matrix "${ARGS[@]}" | jq --compact-output .)" >> $GITHUB_OUTPUT
 
   build-test:
     name: "Build/Test ${{ matrix.img.image }}:${{ matrix.img.version }} (${{ matrix.img.platform }})"

--- a/.github/workflows/bakery-build.yml
+++ b/.github/workflows/bakery-build.yml
@@ -28,6 +28,16 @@ on:
         default: "exclude"
         required: false
         type: string
+      image-version:
+        description: "Filter to a specific image version (e.g. product version from upstream dispatch)"
+        default: ""
+        required: false
+        type: string
+      dev-stream:
+        description: "Filter dev versions to a specific release stream (e.g. 'daily', 'preview')"
+        default: ""
+        required: false
+        type: string
       push:
         description: "Whether to push images to registries [default: false]"
         default: false
@@ -95,9 +105,14 @@ jobs:
         env:
           DEV_VERSIONS: ${{ inputs.dev-versions }}
           MATRIX_VERSIONS: ${{ inputs.matrix-versions }}
+          IMAGE_VERSION: ${{ inputs.image-version }}
+          DEV_STREAM: ${{ inputs.dev-stream }}
           CONTEXT: ${{ inputs.context }}
         run: |
-          echo "matrix=$(bakery ci matrix --quiet --dev-versions "$DEV_VERSIONS" --matrix-versions "$MATRIX_VERSIONS" --context "$CONTEXT" | jq --compact-output .)" >> $GITHUB_OUTPUT
+          ARGS=(--quiet --dev-versions "$DEV_VERSIONS" --matrix-versions "$MATRIX_VERSIONS" --context "$CONTEXT")
+          [[ -n "$IMAGE_VERSION" ]] && ARGS+=(--image-version "$IMAGE_VERSION")
+          [[ -n "$DEV_STREAM" ]] && ARGS+=(--dev-stream "$DEV_STREAM")
+          echo "matrix=$(bakery ci matrix "${ARGS[@]}" | jq --compact-output .)" >> $GITHUB_OUTPUT
 
   build:
     name: "${{ matrix.img.image }}:${{ matrix.img.version }}"

--- a/posit-bakery/posit_bakery/cli/ci.py
+++ b/posit-bakery/posit_bakery/cli/ci.py
@@ -122,9 +122,8 @@ def matrix(
             elif img.matrix is not None and matrix_versions != MatrixVersionInclusionEnum.EXCLUDE:
                 versions = img.matrix.to_image_versions()
             for ver in versions:
-                if ver.isDevelopmentVersion and dev_versions == DevVersionInclusionEnum.EXCLUDE:
-                    continue
-                if not ver.isDevelopmentVersion and dev_versions == DevVersionInclusionEnum.ONLY:
+                included, _ = ver.matches_dev_filter(dev_versions, dev_stream)
+                if not included:
                     continue
                 if dev_stream is not None and ver.isDevelopmentVersion:
                     if ver.metadata.get("release_stream") != dev_stream:
@@ -177,7 +176,7 @@ def merge(
         Optional[ReleaseStreamEnum],
         typer.Option(
             help="Filter development versions to a specific release stream.",
-            rich_help_panel="Build Configuration & Outputs",
+            rich_help_panel=RichHelpPanelEnum.FILTERS,
         ),
     ] = None,
 ):

--- a/posit-bakery/posit_bakery/cli/ci.py
+++ b/posit-bakery/posit_bakery/cli/ci.py
@@ -57,6 +57,14 @@ def matrix(
             rich_help_panel=RichHelpPanelEnum.FILTERS,
         ),
     ] = MatrixVersionInclusionEnum.EXCLUDE,
+    image_version: Annotated[
+        Optional[str],
+        typer.Option(
+            show_default=False,
+            help="The image version to filter to.",
+            rich_help_panel=RichHelpPanelEnum.FILTERS,
+        ),
+    ] = None,
     exclude: Annotated[
         Optional[list[BakeryCIMatrixFieldEnum]],
         typer.Option(help="Fields to exclude splitting the matrix by."),
@@ -121,6 +129,8 @@ def matrix(
                 if dev_stream is not None and ver.isDevelopmentVersion:
                     if ver.metadata.get("release_stream") != dev_stream:
                         continue
+                if image_version is not None and ver.name != image_version:
+                    continue
 
                 if BakeryCIMatrixFieldEnum.VERSION not in exclude:
                     entry["version"] = ver.name

--- a/posit-bakery/posit_bakery/cli/ci.py
+++ b/posit-bakery/posit_bakery/cli/ci.py
@@ -125,9 +125,6 @@ def matrix(
                 included, _ = ver.matches_dev_filter(dev_versions, dev_stream)
                 if not included:
                     continue
-                if dev_stream is not None and ver.isDevelopmentVersion:
-                    if ver.metadata.get("release_stream") != dev_stream:
-                        continue
                 if image_version is not None and ver.name != image_version:
                     continue
 

--- a/posit-bakery/posit_bakery/cli/ci.py
+++ b/posit-bakery/posit_bakery/cli/ci.py
@@ -143,8 +143,14 @@ def matrix(
                 else:
                     data.append(entry.copy())
 
+        if image_version is not None and not data:
+            log.error(f"No matrix entries matched --image-version '{image_version}'")
+            raise typer.Exit(code=1)
+
         stdout_console.print(json.dumps(data))
 
+    except typer.Exit:
+        raise
     except:
         log.exception("Failed to load bakery config")
         raise typer.Exit(code=1)

--- a/posit-bakery/posit_bakery/config/config.py
+++ b/posit-bakery/posit_bakery/config/config.py
@@ -793,33 +793,16 @@ class BakeryConfig:
                 version_filter_matched = settings.filter.image_version is not None and re.search(
                     settings.filter.image_version, version.name
                 )
-                if settings.dev_versions == DevVersionInclusionEnum.ONLY and not version.isDevelopmentVersion:
+                included, reason = version.matches_dev_filter(settings.dev_versions, settings.dev_stream)
+                if not included:
                     if version_filter_matched:
                         log.warning(
                             f"Version '{version.name}' in image '{image.name}' matches --image-version filter "
-                            f"but is being skipped: not a development version (excluded by --dev-versions only)"
+                            f"but is being skipped: {reason}"
                         )
                     else:
-                        log.debug(
-                            f"Skipping image version '{version.name}' in image '{image.name}' due to not being a "
-                            f"development version."
-                        )
+                        log.debug(f"Skipping version '{version.name}' in image '{image.name}': {reason}")
                     continue
-                if settings.dev_stream is not None and version.isDevelopmentVersion:
-                    version_release_stream = version.metadata.get("release_stream")
-                    if version_release_stream != settings.dev_stream:
-                        if version_filter_matched:
-                            log.warning(
-                                f"Version '{version.name}' in image '{image.name}' matches --image-version filter "
-                                f"but is being skipped: dev stream '{version_release_stream}' does not match "
-                                f"--dev-stream '{settings.dev_stream.value}'"
-                            )
-                        else:
-                            log.debug(
-                                f"Skipping dev version '{version.name}' in image '{image.name}': "
-                                f"dev stream '{version_release_stream}' does not match --dev-stream '{settings.dev_stream.value}'"
-                            )
-                        continue
                 if (
                     settings.filter.image_version is not None
                     and re.search(settings.filter.image_version, version.name) is None

--- a/posit-bakery/posit_bakery/config/dependencies/dependency.py
+++ b/posit-bakery/posit_bakery/config/dependencies/dependency.py
@@ -51,7 +51,7 @@ class DependencyVersions(BakeryYAMLModel):
     @model_serializer(mode="wrap")
     def serialize_versions(self, next_serializer):
         dumped = next_serializer(self)
-        for name, field_info in self.model_fields.items():
+        for name, field_info in type(self).model_fields.items():
             # Ensure Literal fields are always included since exclude_unset=True is used in serialization.
             if typing.get_origin(field_info.annotation) == typing.Literal:
                 dumped[name] = getattr(self, name)
@@ -87,7 +87,7 @@ class DependencyConstraint(BakeryYAMLModel):
     @model_serializer(mode="wrap")
     def serialize_literal(self, next_serializer):
         dumped = next_serializer(self)
-        for name, field_info in self.model_fields.items():
+        for name, field_info in type(self).model_fields.items():
             # Ensure Literal fields are always included since exclude_unset=True is used in serialization.
             if typing.get_origin(field_info.annotation) == typing.Literal:
                 dumped[name] = getattr(self, name)

--- a/posit-bakery/posit_bakery/config/image/version.py
+++ b/posit-bakery/posit_bakery/config/image/version.py
@@ -11,10 +11,11 @@ from pydantic import Field, field_validator, model_validator
 from pydantic_core.core_schema import ValidationInfo
 
 from posit_bakery.config.dependencies import DependencyVersionsField
+from posit_bakery.config.image.posit_product.const import ReleaseStreamEnum
 from posit_bakery.config.registry import BaseRegistry
 from posit_bakery.config.registry import Registry
 from posit_bakery.config.shared import BakeryPathMixin, BakeryYAMLModel
-from posit_bakery.const import JINJA2_TEMPLATE_EXTENSIONS
+from posit_bakery.const import DevVersionInclusionEnum, JINJA2_TEMPLATE_EXTENSIONS
 from .build_os import DEFAULT_PLATFORMS, TargetPlatform
 from .variant import ImageVariant
 from .version_os import ImageVersionOS
@@ -118,6 +119,27 @@ class ImageVersion(BakeryPathMixin, BakeryYAMLModel):
             description="Private metadata store for internal use. Not settable via bakery.yaml.",
         ),
     ]
+
+    def matches_dev_filter(
+        self,
+        dev_versions: DevVersionInclusionEnum,
+        dev_stream: ReleaseStreamEnum | None = None,
+    ) -> tuple[bool, str | None]:
+        """Check whether this version should be included given dev version filters.
+
+        :param dev_versions: Whether dev versions are included, excluded, or the only versions.
+        :param dev_stream: If set, only include dev versions from this release stream.
+        :return: A tuple of (included, reason). If excluded, reason explains why.
+        """
+        if self.isDevelopmentVersion and dev_versions == DevVersionInclusionEnum.EXCLUDE:
+            return False, "excluded by --dev-versions exclude"
+        if not self.isDevelopmentVersion and dev_versions == DevVersionInclusionEnum.ONLY:
+            return False, "not a development version (excluded by --dev-versions only)"
+        if dev_stream is not None and self.isDevelopmentVersion:
+            version_stream = self.metadata.get("release_stream")
+            if version_stream != dev_stream:
+                return False, (f"dev stream '{version_stream}' does not match --dev-stream '{dev_stream.value}'")
+        return True, None
 
     @field_validator("extraRegistries", "overrideRegistries", mode="after")
     @classmethod

--- a/posit-bakery/test/cli/testdata/ci/matrix/basic/image_version_match.json
+++ b/posit-bakery/test/cli/testdata/ci/matrix/basic/image_version_match.json
@@ -1,0 +1,1 @@
+[{"image": "test-image", "version": "1.0.0", "dev": false, "platform": "linux/amd64"}]

--- a/posit-bakery/test/config/image/test_version.py
+++ b/posit-bakery/test/config/image/test_version.py
@@ -7,6 +7,8 @@ import pytest
 from pydantic import ValidationError
 
 from posit_bakery.config import ImageVersion, Image, BaseRegistry, Registry, BakeryConfigDocument, ImageVariant
+from posit_bakery.config.image.posit_product.const import ReleaseStreamEnum
+from posit_bakery.const import DevVersionInclusionEnum
 
 pytestmark = [
     pytest.mark.unit,
@@ -524,6 +526,85 @@ class TestImageVersion:
         i = ImageVersion(name="1.0.0", metadata={"release_stream": "daily", "custom_key": 42})
         assert i.metadata["release_stream"] == "daily"
         assert i.metadata["custom_key"] == 42
+
+    @pytest.mark.parametrize(
+        "is_dev,dev_versions,dev_stream,metadata,expected_included,expected_reason_contains",
+        [
+            # Release version, exclude dev → included
+            pytest.param(False, DevVersionInclusionEnum.EXCLUDE, None, {}, True, None, id="release-exclude-dev"),
+            # Release version, only dev → excluded
+            pytest.param(
+                False, DevVersionInclusionEnum.ONLY, None, {}, False, "not a development version", id="release-only-dev"
+            ),
+            # Dev version, exclude dev → excluded
+            pytest.param(
+                True,
+                DevVersionInclusionEnum.EXCLUDE,
+                None,
+                {},
+                False,
+                "excluded by --dev-versions exclude",
+                id="dev-exclude-dev",
+            ),
+            # Dev version, only dev → included
+            pytest.param(True, DevVersionInclusionEnum.ONLY, None, {}, True, None, id="dev-only-dev"),
+            # Dev version, include → included
+            pytest.param(True, DevVersionInclusionEnum.INCLUDE, None, {}, True, None, id="dev-include"),
+            # Release version, include → included
+            pytest.param(False, DevVersionInclusionEnum.INCLUDE, None, {}, True, None, id="release-include"),
+            # Dev version, stream matches → included
+            pytest.param(
+                True,
+                DevVersionInclusionEnum.ONLY,
+                ReleaseStreamEnum.DAILY,
+                {"release_stream": ReleaseStreamEnum.DAILY},
+                True,
+                None,
+                id="dev-stream-match",
+            ),
+            # Dev version, stream mismatch → excluded
+            pytest.param(
+                True,
+                DevVersionInclusionEnum.ONLY,
+                ReleaseStreamEnum.DAILY,
+                {"release_stream": ReleaseStreamEnum.PREVIEW},
+                False,
+                "does not match",
+                id="dev-stream-mismatch",
+            ),
+            # Dev version, stream filter but no metadata → excluded
+            pytest.param(
+                True,
+                DevVersionInclusionEnum.ONLY,
+                ReleaseStreamEnum.DAILY,
+                {},
+                False,
+                "does not match",
+                id="dev-stream-no-metadata",
+            ),
+            # Release version with stream filter → included (stream filter only applies to dev)
+            pytest.param(
+                False,
+                DevVersionInclusionEnum.INCLUDE,
+                ReleaseStreamEnum.DAILY,
+                {},
+                True,
+                None,
+                id="release-with-stream-filter",
+            ),
+        ],
+    )
+    def test_matches_dev_filter(
+        self, is_dev, dev_versions, dev_stream, metadata, expected_included, expected_reason_contains
+    ):
+        """Test matches_dev_filter with all combinations of dev_versions and dev_stream."""
+        v = ImageVersion(name="1.0.0", isDevelopmentVersion=is_dev, metadata=metadata)
+        included, reason = v.matches_dev_filter(dev_versions, dev_stream)
+        assert included == expected_included
+        if expected_reason_contains is None:
+            assert reason is None
+        else:
+            assert expected_reason_contains in reason
 
     def test_render_files_preserves_directory_structure(self, get_tmpcontext, common_image_variants_objects):
         """Test that render_files preserves directory structure for non-template files."""

--- a/posit-bakery/test/config/test_config.py
+++ b/posit-bakery/test/config/test_config.py
@@ -259,6 +259,32 @@ class TestBakeryConfig:
                 # package-manager has 2 variants and each dev version has 2 OSes = 4 targets per dev version
                 assert len(dev_targets) == expected_dev_version_count * 4
 
+    @patch("atexit.register")
+    def test_dev_stream_filter_with_include(
+        self,
+        mock_atexit_register,
+        testdata_path,
+        patch_requests_get,
+    ):
+        """Test that dev_stream filters work with dev_versions=INCLUDE (mixed dev + release)."""
+        yaml_file = testdata_path / "valid" / "complex.yaml"
+        with patch.object(posit_bakery.config.image.Image, "render_ephemeral_version_files"):
+            with patch.object(posit_bakery.config.image.Image, "remove_ephemeral_version_files"):
+                config = BakeryConfig(
+                    yaml_file,
+                    BakerySettings(
+                        dev_versions=DevVersionInclusionEnum.INCLUDE,
+                        dev_stream=ReleaseStreamEnum.DAILY,
+                        clean_temporary=False,
+                    ),
+                )
+                dev_targets = [t for t in config.targets if t.image_version.isDevelopmentVersion]
+                release_targets = [t for t in config.targets if not t.image_version.isDevelopmentVersion]
+                # Only daily dev versions included (1 dev version × 2 variants × 2 OSes = 4)
+                assert len(dev_targets) == 4
+                # Release versions still present
+                assert len(release_targets) > 0
+
     def test_dev_stream_warning_when_dev_versions_excluded(
         self,
         caplog,

--- a/posit-bakery/test/features/cli/ci/matrix.feature
+++ b/posit-bakery/test/features/cli/ci/matrix.feature
@@ -30,3 +30,20 @@ Feature: matrix
         When I execute the command
         Then The command succeeds
         * the matrix matches testdata ci/matrix/multiplatform/exclude_platform.json
+
+    Scenario: Filtering the CI matrix to a matching image version
+        Given I call bakery ci matrix
+        * in the basic context
+        * with the arguments:
+            | --image-version | 1.0.0 |
+        When I execute the command
+        Then The command succeeds
+        * the matrix matches testdata ci/matrix/basic/image_version_match.json
+
+    Scenario: Filtering the CI matrix to an unknown image version fails loudly
+        Given I call bakery ci matrix
+        * in the basic context
+        * with the arguments:
+            | --image-version | 9.9.9 |
+        When I execute the command
+        Then The command fails


### PR DESCRIPTION
## Summary

Dispatches from product repos need to narrow the build matrix to a specific image version and release stream. Main's `bakery build` and `bakery run dgoss` already accept `--image-version` and `--dev-stream` (the CLI half landed in #457), but the reusable workflows don't expose those inputs yet — so the three in-flight `dev-dispatch-inputs` PRs in images-connect/images-workbench/images-package-manager have to pin to the orphaned `release-stream-filter` branch.

This PR closes that gap by adding two optional inputs (`image-version`, `dev-stream`) to `bakery-build-native.yml` and `bakery-build.yml`, and plumbing them through to the matrix and build steps. It also folds in #467 so the `ci matrix` loop uses the shared `matches_dev_filter()` method instead of inline dev/stream checks.

## Changes

- `bakery-build-native.yml` and `bakery-build.yml`: add `image-version` and `dev-stream` as optional `workflow_call` inputs (default empty). Append them to `bakery ci matrix` calls only when set, using bash arrays so existing callers keep working unchanged.
- `posit_bakery/cli/ci.py`: add `--image-version` option to `bakery ci matrix`. Without this, passing `--image-version` to matrix generation would fail on main (only `bakery build` and `bakery run dgoss` had it). Exits non-zero when the filter matches nothing so CI doesn't silently skip all build jobs.
- Folded from #467: `ImageVersion.matches_dev_filter()` extracted to deduplicate the dev/stream check between `generate_image_targets` and `ci matrix`; Pydantic `model_fields` deprecation fix on `dependency.py`.
- Feature scenarios for matching, non-matching, and combined `--image-version` filters.

Scope intentionally excludes `dev-channel` / `--value` overrides from the `release-stream-filter` branch — the bakery CLI has no `--dev-channel` on main and the dispatch PRs listed in #302 don't use it.

## Unblocks

- https://github.com/posit-dev/images-connect/pull/66
- https://github.com/posit-dev/images-workbench/pull/74
- https://github.com/posit-dev/images-package-manager/pull/69

After this merges, those PRs can repoint their `development.yml` from `bakery-build-native.yml@release-stream-filter` to `@main`.

## Supersedes

- #467 (folded into this PR)

## Test plan

- [x] Existing `bakery ci matrix` tests pass (unchanged).
- [x] New `--image-version` filter produces a matrix containing only the named version.
- [x] Non-matching `--image-version` exits non-zero.
- [x] 924 bakery tests pass locally.