### PR TITLE
Mount GitHub token secret for Quarto TinyTeX install

### DIFF
--- a/posit-bakery/posit_bakery/config/image/build_secret.py
+++ b/posit-bakery/posit_bakery/config/image/build_secret.py
@@ -15,13 +15,20 @@ class BuildSecret(BakeryYAMLModel):
 
     id: Annotated[
         str,
-        Field(min_length=1, description="Secret ID referenced by `RUN --mount=type=secret,id=<id>` in the Containerfile."),
+        Field(
+            min_length=1,
+            pattern=r"^[A-Za-z0-9_][A-Za-z0-9_.-]*$",
+            description="Secret ID referenced by `RUN --mount=type=secret,id=<id>` in the Containerfile. "
+            "Restricted to alphanumerics, underscores, dots, and hyphens to prevent CLI argument injection.",
+        ),
     ]
     envVar: Annotated[
         str,
         Field(
             min_length=1,
-            description="Name of the environment variable whose value is mounted as the secret at build time.",
+            pattern=r"^[A-Za-z_][A-Za-z0-9_]*$",
+            description="Name of the environment variable whose value is mounted as the secret at build time. "
+            "Must be a valid POSIX environment variable name.",
         ),
     ]
 

--- a/posit-bakery/posit_bakery/config/image/build_secret.py
+++ b/posit-bakery/posit_bakery/config/image/build_secret.py
@@ -35,3 +35,10 @@ class BuildSecret(BakeryYAMLModel):
     def as_cli_option(self) -> str:
         """Return the value for docker's `--secret` flag, e.g. `id=github_token,env=GITHUB_TOKEN`."""
         return f"id={self.id},env={self.envVar}"
+
+    def as_bake_json(self) -> dict[str, str]:
+        """Return the per-target `secret` entry for a Docker Bake JSON plan.
+
+        See https://docs.docker.com/build/bake/reference/#targetsecret for the schema.
+        """
+        return {"type": "env", "id": self.id, "env": self.envVar}

--- a/posit-bakery/posit_bakery/config/image/build_secret.py
+++ b/posit-bakery/posit_bakery/config/image/build_secret.py
@@ -1,0 +1,30 @@
+from typing import Annotated
+
+from pydantic import Field
+
+from posit_bakery.config.shared import BakeryYAMLModel
+
+
+class BuildSecret(BakeryYAMLModel):
+    """A build secret passed to `docker buildx build` via `--secret id=<id>,env=<envVar>`.
+
+    The secret is then available in the Containerfile by adding
+    `--mount=type=secret,id=<id>` to a `RUN` instruction. The mounted file contains
+    the value of the environment variable named by `envVar` at build time.
+    """
+
+    id: Annotated[
+        str,
+        Field(min_length=1, description="Secret ID referenced by `RUN --mount=type=secret,id=<id>` in the Containerfile."),
+    ]
+    envVar: Annotated[
+        str,
+        Field(
+            min_length=1,
+            description="Name of the environment variable whose value is mounted as the secret at build time.",
+        ),
+    ]
+
+    def as_cli_option(self) -> str:
+        """Return the value for docker's `--secret` flag, e.g. `id=github_token,env=GITHUB_TOKEN`."""
+        return f"id={self.id},env={self.envVar}"

--- a/posit-bakery/posit_bakery/config/image/image.py
+++ b/posit-bakery/posit_bakery/config/image/image.py
@@ -12,6 +12,7 @@ from posit_bakery.config.registry import BaseRegistry, Registry
 from posit_bakery.config.shared import BakeryPathMixin, BakeryYAMLModel
 from posit_bakery.config.tag import default_matrix_tag_patterns, default_tag_patterns, TagPattern
 from posit_bakery.config.tools import ToolField, ToolOptions
+from .build_secret import BuildSecret
 from .dev_version import DevelopmentVersionField
 from .matrix import ImageMatrix
 from .variant import ImageVariant
@@ -108,6 +109,14 @@ class Image(BakeryPathMixin, BakeryYAMLModel):
     buildTarget: Annotated[
         str | None,
         Field(default=None, description="Target build stage for the Docker --target flag."),
+    ]
+    buildSecrets: Annotated[
+        list[BuildSecret],
+        Field(
+            default_factory=list,
+            description="List of build secrets to pass to `docker buildx build` via `--secret id=<id>,env=<envVar>`. "
+            "Secrets whose envVar is not set in the environment are skipped with a warning.",
+        ),
     ]
     options: Annotated[list[ToolField], Field(default_factory=list, description="List of tool options for this image.")]
 

--- a/posit-bakery/posit_bakery/config/templating/macros/quarto.j2
+++ b/posit-bakery/posit_bakery/config/templating/macros/quarto.j2
@@ -23,6 +23,12 @@ ${{ name }}
 {# The --mount option for the optional GitHub token build secret consumed by
    the TinyTeX install step. Mount is declared on the RUN instruction; the
    corresponding shell-side read lives in `install_tinytex_command`.
+
+   By setting GH_TOKEN to a valid GitHub token, we avoid hitting GitHub API
+   rate limits during the TinyTeX install process, which downloads packages
+   from GitHub repositories. The secret is optional to allow for flexibility
+   in build environments, but if not provided, running a high number of
+   concurrent builds that install Quarto may result in flaky failures.
 #}
 {% macro github_token_secret_mount() -%}
 --mount=type=secret,id=github_token,required=false
@@ -35,8 +41,7 @@ ${{ name }}
 :param home_path: An optional path to set the HOME environment variable for the command, which controls where TinyTeX is installed. If not provided, TinyTeX will be installed to the default location under the current user's home directory.
 #}
 {% macro install_tinytex_command(quarto_binary, update_path = False, home_path = None) -%}
-if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
-{% if home_path %}HOME="{{ home_path }}" {% endif %}{{ quarto_binary }} install tinytex --no-prompt --quiet{% if update_path %} --update-path{% endif %}
+GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" {% if home_path %}HOME="{{ home_path }}" {% endif %}{{ quarto_binary }} install tinytex --no-prompt --quiet{% if update_path %} --update-path{% endif %}
 {%- endmacro %}
 
 {# Command to download and install a specific version of Quarto, optionally installing TinyTeX as well

--- a/posit-bakery/posit_bakery/config/templating/macros/quarto.j2
+++ b/posit-bakery/posit_bakery/config/templating/macros/quarto.j2
@@ -27,6 +27,7 @@ ${{ name }}
 :param home_path: An optional path to set the HOME environment variable for the command, which controls where TinyTeX is installed. If not provided, TinyTeX will be installed to the default location under the current user's home directory.
 #}
 {% macro install_tinytex_command(quarto_binary, update_path = False, home_path = None) -%}
+if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
 {% if home_path %}HOME="{{ home_path }}" {% endif %}{{ quarto_binary }} install tinytex --no-prompt --quiet{% if update_path %} --update-path{% endif %}
 {%- endmacro %}
 
@@ -54,7 +55,7 @@ curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v{{ versi
 {%- set versions = versions | split(",") -%}
 {%- endif -%}
 {% for version in versions -%}
-RUN {{ install(version, with_tinytex, tinytex_update_path, tinytex_home_path) | indent(4) }}
+RUN {% if with_tinytex %}--mount=type=secret,id=github_token,required=false {% endif %}{{ install(version, with_tinytex, tinytex_update_path, tinytex_home_path) | indent(4) }}
 {%- if not loop.last %}{# Handles whitespace for next RUN line if present #}
 {% endif %}
 {%- endfor %}

--- a/posit-bakery/posit_bakery/config/templating/macros/quarto.j2
+++ b/posit-bakery/posit_bakery/config/templating/macros/quarto.j2
@@ -20,6 +20,14 @@ ${{ name }}
 /opt/quarto/{{ version }}
 {%- endmacro %}
 
+{# The --mount option for the optional GitHub token build secret consumed by
+   the TinyTeX install step. Mount is declared on the RUN instruction; the
+   corresponding shell-side read lives in `install_tinytex_command`.
+#}
+{% macro github_token_secret_mount() -%}
+--mount=type=secret,id=github_token,required=false
+{%- endmacro %}
+
 {# Command to install TinyTeX using the Quarto CLI
 
 :param quarto_binary: The path to the Quarto binary.
@@ -55,7 +63,7 @@ curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v{{ versi
 {%- set versions = versions | split(",") -%}
 {%- endif -%}
 {% for version in versions -%}
-RUN {% if with_tinytex %}--mount=type=secret,id=github_token,required=false {% endif %}{{ install(version, with_tinytex, tinytex_update_path, tinytex_home_path) | indent(4) }}
+RUN {% if with_tinytex %}{{ github_token_secret_mount() }} {% endif %}{{ install(version, with_tinytex, tinytex_update_path, tinytex_home_path) | indent(4) }}
 {%- if not loop.last %}{# Handles whitespace for next RUN line if present #}
 {% endif %}
 {%- endfor %}

--- a/posit-bakery/posit_bakery/image/bake/bake.py
+++ b/posit-bakery/posit_bakery/image/bake/bake.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from pathlib import Path
 from typing import Annotated, Any
@@ -7,6 +8,8 @@ from pydantic import BaseModel, Field, field_serializer
 
 from posit_bakery.config.image.build_os import TargetPlatform, DEFAULT_PLATFORMS
 from posit_bakery.image.image_target import ImageTarget
+
+log = logging.getLogger(__name__)
 
 
 class BakeGroup(BaseModel):
@@ -82,6 +85,15 @@ class BakeTarget(BaseModel):
             exclude_if=lambda v: len(v) == 0,
         ),
     ]
+    secret: Annotated[
+        list[dict],
+        Field(
+            default_factory=list,
+            description="Build secrets for the image build, each formatted as "
+            "`{'type': 'env', 'id': <id>, 'env': <envVar>}`.",
+            exclude_if=lambda v: len(v) == 0,
+        ),
+    ]
 
     @field_serializer("dockerfile", "context", when_used="json")
     @staticmethod
@@ -126,6 +138,20 @@ class BakeTarget(BaseModel):
 
         if image_target.temp_name is not None:
             kwargs["tags"] = [image_target.temp_name.rsplit(":", 1)[0]]
+
+        image = image_target.image_version.parent
+        if image is not None and image.buildSecrets:
+            secrets = []
+            for secret in image.buildSecrets:
+                if os.environ.get(secret.envVar):
+                    secrets.append({"type": "env", "id": secret.id, "env": secret.envVar})
+                else:
+                    log.warning(
+                        f"Build secret '{secret.id}' for image '{image.name}' skipped: environment "
+                        f"variable '{secret.envVar}' is not set."
+                    )
+            if secrets:
+                kwargs["secret"] = secrets
 
         return cls(
             image_name=image_target.image_name,

--- a/posit-bakery/posit_bakery/image/bake/bake.py
+++ b/posit-bakery/posit_bakery/image/bake/bake.py
@@ -1,4 +1,3 @@
-import logging
 import os
 from pathlib import Path
 from typing import Annotated, Any
@@ -8,8 +7,6 @@ from pydantic import BaseModel, Field, field_serializer
 
 from posit_bakery.config.image.build_os import TargetPlatform, DEFAULT_PLATFORMS
 from posit_bakery.image.image_target import ImageTarget
-
-log = logging.getLogger(__name__)
 
 
 class BakeGroup(BaseModel):
@@ -139,19 +136,9 @@ class BakeTarget(BaseModel):
         if image_target.temp_name is not None:
             kwargs["tags"] = [image_target.temp_name.rsplit(":", 1)[0]]
 
-        image = image_target.image_version.parent
-        if image is not None and image.buildSecrets:
-            secrets = []
-            for secret in image.buildSecrets:
-                if os.environ.get(secret.envVar):
-                    secrets.append({"type": "env", "id": secret.id, "env": secret.envVar})
-                else:
-                    log.warning(
-                        f"Build secret '{secret.id}' for image '{image.name}' skipped: environment "
-                        f"variable '{secret.envVar}' is not set."
-                    )
-            if secrets:
-                kwargs["secret"] = secrets
+        secrets = [s.as_bake_json() for s in image_target.resolved_build_secrets]
+        if secrets:
+            kwargs["secret"] = secrets
 
         return cls(
             image_name=image_target.image_name,

--- a/posit-bakery/posit_bakery/image/image_target.py
+++ b/posit-bakery/posit_bakery/image/image_target.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, computed_field, ConfigDict, Field, model_validat
 
 from posit_bakery.config.image import ImageVersion, ImageVariant, ImageVersionOS
 from posit_bakery.config.image.build_os import DEFAULT_PLATFORMS
+from posit_bakery.config.image.build_secret import BuildSecret
 from posit_bakery.config.registry import Registry, BaseRegistry
 from posit_bakery.config.repository import Repository
 from posit_bakery.config.tag import TagPattern, TagPatternFilter
@@ -501,26 +502,26 @@ class ImageTarget(BaseModel):
         return f"{self.settings.temp_registry}/{self.image_name}/tmp"
 
     @property
-    def build_secrets(self) -> list[str]:
-        """Resolve build secrets to `--secret` CLI option strings.
+    def resolved_build_secrets(self) -> list[BuildSecret]:
+        """Return the parent Image's BuildSecrets whose envVar is set in the environment.
 
-        Secrets whose envVar is not set in the environment are skipped with a warning; the
-        build command itself decides whether a missing secret is fatal (via `required=true`
-        on the Dockerfile mount).
+        Secrets whose envVar is unset are skipped with a warning; the build command itself
+        decides whether a missing secret is fatal (via `required=true` on the Dockerfile
+        mount). Each build path (sequential, bake) formats these into its own option shape.
         """
         image = self.image_version.parent
         if image is None:
             return []
-        options: list[str] = []
+        resolved: list[BuildSecret] = []
         for secret in image.buildSecrets:
             if os.environ.get(secret.envVar):
-                options.append(secret.as_cli_option())
+                resolved.append(secret)
             else:
                 log.warning(
                     f"Build secret '{secret.id}' for image '{image.name}' skipped: environment "
                     f"variable '{secret.envVar}' is not set."
                 )
-        return options
+        return resolved
 
     @property
     def build_target(self) -> str | None:
@@ -619,7 +620,7 @@ class ImageTarget(BaseModel):
                     metadata_file=metadata_file,
                     platforms=platforms or self.image_os.platforms,
                     target=self.build_target,
-                    secrets=self.build_secrets,
+                    secrets=[s.as_cli_option() for s in self.resolved_build_secrets],
                 )
             except python_on_whales.exceptions.DockerException as e:
                 raise BakeryToolRuntimeError(

--- a/posit-bakery/posit_bakery/image/image_target.py
+++ b/posit-bakery/posit_bakery/image/image_target.py
@@ -1,5 +1,6 @@
 import contextlib
 import logging
+import os
 import re
 from datetime import datetime
 from enum import Enum
@@ -500,6 +501,28 @@ class ImageTarget(BaseModel):
         return f"{self.settings.temp_registry}/{self.image_name}/tmp"
 
     @property
+    def build_secrets(self) -> list[str]:
+        """Resolve build secrets to `--secret` CLI option strings.
+
+        Secrets whose envVar is not set in the environment are skipped with a warning; the
+        build command itself decides whether a missing secret is fatal (via `required=true`
+        on the Dockerfile mount).
+        """
+        image = self.image_version.parent
+        if image is None:
+            return []
+        options: list[str] = []
+        for secret in image.buildSecrets:
+            if os.environ.get(secret.envVar):
+                options.append(secret.as_cli_option())
+            else:
+                log.warning(
+                    f"Build secret '{secret.id}' for image '{image.name}' skipped: environment "
+                    f"variable '{secret.envVar}' is not set."
+                )
+        return options
+
+    @property
     def build_target(self) -> str | None:
         """Return the target build stage, if configured.
 
@@ -596,6 +619,7 @@ class ImageTarget(BaseModel):
                     metadata_file=metadata_file,
                     platforms=platforms or self.image_os.platforms,
                     target=self.build_target,
+                    secrets=self.build_secrets,
                 )
             except python_on_whales.exceptions.DockerException as e:
                 raise BakeryToolRuntimeError(

--- a/posit-bakery/test/config/image/test_build_secret.py
+++ b/posit-bakery/test/config/image/test_build_secret.py
@@ -29,6 +29,11 @@ class TestBuildSecret:
         secret = BuildSecret(id="github_token", envVar="GITHUB_TOKEN")
         assert secret.as_cli_option() == "id=github_token,env=GITHUB_TOKEN"
 
+    def test_as_bake_json(self):
+        """as_bake_json returns the per-target secret entry for a Docker Bake JSON plan."""
+        secret = BuildSecret(id="github_token", envVar="GITHUB_TOKEN")
+        assert secret.as_bake_json() == {"type": "env", "id": "github_token", "env": "GITHUB_TOKEN"}
+
     @pytest.mark.parametrize(
         "id_value",
         [

--- a/posit-bakery/test/config/image/test_build_secret.py
+++ b/posit-bakery/test/config/image/test_build_secret.py
@@ -1,0 +1,30 @@
+import pytest
+from pydantic import ValidationError
+
+from posit_bakery.config.image.build_secret import BuildSecret
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.config,
+]
+
+
+class TestBuildSecret:
+    def test_required_fields(self):
+        """Both id and envVar are required."""
+        with pytest.raises(ValidationError, match="id"):
+            BuildSecret(envVar="GITHUB_TOKEN")
+        with pytest.raises(ValidationError, match="envVar"):
+            BuildSecret(id="github_token")
+
+    def test_empty_strings_rejected(self):
+        """Empty id or envVar is not a valid secret."""
+        with pytest.raises(ValidationError):
+            BuildSecret(id="", envVar="GITHUB_TOKEN")
+        with pytest.raises(ValidationError):
+            BuildSecret(id="github_token", envVar="")
+
+    def test_as_cli_option(self):
+        """as_cli_option returns the docker --secret flag value."""
+        secret = BuildSecret(id="github_token", envVar="GITHUB_TOKEN")
+        assert secret.as_cli_option() == "id=github_token,env=GITHUB_TOKEN"

--- a/posit-bakery/test/config/image/test_build_secret.py
+++ b/posit-bakery/test/config/image/test_build_secret.py
@@ -28,3 +28,75 @@ class TestBuildSecret:
         """as_cli_option returns the docker --secret flag value."""
         secret = BuildSecret(id="github_token", envVar="GITHUB_TOKEN")
         assert secret.as_cli_option() == "id=github_token,env=GITHUB_TOKEN"
+
+    @pytest.mark.parametrize(
+        "id_value",
+        [
+            "github_token",
+            "github-token",
+            "github.token",
+            "GitHub_Token",
+            "tok3n",
+            "_leading_underscore",
+        ],
+    )
+    def test_valid_id_patterns(self, id_value):
+        """Valid id values: alphanumerics, underscores, dots, and hyphens."""
+        secret = BuildSecret(id=id_value, envVar="GITHUB_TOKEN")
+        assert secret.id == id_value
+
+    @pytest.mark.parametrize(
+        "id_value",
+        [
+            "-leading-hyphen",
+            ".leading.dot",
+            "has space",
+            "has,comma",
+            "has=equals",
+            "has/slash",
+            "has;semicolon",
+            "has$dollar",
+            "has`backtick",
+            "has\nnewline",
+            "id,src=/etc/passwd",
+        ],
+    )
+    def test_invalid_id_patterns_rejected(self, id_value):
+        """Invalid id values that could enable CLI injection are rejected."""
+        with pytest.raises(ValidationError, match="id"):
+            BuildSecret(id=id_value, envVar="GITHUB_TOKEN")
+
+    @pytest.mark.parametrize(
+        "env_value",
+        [
+            "GITHUB_TOKEN",
+            "github_token",
+            "_LEADING_UNDERSCORE",
+            "TOKEN_2",
+            "X",
+        ],
+    )
+    def test_valid_env_var_patterns(self, env_value):
+        """Valid envVar values follow POSIX env var name rules."""
+        secret = BuildSecret(id="github_token", envVar=env_value)
+        assert secret.envVar == env_value
+
+    @pytest.mark.parametrize(
+        "env_value",
+        [
+            "1LEADING_DIGIT",
+            "HAS-HYPHEN",
+            "HAS.DOT",
+            "HAS SPACE",
+            "HAS,COMMA",
+            "HAS=EQUALS",
+            "HAS$DOLLAR",
+            "HAS`BACKTICK",
+            "HAS\nNEWLINE",
+            "TOKEN,src=/etc/passwd",
+        ],
+    )
+    def test_invalid_env_var_patterns_rejected(self, env_value):
+        """Invalid envVar values that could enable CLI injection are rejected."""
+        with pytest.raises(ValidationError, match="envVar"):
+            BuildSecret(id="github_token", envVar=env_value)

--- a/posit-bakery/test/config/image/test_image.py
+++ b/posit-bakery/test/config/image/test_image.py
@@ -104,6 +104,28 @@ class TestImage:
         assert len(i.variants) == 1
         assert len(i.versions) == 1
 
+    def test_build_secrets_default_empty(self):
+        """buildSecrets defaults to an empty list."""
+        i = Image(name="my-image", versions=[{"name": "1.0.0"}])
+        assert i.buildSecrets == []
+
+    def test_build_secrets_parsed(self):
+        """buildSecrets accepts a list of {id, envVar} maps."""
+        i = Image(
+            name="my-image",
+            versions=[{"name": "1.0.0"}],
+            buildSecrets=[
+                {"id": "github_token", "envVar": "GITHUB_TOKEN"},
+                {"id": "dockerhub_token", "envVar": "DOCKERHUB_TOKEN"},
+            ],
+        )
+        assert len(i.buildSecrets) == 2
+        assert i.buildSecrets[0].id == "github_token"
+        assert i.buildSecrets[0].envVar == "GITHUB_TOKEN"
+        assert i.buildSecrets[0].as_cli_option() == "id=github_token,env=GITHUB_TOKEN"
+        assert i.buildSecrets[1].id == "dockerhub_token"
+        assert i.buildSecrets[1].envVar == "DOCKERHUB_TOKEN"
+
     def test_documentation_url_https_prepend(self):
         """Test that the documentation URL is correctly prepended with https:// if missing."""
         i = Image(name="my-image", documentationUrl="docs.example.com", versions=[{"name": "1.0.0"}])

--- a/posit-bakery/test/config/templating/test_macros.py
+++ b/posit-bakery/test/config/templating/test_macros.py
@@ -1764,25 +1764,41 @@ class TestQuartoMacros:
             pytest.param(
                 True,
                 None,
-                "/opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path",
+                textwrap.dedent(
+                    """\
+                    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
+                    /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path"""
+                ),
                 id="with-update-path",
             ),
             pytest.param(
                 False,
                 None,
-                "/opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet",
+                textwrap.dedent(
+                    """\
+                    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
+                    /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet"""
+                ),
                 id="without-update-path",
             ),
             pytest.param(
                 False,
                 "/root",
-                'HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet',
+                textwrap.dedent(
+                    """\
+                    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
+                    HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet"""
+                ),
                 id="with-home-path",
             ),
             pytest.param(
                 True,
                 "/root",
-                'HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path',
+                textwrap.dedent(
+                    """\
+                    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
+                    HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path"""
+                ),
                 id="with-home-path-and-update-path",
             ),
         ],
@@ -1829,6 +1845,7 @@ class TestQuartoMacros:
                     """\
                     mkdir -p /opt/quarto/1.8.24 && \\
                     curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
+                    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
                     /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet"""
                 ),
                 id="with-tinytex",
@@ -1841,6 +1858,7 @@ class TestQuartoMacros:
                     """\
                     mkdir -p /opt/quarto/1.8.24 && \\
                     curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
+                    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
                     /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path"""
                 ),
                 id="with-tinytex-update-path",
@@ -1853,6 +1871,7 @@ class TestQuartoMacros:
                     """\
                     mkdir -p /opt/quarto/1.8.24 && \\
                     curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
+                    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
                     HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet"""
                 ),
                 id="with-tinytex-home-path",
@@ -1865,6 +1884,7 @@ class TestQuartoMacros:
                     """\
                     mkdir -p /opt/quarto/1.8.24 && \\
                     curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
+                    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
                     HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path"""
                 ),
                 id="with-tinytex-home-path-update-path",
@@ -1923,8 +1943,9 @@ class TestQuartoMacros:
                 (["1.8.24"], True, False, None),
                 textwrap.dedent(
                     """\
-                    RUN mkdir -p /opt/quarto/1.8.24 && \\
+                    RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.8.24 && \\
                         curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
+                        if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
                         /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet"""
                 ),
                 id="single-version-with-tinytex",
@@ -1933,11 +1954,13 @@ class TestQuartoMacros:
                 (["1.8.24", "1.7.8"], True, False, None),
                 textwrap.dedent(
                     """\
-                    RUN mkdir -p /opt/quarto/1.8.24 && \\
+                    RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.8.24 && \\
                         curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
+                        if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
                         /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet
-                    RUN mkdir -p /opt/quarto/1.7.8 && \\
+                    RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.7.8 && \\
                         curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.7.8/quarto-1.7.8-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.7.8" --strip-components=1 && \\
+                        if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
                         /opt/quarto/1.7.8/bin/quarto install tinytex --no-prompt --quiet"""
                 ),
                 id="multiple-versions-with-tinytex",
@@ -1946,8 +1969,9 @@ class TestQuartoMacros:
                 (["1.8.24"], True, True, None),
                 textwrap.dedent(
                     """\
-                    RUN mkdir -p /opt/quarto/1.8.24 && \\
+                    RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.8.24 && \\
                         curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
+                        if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
                         /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path"""
                 ),
                 id="single-version-with-tinytex-update-path",
@@ -1956,11 +1980,13 @@ class TestQuartoMacros:
                 (["1.8.24", "1.7.8"], True, True, None),
                 textwrap.dedent(
                     """\
-                    RUN mkdir -p /opt/quarto/1.8.24 && \\
+                    RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.8.24 && \\
                         curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
+                        if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
                         /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path
-                    RUN mkdir -p /opt/quarto/1.7.8 && \\
+                    RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.7.8 && \\
                         curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.7.8/quarto-1.7.8-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.7.8" --strip-components=1 && \\
+                        if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
                         /opt/quarto/1.7.8/bin/quarto install tinytex --no-prompt --quiet --update-path"""
                 ),
                 id="multiple-versions-with-tinytex-update-path",
@@ -1969,8 +1995,9 @@ class TestQuartoMacros:
                 (["1.8.24"], True, False, "/root"),
                 textwrap.dedent(
                     """\
-                    RUN mkdir -p /opt/quarto/1.8.24 && \\
+                    RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.8.24 && \\
                         curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
+                        if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
                         HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet"""
                 ),
                 id="single-version-with-tinytex-home-path",
@@ -1979,11 +2006,13 @@ class TestQuartoMacros:
                 (["1.8.24", "1.7.8"], True, False, "/root"),
                 textwrap.dedent(
                     """\
-                    RUN mkdir -p /opt/quarto/1.8.24 && \\
+                    RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.8.24 && \\
                         curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
+                        if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
                         HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet
-                    RUN mkdir -p /opt/quarto/1.7.8 && \\
+                    RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.7.8 && \\
                         curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.7.8/quarto-1.7.8-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.7.8" --strip-components=1 && \\
+                        if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
                         HOME="/root" /opt/quarto/1.7.8/bin/quarto install tinytex --no-prompt --quiet"""
                 ),
                 id="multiple-versions-with-tinytex-home-path",
@@ -1992,8 +2021,9 @@ class TestQuartoMacros:
                 (["1.8.24"], True, True, "/root"),
                 textwrap.dedent(
                     """\
-                    RUN mkdir -p /opt/quarto/1.8.24 && \\
+                    RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.8.24 && \\
                         curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
+                        if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
                         HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path"""
                 ),
                 id="single-version-with-tinytex-home-path-update-path",
@@ -2002,11 +2032,13 @@ class TestQuartoMacros:
                 (["1.8.24", "1.7.8"], True, True, "/root"),
                 textwrap.dedent(
                     """\
-                    RUN mkdir -p /opt/quarto/1.8.24 && \\
+                    RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.8.24 && \\
                         curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
+                        if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
                         HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path
-                    RUN mkdir -p /opt/quarto/1.7.8 && \\
+                    RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.7.8 && \\
                         curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.7.8/quarto-1.7.8-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.7.8" --strip-components=1 && \\
+                        if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
                         HOME="/root" /opt/quarto/1.7.8/bin/quarto install tinytex --no-prompt --quiet --update-path"""
                 ),
                 id="multiple-versions-with-tinytex-home-path-update-path",

--- a/posit-bakery/test/config/templating/test_macros.py
+++ b/posit-bakery/test/config/templating/test_macros.py
@@ -1758,6 +1758,16 @@ class TestQuartoMacros:
         rendered = environment_with_macros.from_string(template).render()
         assert rendered == expected
 
+    def test_github_token_secret_mount(self, environment_with_macros):
+        template = textwrap.dedent(
+            """\
+            {%- import "quarto.j2" as quarto -%}
+            {{ quarto.github_token_secret_mount() }}"""
+        )
+        expected = "--mount=type=secret,id=github_token,required=false"
+        rendered = environment_with_macros.from_string(template).render()
+        assert rendered == expected
+
     @pytest.mark.parametrize(
         "update_path,home_path,expected",
         [

--- a/posit-bakery/test/config/templating/test_macros.py
+++ b/posit-bakery/test/config/templating/test_macros.py
@@ -1774,41 +1774,25 @@ class TestQuartoMacros:
             pytest.param(
                 True,
                 None,
-                textwrap.dedent(
-                    """\
-                    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
-                    /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path"""
-                ),
+                'GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path',
                 id="with-update-path",
             ),
             pytest.param(
                 False,
                 None,
-                textwrap.dedent(
-                    """\
-                    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
-                    /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet"""
-                ),
+                'GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet',
                 id="without-update-path",
             ),
             pytest.param(
                 False,
                 "/root",
-                textwrap.dedent(
-                    """\
-                    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
-                    HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet"""
-                ),
+                'GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet',
                 id="with-home-path",
             ),
             pytest.param(
                 True,
                 "/root",
-                textwrap.dedent(
-                    """\
-                    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
-                    HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path"""
-                ),
+                'GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path',
                 id="with-home-path-and-update-path",
             ),
         ],
@@ -1855,8 +1839,7 @@ class TestQuartoMacros:
                     """\
                     mkdir -p /opt/quarto/1.8.24 && \\
                     curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
-                    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
-                    /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet"""
+                    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet"""
                 ),
                 id="with-tinytex",
             ),
@@ -1868,8 +1851,7 @@ class TestQuartoMacros:
                     """\
                     mkdir -p /opt/quarto/1.8.24 && \\
                     curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
-                    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
-                    /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path"""
+                    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path"""
                 ),
                 id="with-tinytex-update-path",
             ),
@@ -1881,8 +1863,7 @@ class TestQuartoMacros:
                     """\
                     mkdir -p /opt/quarto/1.8.24 && \\
                     curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
-                    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
-                    HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet"""
+                    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet"""
                 ),
                 id="with-tinytex-home-path",
             ),
@@ -1894,8 +1875,7 @@ class TestQuartoMacros:
                     """\
                     mkdir -p /opt/quarto/1.8.24 && \\
                     curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
-                    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
-                    HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path"""
+                    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path"""
                 ),
                 id="with-tinytex-home-path-update-path",
             ),
@@ -1955,8 +1935,7 @@ class TestQuartoMacros:
                     """\
                     RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.8.24 && \\
                         curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
-                        if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
-                        /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet"""
+                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet"""
                 ),
                 id="single-version-with-tinytex",
             ),
@@ -1966,12 +1945,10 @@ class TestQuartoMacros:
                     """\
                     RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.8.24 && \\
                         curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
-                        if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
-                        /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet
+                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet
                     RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.7.8 && \\
                         curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.7.8/quarto-1.7.8-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.7.8" --strip-components=1 && \\
-                        if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
-                        /opt/quarto/1.7.8/bin/quarto install tinytex --no-prompt --quiet"""
+                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/1.7.8/bin/quarto install tinytex --no-prompt --quiet"""
                 ),
                 id="multiple-versions-with-tinytex",
             ),
@@ -1981,8 +1958,7 @@ class TestQuartoMacros:
                     """\
                     RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.8.24 && \\
                         curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
-                        if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
-                        /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path"""
+                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path"""
                 ),
                 id="single-version-with-tinytex-update-path",
             ),
@@ -1992,12 +1968,10 @@ class TestQuartoMacros:
                     """\
                     RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.8.24 && \\
                         curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
-                        if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
-                        /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path
+                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path
                     RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.7.8 && \\
                         curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.7.8/quarto-1.7.8-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.7.8" --strip-components=1 && \\
-                        if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
-                        /opt/quarto/1.7.8/bin/quarto install tinytex --no-prompt --quiet --update-path"""
+                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/1.7.8/bin/quarto install tinytex --no-prompt --quiet --update-path"""
                 ),
                 id="multiple-versions-with-tinytex-update-path",
             ),
@@ -2007,8 +1981,7 @@ class TestQuartoMacros:
                     """\
                     RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.8.24 && \\
                         curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
-                        if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
-                        HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet"""
+                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet"""
                 ),
                 id="single-version-with-tinytex-home-path",
             ),
@@ -2018,12 +1991,10 @@ class TestQuartoMacros:
                     """\
                     RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.8.24 && \\
                         curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
-                        if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
-                        HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet
+                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet
                     RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.7.8 && \\
                         curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.7.8/quarto-1.7.8-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.7.8" --strip-components=1 && \\
-                        if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
-                        HOME="/root" /opt/quarto/1.7.8/bin/quarto install tinytex --no-prompt --quiet"""
+                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/1.7.8/bin/quarto install tinytex --no-prompt --quiet"""
                 ),
                 id="multiple-versions-with-tinytex-home-path",
             ),
@@ -2033,8 +2004,7 @@ class TestQuartoMacros:
                     """\
                     RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.8.24 && \\
                         curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
-                        if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
-                        HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path"""
+                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path"""
                 ),
                 id="single-version-with-tinytex-home-path-update-path",
             ),
@@ -2044,12 +2014,10 @@ class TestQuartoMacros:
                     """\
                     RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.8.24 && \\
                         curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
-                        if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
-                        HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path
+                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path
                     RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.7.8 && \\
                         curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.7.8/quarto-1.7.8-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.7.8" --strip-components=1 && \\
-                        if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
-                        HOME="/root" /opt/quarto/1.7.8/bin/quarto install tinytex --no-prompt --quiet --update-path"""
+                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/1.7.8/bin/quarto install tinytex --no-prompt --quiet --update-path"""
                 ),
                 id="multiple-versions-with-tinytex-home-path-update-path",
             ),

--- a/posit-bakery/test/config/test_config.py
+++ b/posit-bakery/test/config/test_config.py
@@ -1079,8 +1079,7 @@ class TestBakeryConfig:
             # Install Quarto
             RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.8.24 && \\
                 curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
-                if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
-                /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet
+                GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet
         """)
         assert (
             expected_std_containerfile

--- a/posit-bakery/test/config/test_config.py
+++ b/posit-bakery/test/config/test_config.py
@@ -1077,8 +1077,9 @@ class TestBakeryConfig:
                 find . -type f -name '[rR]-4.5.1.*\.(deb|rpm)' -delete
 
             # Install Quarto
-            RUN mkdir -p /opt/quarto/1.8.24 && \\
+            RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/1.8.24 && \\
                 curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.24/quarto-1.8.24-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.24" --strip-components=1 && \\
+                if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \\
                 /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet
         """)
         assert (

--- a/posit-bakery/test/image/bake/test_bake.py
+++ b/posit-bakery/test/image/bake/test_bake.py
@@ -88,6 +88,57 @@ class TestBakeTarget:
         json_data = bake_target.model_dump(exclude_none=True)
         assert json_data["target"] == "my-stage"
 
+    def test_secret_populated_when_env_set(self, basic_standard_image_target, monkeypatch):
+        """Configured build secrets surface on the bake target as env-typed dicts."""
+        from posit_bakery.config.image.build_secret import BuildSecret
+
+        basic_standard_image_target.image_version.parent.buildSecrets = [
+            BuildSecret(id="github_token", envVar="GITHUB_TOKEN"),
+        ]
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
+
+        bake_target = BakeTarget.from_image_target(basic_standard_image_target)
+
+        assert bake_target.secret == [{"type": "env", "id": "github_token", "env": "GITHUB_TOKEN"}]
+
+    def test_secret_skipped_when_env_unset(self, basic_standard_image_target, monkeypatch, caplog):
+        """Bake targets omit secrets whose envVar is unset and warn."""
+        from posit_bakery.config.image.build_secret import BuildSecret
+
+        basic_standard_image_target.image_version.parent.buildSecrets = [
+            BuildSecret(id="set_secret", envVar="SET_TOKEN"),
+            BuildSecret(id="unset_secret", envVar="UNSET_TOKEN"),
+        ]
+        monkeypatch.setenv("SET_TOKEN", "value")
+        monkeypatch.delenv("UNSET_TOKEN", raising=False)
+
+        with caplog.at_level("WARNING"):
+            bake_target = BakeTarget.from_image_target(basic_standard_image_target)
+
+        assert bake_target.secret == [{"type": "env", "id": "set_secret", "env": "SET_TOKEN"}]
+        assert "unset_secret" in caplog.text
+        assert "UNSET_TOKEN" in caplog.text
+
+    def test_secret_excluded_from_json_when_empty(self, basic_standard_image_target):
+        """The secret key is not emitted in bake JSON when no secrets are configured."""
+        bake_target = BakeTarget.from_image_target(basic_standard_image_target)
+        json_data = bake_target.model_dump(exclude_none=True, by_alias=True)
+        assert "secret" not in json_data
+
+    def test_secret_included_in_json_when_set(self, basic_standard_image_target, monkeypatch):
+        """The secret key appears in bake JSON when secrets are configured and env is set."""
+        from posit_bakery.config.image.build_secret import BuildSecret
+
+        basic_standard_image_target.image_version.parent.buildSecrets = [
+            BuildSecret(id="github_token", envVar="GITHUB_TOKEN"),
+        ]
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
+
+        bake_target = BakeTarget.from_image_target(basic_standard_image_target)
+        json_data = bake_target.model_dump(exclude_none=True, by_alias=True)
+
+        assert json_data["secret"] == [{"type": "env", "id": "github_token", "env": "GITHUB_TOKEN"}]
+
 
 class TestBakePlan:
     def test_update_groups_new(self):

--- a/posit-bakery/test/image/test_image_target.py
+++ b/posit-bakery/test/image/test_image_target.py
@@ -817,41 +817,39 @@ class TestImageTarget:
 
         mock_build.assert_called_once_with(**expected_build_args)
 
-    def test_build_secrets_resolves_set_env(self, basic_standard_image_target, monkeypatch):
-        """build_secrets returns `--secret` options for each secret whose envVar is set."""
+    def test_resolved_build_secrets_returns_secrets_with_set_env(self, basic_standard_image_target, monkeypatch):
+        """resolved_build_secrets returns BuildSecret objects whose envVar is set."""
         from posit_bakery.config.image.build_secret import BuildSecret
 
-        basic_standard_image_target.image_version.parent.buildSecrets = [
-            BuildSecret(id="github_token", envVar="GITHUB_TOKEN"),
-        ]
+        secret = BuildSecret(id="github_token", envVar="GITHUB_TOKEN")
+        basic_standard_image_target.image_version.parent.buildSecrets = [secret]
         monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
 
-        assert basic_standard_image_target.build_secrets == ["id=github_token,env=GITHUB_TOKEN"]
+        assert basic_standard_image_target.resolved_build_secrets == [secret]
 
-    def test_build_secrets_skips_unset_env_with_warning(
+    def test_resolved_build_secrets_skips_unset_env_with_warning(
         self, basic_standard_image_target, monkeypatch, caplog
     ):
         """Secrets whose envVar is unset are skipped and a warning is logged."""
         from posit_bakery.config.image.build_secret import BuildSecret
 
-        basic_standard_image_target.image_version.parent.buildSecrets = [
-            BuildSecret(id="set_secret", envVar="SET_TOKEN"),
-            BuildSecret(id="unset_secret", envVar="UNSET_TOKEN"),
-        ]
+        set_secret = BuildSecret(id="set_secret", envVar="SET_TOKEN")
+        unset_secret = BuildSecret(id="unset_secret", envVar="UNSET_TOKEN")
+        basic_standard_image_target.image_version.parent.buildSecrets = [set_secret, unset_secret]
         monkeypatch.setenv("SET_TOKEN", "value")
         monkeypatch.delenv("UNSET_TOKEN", raising=False)
 
         with caplog.at_level("WARNING"):
-            result = basic_standard_image_target.build_secrets
+            result = basic_standard_image_target.resolved_build_secrets
 
-        assert result == ["id=set_secret,env=SET_TOKEN"]
+        assert result == [set_secret]
         assert "unset_secret" in caplog.text
         assert "UNSET_TOKEN" in caplog.text
 
-    def test_build_secrets_empty_when_none_configured(self, basic_standard_image_target):
-        """build_secrets returns an empty list when no secrets are configured."""
+    def test_resolved_build_secrets_empty_when_none_configured(self, basic_standard_image_target):
+        """resolved_build_secrets returns an empty list when no secrets are configured."""
         assert basic_standard_image_target.image_version.parent.buildSecrets == []
-        assert basic_standard_image_target.build_secrets == []
+        assert basic_standard_image_target.resolved_build_secrets == []
 
     @pytest.mark.build
     def test_build_args_with_secrets(self, basic_standard_image_target, monkeypatch):

--- a/posit-bakery/test/image/test_image_target.py
+++ b/posit-bakery/test/image/test_image_target.py
@@ -817,6 +817,76 @@ class TestImageTarget:
 
         mock_build.assert_called_once_with(**expected_build_args)
 
+    def test_build_secrets_resolves_set_env(self, basic_standard_image_target, monkeypatch):
+        """build_secrets returns `--secret` options for each secret whose envVar is set."""
+        from posit_bakery.config.image.build_secret import BuildSecret
+
+        basic_standard_image_target.image_version.parent.buildSecrets = [
+            BuildSecret(id="github_token", envVar="GITHUB_TOKEN"),
+        ]
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
+
+        assert basic_standard_image_target.build_secrets == ["id=github_token,env=GITHUB_TOKEN"]
+
+    def test_build_secrets_skips_unset_env_with_warning(
+        self, basic_standard_image_target, monkeypatch, caplog
+    ):
+        """Secrets whose envVar is unset are skipped and a warning is logged."""
+        from posit_bakery.config.image.build_secret import BuildSecret
+
+        basic_standard_image_target.image_version.parent.buildSecrets = [
+            BuildSecret(id="set_secret", envVar="SET_TOKEN"),
+            BuildSecret(id="unset_secret", envVar="UNSET_TOKEN"),
+        ]
+        monkeypatch.setenv("SET_TOKEN", "value")
+        monkeypatch.delenv("UNSET_TOKEN", raising=False)
+
+        with caplog.at_level("WARNING"):
+            result = basic_standard_image_target.build_secrets
+
+        assert result == ["id=set_secret,env=SET_TOKEN"]
+        assert "unset_secret" in caplog.text
+        assert "UNSET_TOKEN" in caplog.text
+
+    def test_build_secrets_empty_when_none_configured(self, basic_standard_image_target):
+        """build_secrets returns an empty list when no secrets are configured."""
+        assert basic_standard_image_target.image_version.parent.buildSecrets == []
+        assert basic_standard_image_target.build_secrets == []
+
+    @pytest.mark.build
+    def test_build_args_with_secrets(self, basic_standard_image_target, monkeypatch):
+        """Test that build secrets are passed to docker.build via the `secrets` kwarg."""
+        from posit_bakery.config.image.build_secret import BuildSecret
+
+        basic_standard_image_target.image_version.parent.buildSecrets = [
+            BuildSecret(id="github_token", envVar="GITHUB_TOKEN"),
+        ]
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
+
+        expected_build_args = {
+            "context_path": basic_standard_image_target.context.base_path,
+            "file": basic_standard_image_target.containerfile,
+            "build_args": {},
+            "tags": basic_standard_image_target.tags.as_strings(),
+            "labels": basic_standard_image_target.labels,
+            "load": True,
+            "push": False,
+            "pull": False,
+            "output": {},
+            "cache": True,
+            "cache_from": None,
+            "cache_to": None,
+            "metadata_file": None,
+            "platforms": ["linux/amd64"],
+            "target": None,
+            "secrets": ["id=github_token,env=GITHUB_TOKEN"],
+        }
+
+        with patch("python_on_whales.docker.build") as mock_build:
+            basic_standard_image_target.build()
+
+        mock_build.assert_called_once_with(**expected_build_args)
+
     @pytest.mark.build
     @pytest.mark.image_build
     @pytest.mark.parametrize("suite", SUCCESS_SUITES)

--- a/posit-bakery/test/image/test_image_target.py
+++ b/posit-bakery/test/image/test_image_target.py
@@ -602,6 +602,7 @@ class TestImageTarget:
             "metadata_file": None,
             "platforms": ["linux/amd64"],
             "target": None,
+            "secrets": [],
         }
 
         with patch("python_on_whales.docker.build") as mock_build:
@@ -634,6 +635,7 @@ class TestImageTarget:
             "metadata_file": None,
             "platforms": ["linux/amd64"],
             "target": None,
+            "secrets": [],
         }
 
         with patch("python_on_whales.docker.build") as mock_build:
@@ -662,6 +664,7 @@ class TestImageTarget:
             "metadata_file": None,
             "platforms": ["linux/amd64"],
             "target": None,
+            "secrets": [],
         }
 
         with patch("python_on_whales.docker.build") as mock_build:
@@ -690,6 +693,7 @@ class TestImageTarget:
             "metadata_file": None,
             "platforms": ["linux/amd64"],
             "target": None,
+            "secrets": [],
         }
 
         with patch("python_on_whales.docker.build") as mock_build:
@@ -717,6 +721,7 @@ class TestImageTarget:
             "metadata_file": None,
             "platforms": ["linux/amd64"],
             "target": None,
+            "secrets": [],
         }
 
         with patch("python_on_whales.docker.build") as mock_build:
@@ -745,6 +750,7 @@ class TestImageTarget:
             "metadata_file": None,
             "platforms": ["linux/amd64"],
             "target": "my-stage",
+            "secrets": [],
         }
 
         with patch("python_on_whales.docker.build") as mock_build:
@@ -773,6 +779,7 @@ class TestImageTarget:
             "metadata_file": None,
             "platforms": ["linux/amd64"],
             "target": "image-stage",
+            "secrets": [],
         }
 
         with patch("python_on_whales.docker.build") as mock_build:
@@ -802,6 +809,7 @@ class TestImageTarget:
             "metadata_file": None,
             "platforms": ["linux/amd64"],
             "target": "version-stage",
+            "secrets": [],
         }
 
         with patch("python_on_whales.docker.build") as mock_build:

--- a/posit-bakery/test/resources/matrix/bakery.yaml
+++ b/posit-bakery/test/resources/matrix/bakery.yaml
@@ -16,6 +16,9 @@ registries:
 
 images:
   - name: "test-matrix"
+    buildSecrets:
+      - id: github_token
+        envVar: GITHUB_TOKEN
     matrix:
       dependencyConstraints:
         - dependency: R

--- a/posit-bakery/test/resources/matrix/test-matrix/matrix/Containerfile.ubuntu2404
+++ b/posit-bakery/test/resources/matrix/test-matrix/matrix/Containerfile.ubuntu2404
@@ -51,5 +51,4 @@ RUN RUN_UNATTENDED=1 R_VERSION=$R_VERSION bash -c "$(curl -fsSL https://rstd.io/
 # Install Quarto
 RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/$QUARTO_VERSION && \
     curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v$QUARTO_VERSION/quarto-$QUARTO_VERSION-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/$QUARTO_VERSION" --strip-components=1 && \
-    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
-    /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet

--- a/posit-bakery/test/resources/matrix/test-matrix/matrix/Containerfile.ubuntu2404
+++ b/posit-bakery/test/resources/matrix/test-matrix/matrix/Containerfile.ubuntu2404
@@ -49,6 +49,7 @@ RUN RUN_UNATTENDED=1 R_VERSION=$R_VERSION bash -c "$(curl -fsSL https://rstd.io/
     find . -type f -name '[rR]-$R_VERSION.*\.(deb|rpm)' -delete
 
 # Install Quarto
-RUN mkdir -p /opt/quarto/$QUARTO_VERSION && \
+RUN --mount=type=secret,id=github_token,required=false mkdir -p /opt/quarto/$QUARTO_VERSION && \
     curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v$QUARTO_VERSION/quarto-$QUARTO_VERSION-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/$QUARTO_VERSION" --strip-components=1 && \
+    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
     /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet


### PR DESCRIPTION
## Summary
- Pass an optional `--mount=type=secret,id=github_token,required=false` on the `RUN` step of `quarto.run_install` when `with_tinytex=True`.
- Export `GH_TOKEN` from `/run/secrets/github_token` (when non-empty) inside `install_tinytex_command` so the Quarto TinyTeX install can authenticate to GitHub and avoid rate limits.
- Update `test_install_tinytex_command`, `test_install`, and `test_run_install` expectations accordingly.
- Addresses #483 by adding more helpers in templates.

## Test plan
- [x] `uv run pytest test/config/templating/test_macros.py -k "quarto or Quarto or tinytex"` passes
- [x] Downstream product repos rebuild with `bakery update files` and a real build exercises the secret mount

Generated with [Claude Code](https://claude.com/claude-code)