### PR TITLE
Warn on "Package version not found" GHCR delete errors

### DIFF
--- a/posit-bakery/posit_bakery/registry_management/ghcr/api.py
+++ b/posit-bakery/posit_bakery/registry_management/ghcr/api.py
@@ -14,6 +14,10 @@ log = logging.getLogger(__name__)
 # doesn't fail CI — the next cleanup run typically deletes the version successfully.
 FLAKY_DOWNLOAD_LIMIT_MESSAGE = "5000 downloads cannot be deleted"
 
+# Concurrent cleanup runs can race: a version discovered by this run may already have been
+# deleted by another run by the time we get to it. Treat as a warning rather than failing.
+VERSION_NOT_FOUND_MESSAGE = "Package version not found"
+
 
 class GHCRClient:
     ENDPOINTS = {
@@ -80,6 +84,12 @@ class GHCRClient:
             except GithubException as e:
                 if e.message and FLAKY_DOWNLOAD_LIMIT_MESSAGE in e.message:
                     log.warning(f"Skipping package version {version.html_url}: {e.message}")
+                    continue
+                if e.message and VERSION_NOT_FOUND_MESSAGE in e.message:
+                    log.warning(
+                        f"Skipping package version {version.html_url}: {e.message}. "
+                        "The version may have already been deleted by a concurrent cleanup run."
+                    )
                     continue
                 log.error(f"Failed to delete package version {version.html_url}: {e.message}")
                 errors.append((version.id, e.message))

--- a/posit-bakery/test/registry_management/ghcr/test_api.py
+++ b/posit-bakery/test/registry_management/ghcr/test_api.py
@@ -77,6 +77,26 @@ class TestDeletePackageVersions:
             "5000 downloads" in record.message and record.levelno == logging.WARNING for record in caplog.records
         )
 
+    def test_suppresses_version_not_found_error_as_warning(self, client, mocker, caplog):
+        message = "Package version not found"
+        mocker.patch.object(
+            client,
+            "delete_package_version",
+            side_effect=GithubException(404, data={}, message=message),
+        )
+        versions = GHCRPackageVersions(versions=[_make_version(1)])
+
+        with caplog.at_level(logging.WARNING, logger="posit_bakery.registry_management.ghcr.api"):
+            errors = client.delete_package_versions(versions)
+
+        assert errors == []
+        assert any(
+            "Package version not found" in record.message
+            and "concurrent cleanup run" in record.message
+            and record.levelno == logging.WARNING
+            for record in caplog.records
+        )
+
     def test_mixed_results_only_reports_non_flaky_errors(self, client, mocker):
         flaky = GithubException(
             422,


### PR DESCRIPTION
## Summary
- Treat GHCR `Package version not found` delete failures as warnings instead of errors, since concurrent cleanup runs can race and delete a version before this run reaches it.
- Mirrors the existing handling for the flaky `5000 downloads cannot be deleted` message and includes a hint that the version may have been deleted by a concurrent cleanup.
- Adds a unit test covering the new warning path.

## Test plan
- [x] `uv run pytest test/registry_management/ghcr/test_api.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)