### PR TITLE
Skip lint on push-to-tag builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,12 @@ jobs:
     steps:
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe  # v1.2.2
         with:
-          allowed-skips: bakery-pr
+          allowed-skips: bakery-pr, lint
           jobs: ${{ toJSON(needs) }}
 
   lint:
     name: Lint
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/product-release.yml
+++ b/.github/workflows/product-release.yml
@@ -28,6 +28,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary

- Adds ``if`` guard to lint job so it only runs on ``pull_request`` and ``merge_group`` events
- Adds ``lint`` to ``allowed-skips`` so the CI gate passes on tag pushes

Pre-commit is a PR-time check. Running it on tag pushes wastes time — the code already passed lint on the PR.

## Test plan

- [ ] CI passes on this PR (lint runs)
- [ ] Tag push builds skip lint without failing the CI gate