### PR TITLE
Extract service layer from BakeryConfig

### DIFF
--- a/posit-bakery/posit_bakery/ci.py
+++ b/posit-bakery/posit_bakery/ci.py
@@ -1,0 +1,67 @@
+import logging
+from enum import Enum
+
+from posit_bakery.config.image.build_os import DEFAULT_PLATFORMS
+from posit_bakery.image.image_target import ImageTarget
+
+log = logging.getLogger(__name__)
+
+
+class CIMatrixField(str, Enum):
+    VERSION = "version"
+    DEV = "dev"
+    PLATFORM = "platform"
+
+
+def ci_matrix(
+    targets: list[ImageTarget],
+    exclude: list[CIMatrixField] | None = None,
+) -> list[dict]:
+    """Build a CI matrix from resolved image targets.
+
+    The matrix is deduplicated by (image, version, platform) — variants and OS
+    entries are not separate matrix dimensions since those are resolved at build
+    time.
+
+    :param targets: Image targets to include in the matrix.
+    :param exclude: Fields to omit from each matrix entry.
+    :return: A list of dicts, one per unique (image, version, platform) combination.
+    """
+    if exclude is None:
+        exclude = []
+
+    seen: set[tuple] = set()
+    data = []
+    for target in targets:
+        version_name = target.image_version.name
+        is_dev = target.image_version.isDevelopmentVersion
+        platforms = target.image_os.platforms if target.image_os else DEFAULT_PLATFORMS
+
+        if CIMatrixField.PLATFORM not in exclude:
+            for platform in platforms:
+                key = (target.image_name, version_name, platform)
+                if key in seen:
+                    continue
+                seen.add(key)
+
+                entry = {"image": target.image_name}
+                if CIMatrixField.VERSION not in exclude:
+                    entry["version"] = version_name
+                if CIMatrixField.DEV not in exclude:
+                    entry["dev"] = is_dev
+                entry["platform"] = platform
+                data.append(entry)
+        else:
+            key = (target.image_name, version_name)
+            if key in seen:
+                continue
+            seen.add(key)
+
+            entry = {"image": target.image_name}
+            if CIMatrixField.VERSION not in exclude:
+                entry["version"] = version_name
+            if CIMatrixField.DEV not in exclude:
+                entry["dev"] = is_dev
+            data.append(entry)
+
+    return data

--- a/posit-bakery/posit_bakery/ci.py
+++ b/posit-bakery/posit_bakery/ci.py
@@ -1,8 +1,11 @@
+import glob
 import logging
 from enum import Enum
+from pathlib import Path
 
 from posit_bakery.config.image.build_os import DEFAULT_PLATFORMS
 from posit_bakery.image.image_target import ImageTarget
+from posit_bakery.plugins.protocol import ToolCallResult
 
 log = logging.getLogger(__name__)
 
@@ -65,3 +68,67 @@ def ci_matrix(
             data.append(entry)
 
     return data
+
+
+def resolve_metadata_globs(metadata_files: list[Path]) -> list[Path]:
+    """Resolve glob patterns in metadata file paths.
+
+    :param metadata_files: Paths that may contain glob patterns.
+    :return: Resolved absolute paths.
+    """
+    resolved: list[Path] = []
+    for file in metadata_files:
+        if "*" in str(file) or "?" in str(file) or "[" in str(file):
+            resolved.extend(sorted(Path(x).absolute() for x in glob.glob(str(file))))
+        else:
+            resolved.append(file.absolute())
+    return resolved
+
+
+def ci_merge(
+    base_path: Path,
+    targets: list[ImageTarget],
+    metadata_files: list[Path],
+    load_metadata: callable,
+    dry_run: bool = False,
+) -> list[ToolCallResult]:
+    """Merge platform-specific builds into multi-platform manifests.
+
+    :param base_path: Root path of the bakery project.
+    :param targets: Resolved image targets with metadata loaded.
+    :param metadata_files: Paths to build metadata JSON files.
+    :param load_metadata: Callable that loads metadata from a file path,
+        returning a list of loaded target UIDs. Typically
+        BakeryConfig.load_build_metadata_from_file.
+    :param dry_run: If True, do not push merged images.
+    :return: List of tool call results from the merge operation.
+    :raises RuntimeError: If any metadata files fail to load.
+    """
+    resolved_files = resolve_metadata_globs(metadata_files)
+
+    log.info(f"Reading targets from {', '.join(f.name for f in resolved_files)}")
+
+    errors = []
+    loaded_targets: list[str] = []
+    for file in resolved_files:
+        try:
+            loaded_targets.extend(load_metadata(file))
+        except Exception as e:
+            log.error(f"Failed to load metadata from file '{file}'")
+            log.error(str(e))
+            errors.append(e)
+    loaded_targets = list(set(loaded_targets))
+
+    if errors:
+        raise RuntimeError("One or more metadata files are invalid, aborting merge.")
+
+    log.info(f"Found {len(loaded_targets)} targets")
+    log.debug(", ".join(loaded_targets))
+
+    from posit_bakery.plugins.registry import get_plugin
+
+    oras = get_plugin("oras")
+    results = oras.execute(base_path, targets, dry_run=dry_run)
+    oras.results(results)
+
+    return results

--- a/posit-bakery/posit_bakery/cli/build.py
+++ b/posit-bakery/posit_bakery/cli/build.py
@@ -14,6 +14,8 @@ from posit_bakery.config.image.posit_product.const import ReleaseStreamEnum
 from posit_bakery.const import DevVersionInclusionEnum, MatrixVersionInclusionEnum
 from posit_bakery.error import BakeryBuildErrorGroup, BakeryToolRuntimeError
 from posit_bakery.image import ImageBuildStrategy
+from posit_bakery.image.bake.bake import BakePlan
+from posit_bakery.image.build import build_targets
 from posit_bakery.log import stderr_console, stdout_console
 from posit_bakery.util import auto_path
 
@@ -230,11 +232,14 @@ def build(
                 style="error",
             )
             raise typer.Exit(code=1)
-        stdout_console.print_json(config.bake_plan_targets(push=push))
+        bake_plan = BakePlan.from_image_targets(context=config.base_path, image_targets=config.targets, push=push)
+        stdout_console.print_json(bake_plan.model_dump_json(indent=2, exclude_none=True, by_alias=True))
         raise typer.Exit(code=0)
 
     try:
-        config.build_targets(
+        build_targets(
+            targets=config.targets,
+            base_path=config.base_path,
             load=load,
             push=push,
             pull=pull,
@@ -244,6 +249,8 @@ def build(
             fail_fast=fail_fast,
             retry=retry,
             metadata_file=metadata_file,
+            temp_registry=config.settings.temp_registry,
+            clean_temporary=config.settings.clean_temporary,
         )
     except BakeryBuildErrorGroup as e:
         stderr_console.print(str(e))

--- a/posit-bakery/posit_bakery/cli/build.py
+++ b/posit-bakery/posit_bakery/cli/build.py
@@ -13,6 +13,8 @@ from posit_bakery.config.image.posit_product.const import ReleaseStreamEnum
 from posit_bakery.const import DevVersionInclusionEnum, MatrixVersionInclusionEnum
 from posit_bakery.error import BakeryBuildErrorGroup, BakeryToolRuntimeError
 from posit_bakery.image import ImageBuildStrategy
+from posit_bakery.image.bake.bake import BakePlan
+from posit_bakery.image.build import build_targets
 from posit_bakery.log import stderr_console, stdout_console
 from posit_bakery.util import auto_path
 
@@ -229,11 +231,14 @@ def build(
                 style="error",
             )
             raise typer.Exit(code=1)
-        stdout_console.print_json(config.bake_plan_targets(push=push))
+        bake_plan = BakePlan.from_image_targets(context=config.base_path, image_targets=config.targets, push=push)
+        stdout_console.print_json(bake_plan.model_dump_json(indent=2, exclude_none=True, by_alias=True))
         raise typer.Exit(code=0)
 
     try:
-        config.build_targets(
+        build_targets(
+            targets=config.targets,
+            base_path=config.base_path,
             load=load,
             push=push,
             pull=pull,
@@ -243,6 +248,8 @@ def build(
             fail_fast=fail_fast,
             retry=retry,
             metadata_file=metadata_file,
+            temp_registry=config.settings.temp_registry,
+            clean_temporary=config.settings.clean_temporary,
         )
     except BakeryBuildErrorGroup as e:
         stderr_console.print(str(e))

--- a/posit-bakery/posit_bakery/cli/ci.py
+++ b/posit-bakery/posit_bakery/cli/ci.py
@@ -8,6 +8,7 @@ from typing import Annotated, Optional
 
 import typer
 
+from posit_bakery.ci import CIMatrixField, ci_matrix
 from posit_bakery.cli.common import with_verbosity_flags
 from posit_bakery.config import BakeryConfig
 from posit_bakery.config.config import BakerySettings, BakeryConfigFilter
@@ -25,12 +26,6 @@ class RichHelpPanelEnum(str, Enum):
     """Enum for categorizing options into rich help panels."""
 
     FILTERS = "Filters"
-
-
-class BakeryCIMatrixFieldEnum(str, Enum):
-    VERSION = "version"
-    DEV = "dev"
-    PLATFORM = "platform"
 
 
 @app.command()
@@ -66,7 +61,7 @@ def matrix(
         ),
     ] = None,
     exclude: Annotated[
-        Optional[list[BakeryCIMatrixFieldEnum]],
+        Optional[list[CIMatrixField]],
         typer.Option(help="Fields to exclude splitting the matrix by."),
     ] = None,
     context: Annotated[
@@ -102,42 +97,13 @@ def matrix(
 
     try:
         settings = BakerySettings(
-            filter=BakeryConfigFilter(image_name=image_name),
+            filter=BakeryConfigFilter(image_name=image_name, image_version=image_version),
             dev_versions=dev_versions,
             dev_stream=dev_stream,
+            matrix_versions=matrix_versions,
         )
-        c = BakeryConfig.from_context(context=context, settings=settings)
-        images = [i for i in c.model.images]
-        if image_name is not None:
-            images = [i for i in images if i.name == image_name]
-
-        data = []
-        for img in images:
-            entry = {"image": img.name}
-            versions = img.versions
-            if (img.matrix is None and matrix_versions == MatrixVersionInclusionEnum.ONLY) or (
-                img.matrix is not None and matrix_versions == MatrixVersionInclusionEnum.EXCLUDE
-            ):
-                continue
-            elif img.matrix is not None and matrix_versions != MatrixVersionInclusionEnum.EXCLUDE:
-                versions = img.matrix.to_image_versions()
-            for ver in versions:
-                included, _ = ver.matches_dev_filter(dev_versions, dev_stream)
-                if not included:
-                    continue
-                if image_version is not None and ver.name != image_version:
-                    continue
-
-                if BakeryCIMatrixFieldEnum.VERSION not in exclude:
-                    entry["version"] = ver.name
-                if BakeryCIMatrixFieldEnum.DEV not in exclude:
-                    entry["dev"] = ver.isDevelopmentVersion
-                if BakeryCIMatrixFieldEnum.PLATFORM not in exclude:
-                    for platform in ver.supported_platforms:
-                        entry["platform"] = platform
-                        data.append(entry.copy())
-                else:
-                    data.append(entry.copy())
+        config = BakeryConfig.from_context(context=context, settings=settings)
+        data = ci_matrix(config.targets, exclude=exclude)
 
         if image_version is not None and not data:
             log.error(f"No matrix entries matched --image-version '{image_version}'")

--- a/posit-bakery/posit_bakery/cli/ci.py
+++ b/posit-bakery/posit_bakery/cli/ci.py
@@ -1,4 +1,3 @@
-import glob
 import json
 import logging
 import python_on_whales
@@ -8,7 +7,7 @@ from typing import Annotated, Optional
 
 import typer
 
-from posit_bakery.ci import CIMatrixField, ci_matrix
+from posit_bakery.ci import CIMatrixField, ci_matrix, ci_merge
 from posit_bakery.cli.common import with_verbosity_flags
 from posit_bakery.config import BakeryConfig
 from posit_bakery.config.config import BakerySettings, BakeryConfigFilter
@@ -168,42 +167,18 @@ def merge(
     )
     config: BakeryConfig = BakeryConfig.from_context(context, settings)
 
-    # Resolve glob patterns in metadata_file arguments
-    resolved_files: list[Path] = []
-    for file in metadata_file:
-        if "*" in str(file) or "?" in str(file) or "[" in str(file):
-            resolved_files.extend(sorted(Path(x).absolute() for x in glob.glob(str(file))))
-        else:
-            resolved_files.append(file.absolute())
-    metadata_file = resolved_files
-
-    log.info(f"Reading targets from {', '.join(f.name for f in metadata_file)}")
-
-    files_ok = True
-    loaded_targets: list[str] = []
-    for file in metadata_file:
-        try:
-            loaded_targets.extend(config.load_build_metadata_from_file(file))
-        except Exception as e:
-            log.error(f"Failed to load metadata from file '{file}'")
-            log.error(str(e))
-            files_ok = False
-    loaded_targets = list(set(loaded_targets))  # Deduplicate targets in case of overlap across files
-
-    if not files_ok:
-        log.error("One or more metadata files are invalid, aborting merge.")
+    try:
+        results = ci_merge(
+            base_path=config.base_path,
+            targets=config.targets,
+            metadata_files=metadata_file,
+            load_metadata=config.load_build_metadata_from_file,
+            dry_run=dry_run,
+        )
+    except RuntimeError as e:
+        log.error(str(e))
         raise typer.Exit(code=1)
 
-    log.info(f"Found {len(loaded_targets)} targets")
-    log.debug(", ".join(loaded_targets))
-
-    # Imported locally for patching in CLI tests
-    from posit_bakery.plugins.registry import get_plugin
-
-    oras = get_plugin("oras")
-    results = oras.execute(config.base_path, config.targets, dry_run=dry_run)
-
-    # CI-specific: verify final manifests with imagetools inspect
     if not dry_run:
         for result in results:
             if result.exit_code == 0 and result.artifacts:
@@ -211,8 +186,6 @@ def merge(
                 if workflow_result and workflow_result.destinations:
                     manifest = python_on_whales.docker.buildx.imagetools.inspect(workflow_result.destinations[0])
                     stdout_console.print_json(manifest.model_dump_json(indent=2, exclude_unset=True, exclude_none=True))
-
-    oras.results(results)
 
 
 @app.command()

--- a/posit-bakery/posit_bakery/cli/ci.py
+++ b/posit-bakery/posit_bakery/cli/ci.py
@@ -8,9 +8,10 @@ from typing import Annotated, Optional
 
 import typer
 
+from posit_bakery.ci import CIMatrixField, ci_matrix
 from posit_bakery.cli.common import with_verbosity_flags
 from posit_bakery.config import BakeryConfig
-from posit_bakery.config.config import BakerySettings, BakeryConfigFilter, version_matches
+from posit_bakery.config.config import BakerySettings, BakeryConfigFilter
 from posit_bakery.config.image.posit_product.const import ReleaseStreamEnum
 from posit_bakery.const import DevVersionInclusionEnum, MatrixVersionInclusionEnum
 from posit_bakery.log import stderr_console, stdout_console
@@ -25,12 +26,6 @@ class RichHelpPanelEnum(str, Enum):
     """Enum for categorizing options into rich help panels."""
 
     FILTERS = "Filters"
-
-
-class BakeryCIMatrixFieldEnum(str, Enum):
-    VERSION = "version"
-    DEV = "dev"
-    PLATFORM = "platform"
 
 
 @app.command()
@@ -66,7 +61,7 @@ def matrix(
         ),
     ] = None,
     exclude: Annotated[
-        Optional[list[BakeryCIMatrixFieldEnum]],
+        Optional[list[CIMatrixField]],
         typer.Option(help="Fields to exclude splitting the matrix by."),
     ] = None,
     context: Annotated[
@@ -102,42 +97,19 @@ def matrix(
 
     try:
         settings = BakerySettings(
-            filter=BakeryConfigFilter(image_name=image_name),
+            filter=BakeryConfigFilter(image_name=image_name, image_version=image_version),
             dev_versions=dev_versions,
             dev_stream=dev_stream,
+            matrix_versions=matrix_versions,
         )
-        c = BakeryConfig.from_context(context=context, settings=settings)
-        images = [i for i in c.model.images]
+        config = BakeryConfig.from_context(context=context, settings=settings)
+        # BakeryConfigFilter.image_name uses regex; ci matrix uses exact match so
+        # CI dispatch can't fan out to overlapping image names (e.g. "connect"
+        # matching "connect-content").
+        targets = config.targets
         if image_name is not None:
-            images = [i for i in images if i.name == image_name]
-
-        data = []
-        for img in images:
-            entry = {"image": img.name}
-            versions = img.versions
-            if (img.matrix is None and matrix_versions == MatrixVersionInclusionEnum.ONLY) or (
-                img.matrix is not None and matrix_versions == MatrixVersionInclusionEnum.EXCLUDE
-            ):
-                continue
-            elif img.matrix is not None and matrix_versions != MatrixVersionInclusionEnum.EXCLUDE:
-                versions = img.matrix.to_image_versions()
-            for ver in versions:
-                included, _ = ver.matches_dev_filter(dev_versions, dev_stream)
-                if not included:
-                    continue
-                if image_version is not None and not version_matches(ver.name, image_version):
-                    continue
-
-                if BakeryCIMatrixFieldEnum.VERSION not in exclude:
-                    entry["version"] = ver.name
-                if BakeryCIMatrixFieldEnum.DEV not in exclude:
-                    entry["dev"] = ver.isDevelopmentVersion
-                if BakeryCIMatrixFieldEnum.PLATFORM not in exclude:
-                    for platform in ver.supported_platforms:
-                        entry["platform"] = platform
-                        data.append(entry.copy())
-                else:
-                    data.append(entry.copy())
+            targets = [t for t in targets if t.image_name == image_name]
+        data = ci_matrix(targets, exclude=exclude)
 
         if image_version is not None and not data:
             log.error(f"No matrix entries matched --image-version '{image_version}'")

--- a/posit-bakery/posit_bakery/cli/ci.py
+++ b/posit-bakery/posit_bakery/cli/ci.py
@@ -1,4 +1,3 @@
-import glob
 import json
 import logging
 import python_on_whales
@@ -8,7 +7,7 @@ from typing import Annotated, Optional
 
 import typer
 
-from posit_bakery.ci import CIMatrixField, ci_matrix
+from posit_bakery.ci import CIMatrixField, ci_matrix, ci_merge
 from posit_bakery.cli.common import with_verbosity_flags
 from posit_bakery.config import BakeryConfig
 from posit_bakery.config.config import BakerySettings, BakeryConfigFilter
@@ -174,42 +173,18 @@ def merge(
     )
     config: BakeryConfig = BakeryConfig.from_context(context, settings)
 
-    # Resolve glob patterns in metadata_file arguments
-    resolved_files: list[Path] = []
-    for file in metadata_file:
-        if "*" in str(file) or "?" in str(file) or "[" in str(file):
-            resolved_files.extend(sorted(Path(x).absolute() for x in glob.glob(str(file))))
-        else:
-            resolved_files.append(file.absolute())
-    metadata_file = resolved_files
-
-    log.info(f"Reading targets from {', '.join(f.name for f in metadata_file)}")
-
-    files_ok = True
-    loaded_targets: list[str] = []
-    for file in metadata_file:
-        try:
-            loaded_targets.extend(config.load_build_metadata_from_file(file))
-        except Exception as e:
-            log.error(f"Failed to load metadata from file '{file}'")
-            log.error(str(e))
-            files_ok = False
-    loaded_targets = list(set(loaded_targets))  # Deduplicate targets in case of overlap across files
-
-    if not files_ok:
-        log.error("One or more metadata files are invalid, aborting merge.")
+    try:
+        results = ci_merge(
+            base_path=config.base_path,
+            targets=config.targets,
+            metadata_files=metadata_file,
+            load_metadata=config.load_build_metadata_from_file,
+            dry_run=dry_run,
+        )
+    except RuntimeError as e:
+        log.error(str(e))
         raise typer.Exit(code=1)
 
-    log.info(f"Found {len(loaded_targets)} targets")
-    log.debug(", ".join(loaded_targets))
-
-    # Imported locally for patching in CLI tests
-    from posit_bakery.plugins.registry import get_plugin
-
-    oras = get_plugin("oras")
-    results = oras.execute(config.base_path, config.targets, dry_run=dry_run)
-
-    # CI-specific: verify final manifests with imagetools inspect
     if not dry_run:
         for result in results:
             if result.exit_code == 0 and result.artifacts:
@@ -217,8 +192,6 @@ def merge(
                 if workflow_result and workflow_result.destinations:
                     manifest = python_on_whales.docker.buildx.imagetools.inspect(workflow_result.destinations[0])
                     stdout_console.print_json(manifest.model_dump_json(indent=2, exclude_unset=True, exclude_none=True))
-
-    oras.results(results)
 
 
 @app.command()

--- a/posit-bakery/posit_bakery/cli/clean.py
+++ b/posit-bakery/posit_bakery/cli/clean.py
@@ -11,6 +11,8 @@ from posit_bakery.config import BakeryConfig
 from posit_bakery.config.config import BakerySettings, BakeryConfigFilter
 from posit_bakery.config.image.posit_product.const import ReleaseStreamEnum
 from posit_bakery.const import DevVersionInclusionEnum, MatrixVersionInclusionEnum
+from posit_bakery.registry_management.clean import clean_caches as do_clean_caches
+from posit_bakery.registry_management.clean import clean_temporary as do_clean_temporary
 from posit_bakery.util import auto_path
 
 app = typer.Typer()
@@ -106,7 +108,8 @@ def cache_registry(
 
     log.info(f"Cleaning cache registries in {registry}")
 
-    errors = config.clean_caches(
+    errors = do_clean_caches(
+        targets=config.targets,
         remove_untagged=untagged,
         remove_older_than=timedelta(days=older_than) if older_than else None,
         dry_run=dry_run,
@@ -199,7 +202,8 @@ def temp_registry(
 
     log.info(f"Cleaning temporary registries in {registry}")
 
-    errors = config.clean_temporary(
+    errors = do_clean_temporary(
+        targets=config.targets,
         remove_untagged=untagged,
         remove_older_than=timedelta(days=older_than) if older_than else None,
         dry_run=dry_run,

--- a/posit-bakery/posit_bakery/config/config.py
+++ b/posit-bakery/posit_bakery/config/config.py
@@ -4,7 +4,6 @@ import logging
 import os
 import re
 import shutil
-from datetime import timedelta
 from pathlib import Path
 from typing import Annotated, Self, Any
 
@@ -31,8 +30,7 @@ from posit_bakery.error import (
     BakeryRenderErrorGroup,
 )
 from posit_bakery.image.image_metadata import MetadataFile
-from posit_bakery.image.image_target import ImageTarget, ImageBuildStrategy, ImageTargetSettings
-from posit_bakery.registry_management import ghcr
+from posit_bakery.image.image_target import ImageTarget, ImageTargetSettings
 
 log = logging.getLogger(__name__)
 
@@ -866,57 +864,3 @@ class BakeryConfig:
                 log.info(f"Loaded build metadata for target '{target}' from file '{metadata_file.filepath}'.")
 
         return targets_loaded
-
-    def clean_caches(
-        self,
-        remove_untagged: bool = True,
-        remove_older_than: timedelta | None = None,
-        dry_run: bool = False,
-    ):
-        """Cleans up dangling caches in the specified registry for all generated image targets.
-
-        :param remove_untagged: If True, remove untagged caches.
-        :param remove_older_than: Optional timedelta to remove caches older than the specified duration.
-        :param dry_run: If True, print what would be deleted without actually deleting anything.
-        """
-        target_caches = list(set([cn.split(":")[0] for target in self.targets if (cn := target.cache_name())]))
-
-        errors = []
-        for target_cache in target_caches:
-            errors.extend(
-                ghcr.clean_temporary_artifacts(
-                    ghcr_registry=target_cache,
-                    remove_untagged=remove_untagged,
-                    remove_older_than=remove_older_than,
-                    dry_run=dry_run,
-                )
-            )
-
-        return errors
-
-    def clean_temporary(
-        self,
-        remove_untagged: bool = True,
-        remove_older_than: timedelta | None = None,
-        dry_run: bool = False,
-    ):
-        """Cleans up temporary images in the specified registry for all generated image targets.
-
-        :param remove_untagged: If True, remove untagged images.
-        :param remove_older_than: Optional timedelta to remove images older than the specified duration.
-        :param dry_run: If True, print what would be deleted without actually deleting anything.
-        """
-        target_caches = list(set([target.temp_name for target in self.targets]))
-
-        errors = []
-        for target_cache in target_caches:
-            errors.extend(
-                ghcr.clean_temporary_artifacts(
-                    ghcr_registry=target_cache,
-                    remove_untagged=remove_untagged,
-                    remove_older_than=remove_older_than,
-                    dry_run=dry_run,
-                )
-            )
-
-        return errors

--- a/posit-bakery/posit_bakery/config/config.py
+++ b/posit-bakery/posit_bakery/config/config.py
@@ -4,16 +4,13 @@ import logging
 import os
 import re
 import shutil
-import time
 from datetime import timedelta
 from pathlib import Path
 from typing import Annotated, Self, Any
 
 import jinja2
 import pydantic
-import python_on_whales
 from pydantic import Field, model_validator, field_validator, BaseModel
-from python_on_whales import DockerException
 from ruamel.yaml import YAML
 
 from posit_bakery import util
@@ -29,45 +26,15 @@ from posit_bakery.config.image.posit_product.const import ReleaseStreamEnum
 from posit_bakery.const import DEFAULT_BASE_IMAGE, DevVersionInclusionEnum, MatrixVersionInclusionEnum
 from posit_bakery.error import (
     BakeryError,
-    BakeryToolRuntimeError,
-    BakeryToolRuntimeErrorGroup,
     BakeryFileError,
-    BakeryBuildErrorGroup,
     BakeryRenderError,
     BakeryRenderErrorGroup,
 )
-from posit_bakery.image.bake.bake import BakePlan
 from posit_bakery.image.image_metadata import MetadataFile
 from posit_bakery.image.image_target import ImageTarget, ImageBuildStrategy, ImageTargetSettings
 from posit_bakery.registry_management import ghcr
 
 log = logging.getLogger(__name__)
-
-_RETRY_DELAY_SECONDS = 5
-
-
-def _retry_build(fn, retry: int, label: str) -> None:
-    """Attempt fn() up to (retry + 1) times, re-raising on final failure.
-
-    :param fn: The function to call.
-    :param retry: Number of retries (0 means no retries, just one attempt).
-    :param label: A label for logging purposes.
-    """
-    for attempt in range(retry + 1):
-        try:
-            fn()
-            return
-        except BakeryFileError:
-            raise  # Never retry file errors
-        except (DockerException, BakeryToolRuntimeError) as e:
-            if attempt < retry:
-                log.warning(
-                    f"Build failed for '{label}' (attempt {attempt + 1}/{retry + 1}). "
-                    f"Retrying in {_RETRY_DELAY_SECONDS}s..."
-                )
-                time.sleep(_RETRY_DELAY_SECONDS)
-            else:
-                raise
 
 
 class BakeryConfigDocument(BakeryPathMixin, BakeryYAMLModel):
@@ -883,18 +850,6 @@ class BakeryConfig:
                 return target
         return None
 
-    def _merge_sequential_build_metadata_files(self) -> dict[str, Any]:
-        """Merges all sequential build metadata files generated during image builds.
-
-        :return: A dictionary containing the merged metadata.
-        """
-        merged_metadata: dict[str, dict[str, Any]] = {}
-        for target in self.targets:
-            for build_metadata in target.build_metadata:
-                merged_metadata[target.uid] = build_metadata.model_dump(exclude_none=True, by_alias=True)
-
-        return merged_metadata
-
     def load_build_metadata_from_file(self, metadata_file: Path) -> list[str]:
         """Loads build metadata from a given metadata file.
 
@@ -911,91 +866,6 @@ class BakeryConfig:
                 log.info(f"Loaded build metadata for target '{target}' from file '{metadata_file.filepath}'.")
 
         return targets_loaded
-
-    def bake_plan_targets(self, push: bool = False) -> str:
-        """Generates a bake plan JSON string for the image targets defined in the config.
-
-        :param push: When True, include cache-to exports in the bake plan so that
-            cache layers are written to the registry alongside the built images.
-        """
-        bake_plan = BakePlan.from_image_targets(context=self.base_path, image_targets=self.targets, push=push)
-        return bake_plan.model_dump_json(indent=2, exclude_none=True, by_alias=True)
-
-    def build_targets(
-        self,
-        load: bool = True,
-        push: bool = False,
-        pull: bool = False,
-        cache: bool = True,
-        platforms: list[str] | None = None,
-        strategy: ImageBuildStrategy = ImageBuildStrategy.BAKE,
-        metadata_file: Path | None = None,
-        fail_fast: bool = False,
-        retry: int = 0,
-    ):
-        """Build image targets using the specified strategy.
-
-        :param load: If True, load the built images into the local Docker daemon.
-        :param push: If True, push the built images to the configured registries.
-        :param pull: If True, always pull the latest version of base images.
-        :param cache: If True, use the build cache when building images.
-        :param platforms: Optional list of platforms to build for. If None, builds for the configuration specified
-            platform.
-        :param strategy: The strategy to use when building images.
-        :param metadata_file: Optional path to a metadata file to write build metadata to.
-        :param fail_fast: If True, stop building targets on the first failure.
-        :param retry: Number of times to retry a failed build (default 0, no retries).
-        """
-        if strategy == ImageBuildStrategy.BAKE:
-            bake_plan = BakePlan.from_image_targets(
-                context=self.base_path, image_targets=self.targets, platforms=platforms, push=push
-            )
-            set_opts = None
-            if self.settings.temp_registry is not None and push:
-                set_opts = {"*.output": {"type": "image", "push-by-digest": True, "name-canonical": True, "push": True}}
-            _retry_build(
-                lambda: bake_plan.build(
-                    load=load,
-                    push=push,
-                    pull=pull,
-                    cache=cache,
-                    clean_bakefile=self.settings.clean_temporary,
-                    platforms=platforms,
-                    set_opts=set_opts,
-                ),
-                retry=retry,
-                label="bake plan",
-            )
-        elif strategy == ImageBuildStrategy.BUILD:
-            errors: list[Exception] = []
-            for target in self.targets:
-                try:
-                    _retry_build(
-                        lambda t=target: t.build(
-                            load=load,
-                            push=push,
-                            pull=pull,
-                            cache=cache,
-                            platforms=platforms,
-                            metadata_file=True if metadata_file else False,
-                        ),
-                        retry=retry,
-                        label=str(target),
-                    )
-                except (BakeryFileError, DockerException, BakeryToolRuntimeError) as e:
-                    log.error(f"Failed to build image target '{str(target)}'.")
-                    if fail_fast:
-                        log.info("--fail-fast is set, stopping builds...")
-                        raise e
-                    errors.append(e)
-            if errors:
-                if len(errors) == 1:
-                    raise errors[0]
-                raise BakeryBuildErrorGroup("Multiple errors occurred while building images.", errors)
-            if metadata_file is not None:
-                with open(metadata_file, "w") as f:
-                    log.info(f"Writing build metadata to '{str(metadata_file)}'.")
-                    json.dump(self._merge_sequential_build_metadata_files(), f, indent=2)
 
     def clean_caches(
         self,

--- a/posit-bakery/posit_bakery/config/config.py
+++ b/posit-bakery/posit_bakery/config/config.py
@@ -5,7 +5,6 @@ import logging
 import os
 import re
 import shutil
-from datetime import timedelta
 from pathlib import Path
 from typing import Annotated, Self, Any
 
@@ -33,8 +32,7 @@ from posit_bakery.error import (
     BakeryRenderErrorGroup,
 )
 from posit_bakery.image.image_metadata import MetadataFile
-from posit_bakery.image.image_target import ImageTarget, ImageBuildStrategy, ImageTargetSettings
-from posit_bakery.registry_management import ghcr
+from posit_bakery.image.image_target import ImageTarget, ImageTargetSettings
 
 log = logging.getLogger(__name__)
 
@@ -895,57 +893,3 @@ class BakeryConfig:
                 log.info(f"Loaded build metadata for target '{target}' from file '{metadata_file.filepath}'.")
 
         return targets_loaded
-
-    def clean_caches(
-        self,
-        remove_untagged: bool = True,
-        remove_older_than: timedelta | None = None,
-        dry_run: bool = False,
-    ):
-        """Cleans up dangling caches in the specified registry for all generated image targets.
-
-        :param remove_untagged: If True, remove untagged caches.
-        :param remove_older_than: Optional timedelta to remove caches older than the specified duration.
-        :param dry_run: If True, print what would be deleted without actually deleting anything.
-        """
-        target_caches = list(set([cn.split(":")[0] for target in self.targets if (cn := target.cache_name())]))
-
-        errors = []
-        for target_cache in target_caches:
-            errors.extend(
-                ghcr.clean_temporary_artifacts(
-                    ghcr_registry=target_cache,
-                    remove_untagged=remove_untagged,
-                    remove_older_than=remove_older_than,
-                    dry_run=dry_run,
-                )
-            )
-
-        return errors
-
-    def clean_temporary(
-        self,
-        remove_untagged: bool = True,
-        remove_older_than: timedelta | None = None,
-        dry_run: bool = False,
-    ):
-        """Cleans up temporary images in the specified registry for all generated image targets.
-
-        :param remove_untagged: If True, remove untagged images.
-        :param remove_older_than: Optional timedelta to remove images older than the specified duration.
-        :param dry_run: If True, print what would be deleted without actually deleting anything.
-        """
-        target_caches = list(set([target.temp_name for target in self.targets]))
-
-        errors = []
-        for target_cache in target_caches:
-            errors.extend(
-                ghcr.clean_temporary_artifacts(
-                    ghcr_registry=target_cache,
-                    remove_untagged=remove_untagged,
-                    remove_older_than=remove_older_than,
-                    dry_run=dry_run,
-                )
-            )
-
-        return errors

--- a/posit-bakery/posit_bakery/config/config.py
+++ b/posit-bakery/posit_bakery/config/config.py
@@ -5,16 +5,13 @@ import logging
 import os
 import re
 import shutil
-import time
 from datetime import timedelta
 from pathlib import Path
 from typing import Annotated, Self, Any
 
 import jinja2
 import pydantic
-import python_on_whales
 from pydantic import Field, model_validator, field_validator, BaseModel
-from python_on_whales import DockerException
 from ruamel.yaml import YAML
 
 from posit_bakery import util
@@ -31,45 +28,15 @@ from posit_bakery.config.image.posit_product.const import ReleaseStreamEnum
 from posit_bakery.const import DEFAULT_BASE_IMAGE, DevVersionInclusionEnum, MatrixVersionInclusionEnum
 from posit_bakery.error import (
     BakeryError,
-    BakeryToolRuntimeError,
-    BakeryToolRuntimeErrorGroup,
     BakeryFileError,
-    BakeryBuildErrorGroup,
     BakeryRenderError,
     BakeryRenderErrorGroup,
 )
-from posit_bakery.image.bake.bake import BakePlan
 from posit_bakery.image.image_metadata import MetadataFile
 from posit_bakery.image.image_target import ImageTarget, ImageBuildStrategy, ImageTargetSettings
 from posit_bakery.registry_management import ghcr
 
 log = logging.getLogger(__name__)
-
-_RETRY_DELAY_SECONDS = 5
-
-
-def _retry_build(fn, retry: int, label: str) -> None:
-    """Attempt fn() up to (retry + 1) times, re-raising on final failure.
-
-    :param fn: The function to call.
-    :param retry: Number of retries (0 means no retries, just one attempt).
-    :param label: A label for logging purposes.
-    """
-    for attempt in range(retry + 1):
-        try:
-            fn()
-            return
-        except BakeryFileError:
-            raise  # Never retry file errors
-        except (DockerException, BakeryToolRuntimeError) as e:
-            if attempt < retry:
-                log.warning(
-                    f"Build failed for '{label}' (attempt {attempt + 1}/{retry + 1}). "
-                    f"Retrying in {_RETRY_DELAY_SECONDS}s..."
-                )
-                time.sleep(_RETRY_DELAY_SECONDS)
-            else:
-                raise
 
 
 class BakeryConfigDocument(BakeryPathMixin, BakeryYAMLModel):
@@ -912,18 +879,6 @@ class BakeryConfig:
                 return target
         return None
 
-    def _merge_sequential_build_metadata_files(self) -> dict[str, Any]:
-        """Merges all sequential build metadata files generated during image builds.
-
-        :return: A dictionary containing the merged metadata.
-        """
-        merged_metadata: dict[str, dict[str, Any]] = {}
-        for target in self.targets:
-            for build_metadata in target.build_metadata:
-                merged_metadata[target.uid] = build_metadata.model_dump(exclude_none=True, by_alias=True)
-
-        return merged_metadata
-
     def load_build_metadata_from_file(self, metadata_file: Path) -> list[str]:
         """Loads build metadata from a given metadata file.
 
@@ -940,91 +895,6 @@ class BakeryConfig:
                 log.info(f"Loaded build metadata for target '{target}' from file '{metadata_file.filepath}'.")
 
         return targets_loaded
-
-    def bake_plan_targets(self, push: bool = False) -> str:
-        """Generates a bake plan JSON string for the image targets defined in the config.
-
-        :param push: When True, include cache-to exports in the bake plan so that
-            cache layers are written to the registry alongside the built images.
-        """
-        bake_plan = BakePlan.from_image_targets(context=self.base_path, image_targets=self.targets, push=push)
-        return bake_plan.model_dump_json(indent=2, exclude_none=True, by_alias=True)
-
-    def build_targets(
-        self,
-        load: bool = True,
-        push: bool = False,
-        pull: bool = False,
-        cache: bool = True,
-        platforms: list[str] | None = None,
-        strategy: ImageBuildStrategy = ImageBuildStrategy.BAKE,
-        metadata_file: Path | None = None,
-        fail_fast: bool = False,
-        retry: int = 0,
-    ):
-        """Build image targets using the specified strategy.
-
-        :param load: If True, load the built images into the local Docker daemon.
-        :param push: If True, push the built images to the configured registries.
-        :param pull: If True, always pull the latest version of base images.
-        :param cache: If True, use the build cache when building images.
-        :param platforms: Optional list of platforms to build for. If None, builds for the configuration specified
-            platform.
-        :param strategy: The strategy to use when building images.
-        :param metadata_file: Optional path to a metadata file to write build metadata to.
-        :param fail_fast: If True, stop building targets on the first failure.
-        :param retry: Number of times to retry a failed build (default 0, no retries).
-        """
-        if strategy == ImageBuildStrategy.BAKE:
-            bake_plan = BakePlan.from_image_targets(
-                context=self.base_path, image_targets=self.targets, platforms=platforms, push=push
-            )
-            set_opts = None
-            if self.settings.temp_registry is not None and push:
-                set_opts = {"*.output": {"type": "image", "push-by-digest": True, "name-canonical": True, "push": True}}
-            _retry_build(
-                lambda: bake_plan.build(
-                    load=load,
-                    push=push,
-                    pull=pull,
-                    cache=cache,
-                    clean_bakefile=self.settings.clean_temporary,
-                    platforms=platforms,
-                    set_opts=set_opts,
-                ),
-                retry=retry,
-                label="bake plan",
-            )
-        elif strategy == ImageBuildStrategy.BUILD:
-            errors: list[Exception] = []
-            for target in self.targets:
-                try:
-                    _retry_build(
-                        lambda t=target: t.build(
-                            load=load,
-                            push=push,
-                            pull=pull,
-                            cache=cache,
-                            platforms=platforms,
-                            metadata_file=True if metadata_file else False,
-                        ),
-                        retry=retry,
-                        label=str(target),
-                    )
-                except (BakeryFileError, DockerException, BakeryToolRuntimeError) as e:
-                    log.error(f"Failed to build image target '{str(target)}'.")
-                    if fail_fast:
-                        log.info("--fail-fast is set, stopping builds...")
-                        raise e
-                    errors.append(e)
-            if errors:
-                if len(errors) == 1:
-                    raise errors[0]
-                raise BakeryBuildErrorGroup("Multiple errors occurred while building images.", errors)
-            if metadata_file is not None:
-                with open(metadata_file, "w") as f:
-                    log.info(f"Writing build metadata to '{str(metadata_file)}'.")
-                    json.dump(self._merge_sequential_build_metadata_files(), f, indent=2)
 
     def clean_caches(
         self,

--- a/posit-bakery/posit_bakery/image/build.py
+++ b/posit-bakery/posit_bakery/image/build.py
@@ -1,0 +1,120 @@
+import json
+import logging
+import time
+from pathlib import Path
+
+from python_on_whales import DockerException
+
+from posit_bakery.error import BakeryBuildErrorGroup, BakeryFileError, BakeryToolRuntimeError
+from posit_bakery.image.bake.bake import BakePlan
+from posit_bakery.image.image_target import ImageTarget, ImageBuildStrategy
+
+log = logging.getLogger(__name__)
+
+_RETRY_DELAY_SECONDS = 5
+
+
+def _retry_build(fn, retry: int, label: str) -> None:
+    """Attempt fn() up to (retry + 1) times, re-raising on final failure."""
+    for attempt in range(retry + 1):
+        try:
+            fn()
+            return
+        except BakeryFileError:
+            raise
+        except (DockerException, BakeryToolRuntimeError) as e:
+            if attempt < retry:
+                log.warning(
+                    f"Build failed for '{label}' (attempt {attempt + 1}/{retry + 1}). "
+                    f"Retrying in {_RETRY_DELAY_SECONDS}s..."
+                )
+                time.sleep(_RETRY_DELAY_SECONDS)
+            else:
+                raise e
+
+
+def build_targets(
+    targets: list[ImageTarget],
+    base_path: Path,
+    load: bool = True,
+    push: bool = False,
+    pull: bool = False,
+    cache: bool = True,
+    platforms: list[str] | None = None,
+    strategy: ImageBuildStrategy = ImageBuildStrategy.BAKE,
+    metadata_file: Path | None = None,
+    fail_fast: bool = False,
+    retry: int = 0,
+    temp_registry: str | None = None,
+    clean_temporary: bool = True,
+):
+    """Build image targets using the specified strategy.
+
+    :param targets: Image targets to build.
+    :param base_path: Root path of the bakery project.
+    :param load: If True, load the built images into the local Docker daemon.
+    :param push: If True, push the built images to the configured registries.
+    :param pull: If True, always pull the latest version of base images.
+    :param cache: If True, use the build cache when building images.
+    :param platforms: Optional list of platforms to build for.
+    :param strategy: The strategy to use when building images.
+    :param metadata_file: Optional path to a metadata file to write build metadata to.
+    :param fail_fast: If True, stop building targets on the first failure.
+    :param retry: Number of times to retry a failed build (default 0, no retries).
+    :param temp_registry: Temporary registry for push-by-digest builds.
+    :param clean_temporary: If True, clean up temporary bake files after building.
+    """
+    if strategy == ImageBuildStrategy.BAKE:
+        bake_plan = BakePlan.from_image_targets(
+            context=base_path, image_targets=targets, platforms=platforms, push=push
+        )
+        set_opts = None
+        if temp_registry is not None and push:
+            set_opts = {"*.output": {"type": "image", "push-by-digest": True, "name-canonical": True, "push": True}}
+        _retry_build(
+            lambda: bake_plan.build(
+                load=load,
+                push=push,
+                pull=pull,
+                cache=cache,
+                clean_bakefile=clean_temporary,
+                platforms=platforms,
+                set_opts=set_opts,
+            ),
+            retry=retry,
+            label="bake plan",
+        )
+    elif strategy == ImageBuildStrategy.BUILD:
+        errors: list[Exception] = []
+        for target in targets:
+            try:
+                _retry_build(
+                    lambda t=target: t.build(
+                        load=load,
+                        push=push,
+                        pull=pull,
+                        cache=cache,
+                        platforms=platforms,
+                        metadata_file=True if metadata_file else False,
+                    ),
+                    retry=retry,
+                    label=str(target),
+                )
+            except (BakeryFileError, DockerException, BakeryToolRuntimeError) as e:
+                log.error(f"Failed to build image target '{str(target)}'.")
+                if fail_fast:
+                    log.info("--fail-fast is set, stopping builds...")
+                    raise e
+                errors.append(e)
+        if errors:
+            if len(errors) == 1:
+                raise errors[0]
+            raise BakeryBuildErrorGroup("Multiple errors occurred while building images.", errors)
+        if metadata_file is not None:
+            merged_metadata: dict = {}
+            for target in targets:
+                for build_metadata in target.build_metadata:
+                    merged_metadata[target.uid] = build_metadata.model_dump(exclude_none=True, by_alias=True)
+            with open(metadata_file, "w") as f:
+                log.info(f"Writing build metadata to '{str(metadata_file)}'.")
+                json.dump(merged_metadata, f, indent=2)

--- a/posit-bakery/posit_bakery/image/build.py
+++ b/posit-bakery/posit_bakery/image/build.py
@@ -1,0 +1,120 @@
+import json
+import logging
+import time
+from pathlib import Path
+
+from python_on_whales import DockerException
+
+from posit_bakery.error import BakeryBuildErrorGroup, BakeryFileError, BakeryToolRuntimeError
+from posit_bakery.image.bake.bake import BakePlan
+from posit_bakery.image.image_target import ImageTarget, ImageBuildStrategy
+
+log = logging.getLogger(__name__)
+
+_RETRY_DELAY_SECONDS = 5
+
+
+def _retry_build(fn, retry: int, label: str) -> None:
+    """Attempt fn() up to (retry + 1) times, re-raising on final failure."""
+    for attempt in range(retry + 1):
+        try:
+            fn()
+            return
+        except BakeryFileError:
+            raise  # Never retry file errors
+        except (DockerException, BakeryToolRuntimeError):
+            if attempt < retry:
+                log.warning(
+                    f"Build failed for '{label}' (attempt {attempt + 1}/{retry + 1}). "
+                    f"Retrying in {_RETRY_DELAY_SECONDS}s..."
+                )
+                time.sleep(_RETRY_DELAY_SECONDS)
+            else:
+                raise
+
+
+def build_targets(
+    targets: list[ImageTarget],
+    base_path: Path,
+    load: bool = True,
+    push: bool = False,
+    pull: bool = False,
+    cache: bool = True,
+    platforms: list[str] | None = None,
+    strategy: ImageBuildStrategy = ImageBuildStrategy.BAKE,
+    metadata_file: Path | None = None,
+    fail_fast: bool = False,
+    retry: int = 0,
+    temp_registry: str | None = None,
+    clean_temporary: bool = True,
+):
+    """Build image targets using the specified strategy.
+
+    :param targets: Image targets to build.
+    :param base_path: Root path of the bakery project.
+    :param load: If True, load the built images into the local Docker daemon.
+    :param push: If True, push the built images to the configured registries.
+    :param pull: If True, always pull the latest version of base images.
+    :param cache: If True, use the build cache when building images.
+    :param platforms: Optional list of platforms to build for.
+    :param strategy: The strategy to use when building images.
+    :param metadata_file: Optional path to a metadata file to write build metadata to.
+    :param fail_fast: If True, stop building targets on the first failure.
+    :param retry: Number of times to retry a failed build (default 0, no retries).
+    :param temp_registry: Temporary registry for push-by-digest builds.
+    :param clean_temporary: If True, clean up temporary bake files after building.
+    """
+    if strategy == ImageBuildStrategy.BAKE:
+        bake_plan = BakePlan.from_image_targets(
+            context=base_path, image_targets=targets, platforms=platforms, push=push
+        )
+        set_opts = None
+        if temp_registry is not None and push:
+            set_opts = {"*.output": {"type": "image", "push-by-digest": True, "name-canonical": True, "push": True}}
+        _retry_build(
+            lambda: bake_plan.build(
+                load=load,
+                push=push,
+                pull=pull,
+                cache=cache,
+                clean_bakefile=clean_temporary,
+                platforms=platforms,
+                set_opts=set_opts,
+            ),
+            retry=retry,
+            label="bake plan",
+        )
+    elif strategy == ImageBuildStrategy.BUILD:
+        errors: list[Exception] = []
+        for target in targets:
+            try:
+                _retry_build(
+                    lambda t=target: t.build(
+                        load=load,
+                        push=push,
+                        pull=pull,
+                        cache=cache,
+                        platforms=platforms,
+                        metadata_file=True if metadata_file else False,
+                    ),
+                    retry=retry,
+                    label=str(target),
+                )
+            except (BakeryFileError, DockerException, BakeryToolRuntimeError) as e:
+                log.error(f"Failed to build image target '{str(target)}'.")
+                if fail_fast:
+                    log.info("--fail-fast is set, stopping builds...")
+                    raise e
+                errors.append(e)
+        if errors:
+            if len(errors) == 1:
+                raise errors[0]
+            raise BakeryBuildErrorGroup("Multiple errors occurred while building images.", errors)
+        if metadata_file is not None:
+            merged_metadata: dict = {}
+            for target in targets:
+                for build_metadata in target.build_metadata:
+                    merged_metadata[target.uid] = build_metadata.model_dump(exclude_none=True, by_alias=True)
+            with open(metadata_file, "w") as f:
+                log.info(f"Writing build metadata to '{str(metadata_file)}'.")
+                json.dump(merged_metadata, f, indent=2)

--- a/posit-bakery/posit_bakery/registry_management/clean.py
+++ b/posit-bakery/posit_bakery/registry_management/clean.py
@@ -1,0 +1,67 @@
+import logging
+from datetime import timedelta
+
+from posit_bakery.image.image_target import ImageTarget
+from posit_bakery.registry_management import ghcr
+
+log = logging.getLogger(__name__)
+
+
+def clean_caches(
+    targets: list[ImageTarget],
+    remove_untagged: bool = True,
+    remove_older_than: timedelta | None = None,
+    dry_run: bool = False,
+) -> list[Exception]:
+    """Clean up dangling caches in the registry for the given image targets.
+
+    :param targets: Image targets whose cache registries should be cleaned.
+    :param remove_untagged: If True, remove untagged caches.
+    :param remove_older_than: Remove caches older than the specified duration.
+    :param dry_run: If True, print what would be deleted without deleting.
+    :return: List of errors encountered during cleanup.
+    """
+    target_caches = list(set([cn.split(":")[0] for target in targets if (cn := target.cache_name())]))
+
+    errors = []
+    for target_cache in target_caches:
+        errors.extend(
+            ghcr.clean_temporary_artifacts(
+                ghcr_registry=target_cache,
+                remove_untagged=remove_untagged,
+                remove_older_than=remove_older_than,
+                dry_run=dry_run,
+            )
+        )
+
+    return errors
+
+
+def clean_temporary(
+    targets: list[ImageTarget],
+    remove_untagged: bool = True,
+    remove_older_than: timedelta | None = None,
+    dry_run: bool = False,
+) -> list[Exception]:
+    """Clean up temporary images in the registry for the given image targets.
+
+    :param targets: Image targets whose temporary registries should be cleaned.
+    :param remove_untagged: If True, remove untagged images.
+    :param remove_older_than: Remove images older than the specified duration.
+    :param dry_run: If True, print what would be deleted without deleting.
+    :return: List of errors encountered during cleanup.
+    """
+    target_caches = list(set([target.temp_name for target in targets]))
+
+    errors = []
+    for target_cache in target_caches:
+        errors.extend(
+            ghcr.clean_temporary_artifacts(
+                ghcr_registry=target_cache,
+                remove_untagged=remove_untagged,
+                remove_older_than=remove_older_than,
+                dry_run=dry_run,
+            )
+        )
+
+    return errors

--- a/posit-bakery/test/cli/test_clean.py
+++ b/posit-bakery/test/cli/test_clean.py
@@ -31,11 +31,13 @@ BASIC_CONTEXT = str(Path(__file__).parent.parent / "resources" / "basic")
 
 @pytest.fixture
 def mock_config():
-    """Mock BakeryConfig to capture settings without making API calls."""
-    with patch("posit_bakery.cli.clean.BakeryConfig") as mock:
+    """Mock BakeryConfig and clean functions to capture settings without making API calls."""
+    with (
+        patch("posit_bakery.cli.clean.BakeryConfig") as mock,
+        patch("posit_bakery.cli.clean.do_clean_caches", return_value=[]),
+        patch("posit_bakery.cli.clean.do_clean_temporary", return_value=[]),
+    ):
         instance = MagicMock()
-        instance.clean_caches.return_value = []
-        instance.clean_temporary.return_value = []
         mock.from_context.return_value = instance
         yield mock
 

--- a/posit-bakery/test/config/test_build_retry.py
+++ b/posit-bakery/test/config/test_build_retry.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from python_on_whales import DockerException
 
-from posit_bakery.config.config import _retry_build, _RETRY_DELAY_SECONDS
+from posit_bakery.image.build import _retry_build, _RETRY_DELAY_SECONDS
 from posit_bakery.error import BakeryFileError, BakeryToolRuntimeError
 
 pytestmark = [
@@ -25,7 +25,7 @@ class TestRetryBuild:
 
         mock_fn.assert_called_once()
 
-    @patch("posit_bakery.config.config.time.sleep")
+    @patch("posit_bakery.image.build.time.sleep")
     def test_retry_on_docker_exception_then_success(self, mock_sleep):
         """Test that DockerException triggers retry and succeeds on second attempt."""
         mock_fn = MagicMock(side_effect=[DockerException(["docker", "build"], 1), None])
@@ -35,7 +35,7 @@ class TestRetryBuild:
         assert mock_fn.call_count == 2
         mock_sleep.assert_called_once_with(_RETRY_DELAY_SECONDS)
 
-    @patch("posit_bakery.config.config.time.sleep")
+    @patch("posit_bakery.image.build.time.sleep")
     def test_retry_on_bakery_tool_runtime_error_then_success(self, mock_sleep):
         """Test that BakeryToolRuntimeError triggers retry and succeeds on second attempt."""
         mock_fn = MagicMock(side_effect=[BakeryToolRuntimeError("Build failed", cmd=["docker", "build"]), None])
@@ -45,7 +45,7 @@ class TestRetryBuild:
         assert mock_fn.call_count == 2
         mock_sleep.assert_called_once_with(_RETRY_DELAY_SECONDS)
 
-    @patch("posit_bakery.config.config.time.sleep")
+    @patch("posit_bakery.image.build.time.sleep")
     def test_all_retries_exhausted_raises_exception(self, mock_sleep):
         """Test that exception is raised when all retries are exhausted."""
         error = DockerException(["docker", "build"], 1)
@@ -68,7 +68,7 @@ class TestRetryBuild:
         # Should only be called once, no retries
         mock_fn.assert_called_once()
 
-    @patch("posit_bakery.config.config.time.sleep")
+    @patch("posit_bakery.image.build.time.sleep")
     def test_retry_zero_means_no_retries(self, mock_sleep):
         """Test that retry=0 means no retries, just one attempt."""
         error = DockerException(["docker", "build"], 1)
@@ -80,7 +80,7 @@ class TestRetryBuild:
         mock_fn.assert_called_once()
         mock_sleep.assert_not_called()
 
-    @patch("posit_bakery.config.config.time.sleep")
+    @patch("posit_bakery.image.build.time.sleep")
     def test_multiple_retries_then_success(self, mock_sleep):
         """Test multiple failures before eventual success."""
         mock_fn = MagicMock(
@@ -96,7 +96,7 @@ class TestRetryBuild:
         assert mock_fn.call_count == 3
         assert mock_sleep.call_count == 2
 
-    @patch("posit_bakery.config.config.time.sleep")
+    @patch("posit_bakery.image.build.time.sleep")
     def test_logs_warning_on_retry(self, mock_sleep, caplog):
         """Test that a warning is logged when retrying."""
         import logging

--- a/posit-bakery/test/config/test_config.py
+++ b/posit-bakery/test/config/test_config.py
@@ -1733,19 +1733,6 @@ class TestBakeryConfig:
         with pytest.raises(ValueError, match=f"Version 'non-existent' does not exist for image '{image_name}'"):
             config.remove_version(image_name, "non-existent")
 
-    def test__merge_sequential_build_metadata_files(self, get_config_obj):
-        """Test merging sequential build metadata files."""
-        config = get_config_obj("basic")
-        for target in config.targets:
-            metadata_filepath = CONFIG_TESTDATA_DIR / "build_metadata" / f"{target.uid}.json"
-            target.build_metadata.append(BuildMetadata.model_validate_json(metadata_filepath.read_text()))
-
-        merged_metadata = config._merge_sequential_build_metadata_files()
-        with open(CONFIG_TESTDATA_DIR / "build_metadata" / "expected.json", "r") as f:
-            expected_metadata = json.load(f)
-
-        assert merged_metadata == expected_metadata
-
     def test_load_build_metadata_file(self, get_config_obj):
         """Test loading a build metadata file."""
         metadata_filepath = CONFIG_TESTDATA_DIR / "build_metadata" / "expected.json"
@@ -1807,7 +1794,10 @@ class TestBakeryConfig:
         mock_ghcr_client_instance.get_package_versions.return_value = cache_ghcr_package_versions_data
 
         # Clean caches
-        config.clean_caches(
+        from posit_bakery.registry_management.clean import clean_caches
+
+        clean_caches(
+            targets=config.targets,
             remove_untagged=untagged,
             remove_older_than=timedelta(days=older_than_days) if older_than_days is not None else None,
         )
@@ -1839,7 +1829,10 @@ class TestBakeryConfig:
         mock_ghcr_client_instance.get_package_versions.return_value = cache_ghcr_package_versions_data
 
         # Clean caches
-        config.clean_caches(
+        from posit_bakery.registry_management.clean import clean_caches
+
+        clean_caches(
+            targets=config.targets,
             remove_untagged=True,
             remove_older_than=timedelta(days=14),
             dry_run=True,
@@ -1898,7 +1891,10 @@ class TestBakeryConfig:
         mock_ghcr_client_instance.get_package_versions.return_value = temp_ghcr_package_versions_data
 
         # Clean temp images
-        config.clean_temporary(
+        from posit_bakery.registry_management.clean import clean_temporary
+
+        clean_temporary(
+            targets=config.targets,
             remove_untagged=untagged,
             remove_older_than=timedelta(days=older_than_days) if older_than_days is not None else None,
         )
@@ -1930,7 +1926,10 @@ class TestBakeryConfig:
         mock_ghcr_client_instance.get_package_versions.return_value = temp_ghcr_package_versions_data
 
         # Clean temp images
-        config.clean_temporary(
+        from posit_bakery.registry_management.clean import clean_temporary
+
+        clean_temporary(
+            targets=config.targets,
             remove_untagged=True,
             remove_older_than=timedelta(days=14),
             dry_run=True,

--- a/posit-bakery/test/config/test_config.py
+++ b/posit-bakery/test/config/test_config.py
@@ -1728,19 +1728,6 @@ class TestBakeryConfig:
         with pytest.raises(ValueError, match=f"Version 'non-existent' does not exist for image '{image_name}'"):
             config.remove_version(image_name, "non-existent")
 
-    def test__merge_sequential_build_metadata_files(self, get_config_obj):
-        """Test merging sequential build metadata files."""
-        config = get_config_obj("basic")
-        for target in config.targets:
-            metadata_filepath = CONFIG_TESTDATA_DIR / "build_metadata" / f"{target.uid}.json"
-            target.build_metadata.append(BuildMetadata.model_validate_json(metadata_filepath.read_text()))
-
-        merged_metadata = config._merge_sequential_build_metadata_files()
-        with open(CONFIG_TESTDATA_DIR / "build_metadata" / "expected.json", "r") as f:
-            expected_metadata = json.load(f)
-
-        assert merged_metadata == expected_metadata
-
     def test_load_build_metadata_file(self, get_config_obj):
         """Test loading a build metadata file."""
         metadata_filepath = CONFIG_TESTDATA_DIR / "build_metadata" / "expected.json"
@@ -1802,7 +1789,10 @@ class TestBakeryConfig:
         mock_ghcr_client_instance.get_package_versions.return_value = cache_ghcr_package_versions_data
 
         # Clean caches
-        config.clean_caches(
+        from posit_bakery.registry_management.clean import clean_caches
+
+        clean_caches(
+            targets=config.targets,
             remove_untagged=untagged,
             remove_older_than=timedelta(days=older_than_days) if older_than_days is not None else None,
         )
@@ -1834,7 +1824,10 @@ class TestBakeryConfig:
         mock_ghcr_client_instance.get_package_versions.return_value = cache_ghcr_package_versions_data
 
         # Clean caches
-        config.clean_caches(
+        from posit_bakery.registry_management.clean import clean_caches
+
+        clean_caches(
+            targets=config.targets,
             remove_untagged=True,
             remove_older_than=timedelta(days=14),
             dry_run=True,
@@ -1893,7 +1886,10 @@ class TestBakeryConfig:
         mock_ghcr_client_instance.get_package_versions.return_value = temp_ghcr_package_versions_data
 
         # Clean temp images
-        config.clean_temporary(
+        from posit_bakery.registry_management.clean import clean_temporary
+
+        clean_temporary(
+            targets=config.targets,
             remove_untagged=untagged,
             remove_older_than=timedelta(days=older_than_days) if older_than_days is not None else None,
         )
@@ -1925,7 +1921,10 @@ class TestBakeryConfig:
         mock_ghcr_client_instance.get_package_versions.return_value = temp_ghcr_package_versions_data
 
         # Clean temp images
-        config.clean_temporary(
+        from posit_bakery.registry_management.clean import clean_temporary
+
+        clean_temporary(
+            targets=config.targets,
             remove_untagged=True,
             remove_older_than=timedelta(days=14),
             dry_run=True,

--- a/posit-bakery/test/config/test_e2e.py
+++ b/posit-bakery/test/config/test_e2e.py
@@ -105,7 +105,10 @@ def test_create_from_scratch_bake_plan(tmpdir, common_image_variants_objects):
     config.generate_image_targets()
 
     # Render the bake plan.
-    result = config.bake_plan_targets()
+    from posit_bakery.image.bake.bake import BakePlan
+
+    bake_plan = BakePlan.from_image_targets(context=config.base_path, image_targets=config.targets)
+    result = bake_plan.model_dump_json(indent=2, exclude_none=True, by_alias=True)
 
     expected_plan = {
         "group": {

--- a/posit-bakery/test/plugins/builtin/dgoss/test_suite.py
+++ b/posit-bakery/test/plugins/builtin/dgoss/test_suite.py
@@ -24,7 +24,9 @@ class TestDGossSuite:
     def test_run(self, get_tmpconfig):
         """Test that DGossSuite run executes the DGoss commands."""
         basic_tmpconfig = get_tmpconfig("basic")
-        basic_tmpconfig.build_targets()
+        from posit_bakery.image.build import build_targets
+
+        build_targets(basic_tmpconfig.targets, basic_tmpconfig.base_path)
 
         dgoss_suite = DGossSuite(basic_tmpconfig.base_path, basic_tmpconfig.targets)
 


### PR DESCRIPTION
## Summary

- Extract CI matrix and merge logic from `cli/ci.py` into `posit_bakery/ci.py`
- Extract build orchestration from `config/config.py` into `posit_bakery/image/build.py`
- Extract registry cleanup from `config/config.py` into `posit_bakery/registry_management/clean.py`

`BakeryConfig` was a god class handling config parsing, build orchestration, registry cleanup, and CI matrix generation. The CLI also contained domain logic (matrix construction, glob resolution) that duplicated filtering already done by `generate_image_targets()`.

After this change, `BakeryConfig` only handles YAML lifecycle, CRUD, and target generation. Build, clean, and CI operations are standalone functions that accept `list[ImageTarget]` as input. The CLI is a thin adapter: parse args, load config, call function, format output.

`config/config.py` drops from 1,053 to 866 LOC and no longer imports `BakePlan`, `python_on_whales`, `DockerException`, `ghcr`, `timedelta`, or `ImageBuildStrategy`.

## Test plan

- [x] All existing tests pass (1266 passed, 0 failures)
- [ ] Verify `bakery build` works end-to-end in a product repo
- [ ] Verify `bakery ci matrix` output matches current behavior in CI
- [ ] Verify `bakery clean cache-registry` and `bakery clean temp-registry` work