### PR TITLE
Warn on GHCR delete failures for >5000-downloads error

### DIFF
--- a/posit-bakery/posit_bakery/registry_management/ghcr/api.py
+++ b/posit-bakery/posit_bakery/registry_management/ghcr/api.py
@@ -9,6 +9,11 @@ from posit_bakery.registry_management.ghcr.models import GHCRPackageVersions, GH
 
 log = logging.getLogger(__name__)
 
+# GitHub intermittently returns this message when deleting public package versions, even when
+# the version does not actually have 5000+ downloads. Treat it as a warning so a flaky response
+# doesn't fail CI — the next cleanup run typically deletes the version successfully.
+FLAKY_DOWNLOAD_LIMIT_MESSAGE = "5000 downloads cannot be deleted"
+
 
 class GHCRClient:
     ENDPOINTS = {
@@ -61,7 +66,7 @@ class GHCRClient:
 
     def delete_package_version(self, version: GHCRPackageVersion):
         target_endpoint = version.url.removeprefix("https://api.github.com")
-        logging.debug(f"DELETE {target_endpoint}")
+        log.debug(f"DELETE {target_endpoint}")
         self.client.requester.requestJsonAndCheck(
             "DELETE",
             target_endpoint,
@@ -73,6 +78,9 @@ class GHCRClient:
             try:
                 self.delete_package_version(version)
             except GithubException as e:
-                logging.error(f"Failed to delete package version {version.html_url}: {e.message}")
+                if e.message and FLAKY_DOWNLOAD_LIMIT_MESSAGE in e.message:
+                    log.warning(f"Skipping package version {version.html_url}: {e.message}")
+                    continue
+                log.error(f"Failed to delete package version {version.html_url}: {e.message}")
                 errors.append((version.id, e.message))
         return errors

--- a/posit-bakery/test/registry_management/ghcr/test_api.py
+++ b/posit-bakery/test/registry_management/ghcr/test_api.py
@@ -1,0 +1,93 @@
+import logging
+
+import pytest
+from github import GithubException
+
+from posit_bakery.registry_management.ghcr.api import GHCRClient
+from posit_bakery.registry_management.ghcr.models import (
+    GHCRPackageVersion,
+    GHCRPackageVersionContainerMetadata,
+    GHCRPackageVersionMetadata,
+    GHCRPackageVersions,
+)
+
+
+def _make_version(version_id: int) -> GHCRPackageVersion:
+    return GHCRPackageVersion(
+        id=version_id,
+        name=f"sha256:{version_id:064x}",
+        url=f"https://api.github.com/orgs/posit-test/packages/container/pkg/versions/{version_id}",
+        package_html_url="https://github.com/orgs/posit-test/packages/container/package/pkg",
+        created_at="2026-01-01T00:00:00Z",
+        updated_at="2026-01-02T00:00:00Z",
+        html_url=f"https://github.com/orgs/posit-test/packages/container/pkg/{version_id}",
+        metadata=GHCRPackageVersionMetadata(
+            package_type="container",
+            container=GHCRPackageVersionContainerMetadata(tags=[]),
+        ),
+    )
+
+
+@pytest.fixture
+def client(mocker):
+    mocker.patch("posit_bakery.registry_management.ghcr.api.Auth")
+    mocker.patch("posit_bakery.registry_management.ghcr.api.Github")
+    return GHCRClient("posit-test", token="fake-token")
+
+
+class TestDeletePackageVersions:
+    def test_returns_no_errors_when_all_succeed(self, client, mocker):
+        mocker.patch.object(client, "delete_package_version")
+        versions = GHCRPackageVersions(versions=[_make_version(1), _make_version(2)])
+
+        errors = client.delete_package_versions(versions)
+
+        assert errors == []
+
+    def test_collects_errors_for_generic_failures(self, client, mocker):
+        mocker.patch.object(
+            client,
+            "delete_package_version",
+            side_effect=GithubException(500, data={}, message="Internal server error"),
+        )
+        versions = GHCRPackageVersions(versions=[_make_version(1)])
+
+        errors = client.delete_package_versions(versions)
+
+        assert len(errors) == 1
+        assert errors[0] == (1, "Internal server error")
+
+    def test_suppresses_5000_downloads_error_as_warning(self, client, mocker, caplog):
+        message = (
+            "Publicly visible package versions with more than 5000 downloads cannot be deleted. "
+            "Contact GitHub support for further assistance."
+        )
+        mocker.patch.object(
+            client,
+            "delete_package_version",
+            side_effect=GithubException(422, data={}, message=message),
+        )
+        versions = GHCRPackageVersions(versions=[_make_version(1)])
+
+        with caplog.at_level(logging.WARNING, logger="posit_bakery.registry_management.ghcr.api"):
+            errors = client.delete_package_versions(versions)
+
+        assert errors == []
+        assert any("5000 downloads" in record.message and record.levelno == logging.WARNING for record in caplog.records)
+
+    def test_mixed_results_only_reports_non_flaky_errors(self, client, mocker):
+        flaky = GithubException(
+            422,
+            data={},
+            message="Publicly visible package versions with more than 5000 downloads cannot be deleted.",
+        )
+        real = GithubException(500, data={}, message="Internal server error")
+        mocker.patch.object(client, "delete_package_version", side_effect=[flaky, real, None])
+        versions = GHCRPackageVersions(
+            versions=[_make_version(1), _make_version(2), _make_version(3)],
+        )
+
+        errors = client.delete_package_versions(versions)
+
+        assert len(errors) == 1
+        assert errors[0][0] == 2


### PR DESCRIPTION
## Summary
- GitHub intermittently returns `Publicly visible package versions with more than 5000 downloads cannot be deleted.` when cleaning package versions that do not actually meet that threshold, failing `bakery clean cache-registry` / `bakery clean temp-registry` in CI.
- `GHCRClient.delete_package_versions` now detects that specific message, logs it as a warning, and does not include it in the returned errors list — so the CLI exits 0 and the next cleanup run picks up the stragglers.
- Added a focused unit test module (`test/registry_management/ghcr/test_api.py`) covering the suppression path, generic failure path, and mixed-results case.

## Test plan
- [x] `uv run pytest test/registry_management/ghcr/test_api.py` passes (4 tests)
- [x] `uv run pytest test/config/test_config.py -k clean` still passes (13 tests, no regressions)
- [ ] Observe next scheduled `clean.yml` run in a product repo to confirm the flaky message no longer fails the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)