### PR TITLE
Implement latest tag for image matrix builds

### DIFF
--- a/posit-bakery/docs/configuration.qmd
+++ b/posit-bakery/docs/configuration.qmd
@@ -309,6 +309,14 @@ This generates four image versions:
 - `r4.3.3-py3.12`
 - `r4.3.3-py3.11`
 
+#### Latest Tag Selection
+
+When every version-bearing axis (each `dependency`, each `dependencyConstraint` after resolution, and each list-typed entry in `values`) contains version-parseable strings, Bakery automatically marks the cartesian-product row at the maximum version of every axis as the "latest" combination. That row inherits the same `latest`-family tags applied to non-matrix versions — including the bare `latest` tag when paired with the primary OS and primary variant.
+
+In the example above, the latest combination is `r4.4.3-py3.12`. Built against the primary OS and primary variant (if any), it would receive `latest`, `<os>`, `<variant>`, and `<os>-<variant>` tags in addition to its existing matrix tags.
+
+If any axis has a non-version-parseable entry (e.g., a list-typed `values` axis containing `["alpha", "beta"]`), Bakery emits a warning naming the offending axis and value, and the matrix produces no `latest`-family tags. Scalar (non-list) `values` are constant across the cartesian product and do not affect the latest selection.
+
 ### DependencyConstraint
 
 A DependencyConstraint represents a software dependency installed in a specific image.

--- a/posit-bakery/posit_bakery/config/image/matrix.py
+++ b/posit-bakery/posit_bakery/config/image/matrix.py
@@ -415,6 +415,13 @@ class ImageMatrix(BakeryPathMixin, BakeryYAMLModel):
 
         selected: dict[str, str] = {}
         for axis_key, candidates in axes:
+            if not candidates:
+                log.warning(
+                    f"Image matrix '{self.namePattern}': cannot determine latest because axis "
+                    f"'{axis_key}' has no candidate versions. "
+                    f"No 'latest'-family tags will be emitted for this matrix."
+                )
+                return None
             parsed: list[tuple[DependencyVersion, str]] = []
             for candidate in candidates:
                 try:

--- a/posit-bakery/posit_bakery/config/image/matrix.py
+++ b/posit-bakery/posit_bakery/config/image/matrix.py
@@ -693,8 +693,10 @@ class ImageMatrix(BakeryPathMixin, BakeryYAMLModel):
         """
         image_versions = []
 
+        latest_pick = self.latest_combination
         products = self._cartesian_product(self.resolved_dependencies, self.values)
         for product in products:
+            is_latest = latest_pick is not None and self._matches_latest(product, latest_pick)
             image_version = ImageVersion(
                 parent=self.parent,
                 name=self._render_name_pattern(self.namePattern, product["dependencies"], product["values"]),
@@ -705,8 +707,26 @@ class ImageMatrix(BakeryPathMixin, BakeryYAMLModel):
                 dependencies=product["dependencies"],
                 values=product["values"],
                 isMatrixVersion=True,
+                latest=is_latest,
                 buildTarget=self.buildTarget,
             )
             image_versions.append(image_version)
 
         return image_versions
+
+    @staticmethod
+    def _matches_latest(product: dict[str, list | dict], latest_pick: dict[str, str]) -> bool:
+        """Return True iff every dependency and list-typed value in ``product`` equals
+        the corresponding entry in ``latest_pick`` (by original-string equality).
+
+        Scalar values are not compared — they are constant across all rows.
+        """
+        for dep in product["dependencies"]:
+            expected = latest_pick.get(dep.dependency)
+            if expected is None or dep.versions[0] != expected:
+                return False
+        for key, value in product["values"].items():
+            axis_key = f"value:{key}"
+            if axis_key in latest_pick and value != latest_pick[axis_key]:
+                return False
+        return True

--- a/posit-bakery/posit_bakery/config/image/matrix.py
+++ b/posit-bakery/posit_bakery/config/image/matrix.py
@@ -412,8 +412,7 @@ class ImageMatrix(BakeryPathMixin, BakeryYAMLModel):
                         f"No 'latest'-family tags will be emitted for this matrix."
                     )
                     return None
-            max_version, max_original = max(parsed, key=lambda pair: pair[0])
-            selected[axis_key] = max_original
+            selected[axis_key] = max(parsed, key=lambda pair: pair[0])[1]
 
         return selected
 

--- a/posit-bakery/posit_bakery/config/image/matrix.py
+++ b/posit-bakery/posit_bakery/config/image/matrix.py
@@ -16,6 +16,7 @@ from posit_bakery.config.dependencies import (
     get_dependency_versions_class,
     DependencyVersions,
 )
+from posit_bakery.config.dependencies.version import DependencyVersion
 from posit_bakery.config.image.build_os import TargetPlatform, DEFAULT_PLATFORMS
 from posit_bakery.config.registry import BaseRegistry, Registry
 from posit_bakery.config.shared import BakeryPathMixin, BakeryYAMLModel
@@ -373,6 +374,48 @@ class ImageMatrix(BakeryPathMixin, BakeryYAMLModel):
             resolved.append(dc.resolve_versions())
 
         return resolved
+
+    @property
+    def latest_combination(self) -> dict[str, str] | None:
+        """Resolve the cartesian-product row that represents the matrix's "latest" combination.
+
+        Returns a dict mapping each version-bearing axis to the original string of its
+        maximum version, or ``None`` when any axis has a candidate that cannot be parsed
+        as a version (in which case a warning is logged and the matrix emits no
+        ``latest``-family tags).
+
+        Axes considered:
+          * Every entry in :pyattr:`resolved_dependencies` (key = ``entry.dependency``).
+          * Every entry in :pyattr:`values` whose value is a ``list`` (key = ``f"value:{key}"``).
+
+        Scalar ``values`` are constant across the cartesian product and are skipped.
+        """
+        axes: list[tuple[str, list[str]]] = []
+        for entry in self.resolved_dependencies:
+            axes.append((entry.dependency, list(entry.versions)))
+        for key, value in self.values.items():
+            if isinstance(value, list):
+                axes.append((f"value:{key}", [str(v) for v in value]))
+
+        selected: dict[str, str] = {}
+        for axis_key, candidates in axes:
+            parsed: list[tuple[DependencyVersion, str]] = []
+            for candidate in candidates:
+                try:
+                    parsed.append((DependencyVersion(candidate), candidate))
+                except Exception as e:
+                    # packaging raises InvalidVersion (a ValueError subclass); we keep this
+                    # broad to also catch any defensive parsing errors from DependencyVersion.
+                    log.warning(
+                        f"Image matrix '{self.namePattern}': cannot determine latest because axis "
+                        f"'{axis_key}' has unparseable version '{candidate}' ({e}). "
+                        f"No 'latest'-family tags will be emitted for this matrix."
+                    )
+                    return None
+            max_version, max_original = max(parsed, key=lambda pair: pair[0])
+            selected[axis_key] = max_original
+
+        return selected
 
     def generate_template_values(
         self,

--- a/posit-bakery/posit_bakery/config/image/matrix.py
+++ b/posit-bakery/posit_bakery/config/image/matrix.py
@@ -727,6 +727,8 @@ class ImageMatrix(BakeryPathMixin, BakeryYAMLModel):
                 return False
         for key, value in product["values"].items():
             axis_key = f"value:{key}"
-            if axis_key in latest_pick and value != latest_pick[axis_key]:
+            # latest_combination stringifies list-value candidates; mirror that here
+            # so YAML-typed scalars (e.g., ints/floats) compare correctly.
+            if axis_key in latest_pick and str(value) != latest_pick[axis_key]:
                 return False
         return True

--- a/posit-bakery/posit_bakery/config/image/matrix.py
+++ b/posit-bakery/posit_bakery/config/image/matrix.py
@@ -2,6 +2,7 @@ import itertools
 import logging
 import re
 from copy import deepcopy
+from functools import cached_property
 from pathlib import Path
 from shutil import copy2
 from typing import Annotated, Union, Self, Any, Literal
@@ -349,6 +350,18 @@ class ImageMatrix(BakeryPathMixin, BakeryYAMLModel):
             version_os.parent = self
         return self
 
+    @model_validator(mode="after")
+    def _invalidate_resolved_dependencies_cache(self) -> Self:
+        """Clear the :pyattr:`resolved_dependencies` cache.
+
+        With ``validate_assignment=True`` this validator also runs on every field
+        assignment, so mutations to ``dependencies`` or ``dependencyConstraints``
+        (e.g., via :pymeth:`Image.create_matrix` with ``update_if_exists=True``)
+        do not leave a stale cached list behind.
+        """
+        self.__dict__.pop("resolved_dependencies", None)
+        return self
+
     @property
     def supported_platforms(self) -> list[TargetPlatform]:
         """Returns a list of supported target platforms for this image version.
@@ -365,9 +378,14 @@ class ImageMatrix(BakeryPathMixin, BakeryYAMLModel):
                     platforms.append(platform)
         return platforms
 
-    @property
+    @cached_property
     def resolved_dependencies(self) -> list[DependencyVersions]:
         """Returns the list of resolved dependencies for this image version.
+
+        Cached after the first access — constraint resolution can hit the network
+        (e.g., the Python constraint reads from astral-sh/python-build-standalone),
+        and callers like :pyattr:`latest_combination` and :pymeth:`to_image_versions`
+        may both read this property within a single build.
 
         :return: A list of DependencyVersions objects.
         """

--- a/posit-bakery/posit_bakery/config/image/matrix.py
+++ b/posit-bakery/posit_bakery/config/image/matrix.py
@@ -382,7 +382,9 @@ class ImageMatrix(BakeryPathMixin, BakeryYAMLModel):
         Returns a dict mapping each version-bearing axis to the original string of its
         maximum version, or ``None`` when any axis has a candidate that cannot be parsed
         as a version (in which case a warning is logged and the matrix emits no
-        ``latest``-family tags).
+        ``latest``-family tags). Also returns ``None`` when the matrix has no
+        version-bearing axes (no dependencies and no list-typed values), since there is
+        nothing to select a "latest" row from.
 
         Axes considered:
           * Every entry in :pyattr:`resolved_dependencies` (key = ``entry.dependency``).
@@ -390,12 +392,24 @@ class ImageMatrix(BakeryPathMixin, BakeryYAMLModel):
 
         Scalar ``values`` are constant across the cartesian product and are skipped.
         """
+        return self._compute_latest_combination(self.resolved_dependencies)
+
+    def _compute_latest_combination(self, resolved_dependencies: list[DependencyVersions]) -> dict[str, str] | None:
+        """Helper for :pyattr:`latest_combination` that uses a pre-resolved deps list.
+
+        Accepting the resolved list as a parameter lets callers (notably
+        :pymeth:`to_image_versions`) resolve dependency constraints once rather than
+        triggering the network-bound :pyattr:`resolved_dependencies` property twice.
+        """
         axes: list[tuple[str, list[str]]] = []
-        for entry in self.resolved_dependencies:
+        for entry in resolved_dependencies:
             axes.append((entry.dependency, list(entry.versions)))
         for key, value in self.values.items():
             if isinstance(value, list):
                 axes.append((f"value:{key}", [str(v) for v in value]))
+
+        if not axes:
+            return None
 
         selected: dict[str, str] = {}
         for axis_key, candidates in axes:
@@ -693,8 +707,12 @@ class ImageMatrix(BakeryPathMixin, BakeryYAMLModel):
         """
         image_versions = []
 
-        latest_pick = self.latest_combination
-        products = self._cartesian_product(self.resolved_dependencies, self.values)
+        # Resolve dependency constraints once; the property is network-bound and
+        # deepcopies, so reuse the result across both the cartesian product and the
+        # latest-row computation.
+        resolved_deps = self.resolved_dependencies
+        latest_pick = self._compute_latest_combination(resolved_deps)
+        products = self._cartesian_product(resolved_deps, self.values)
         for product in products:
             is_latest = latest_pick is not None and self._matches_latest(product, latest_pick)
             image_version = ImageVersion(

--- a/posit-bakery/posit_bakery/config/image/matrix.py
+++ b/posit-bakery/posit_bakery/config/image/matrix.py
@@ -16,6 +16,8 @@ from posit_bakery.config.dependencies import (
     get_dependency_versions_class,
     DependencyVersions,
 )
+from packaging.version import InvalidVersion
+
 from posit_bakery.config.dependencies.version import DependencyVersion
 from posit_bakery.config.image.build_os import TargetPlatform, DEFAULT_PLATFORMS
 from posit_bakery.config.registry import BaseRegistry, Registry
@@ -417,12 +419,18 @@ class ImageMatrix(BakeryPathMixin, BakeryYAMLModel):
             for candidate in candidates:
                 try:
                     parsed.append((DependencyVersion(candidate), candidate))
-                except Exception as e:
-                    # packaging raises InvalidVersion (a ValueError subclass); we keep this
-                    # broad to also catch any defensive parsing errors from DependencyVersion.
+                except InvalidVersion as e:
                     log.warning(
                         f"Image matrix '{self.namePattern}': cannot determine latest because axis "
                         f"'{axis_key}' has unparseable version '{candidate}' ({e}). "
+                        f"No 'latest'-family tags will be emitted for this matrix."
+                    )
+                    return None
+                except Exception as e:
+                    log.warning(
+                        f"Image matrix '{self.namePattern}': cannot determine latest because axis "
+                        f"'{axis_key}' raised an unexpected error processing '{candidate}' "
+                        f"({type(e).__name__}: {e}). "
                         f"No 'latest'-family tags will be emitted for this matrix."
                     )
                     return None

--- a/posit-bakery/posit_bakery/config/tag.py
+++ b/posit-bakery/posit_bakery/config/tag.py
@@ -73,6 +73,33 @@ class TagPattern(BakeryYAMLModel):
         return hash((tuple(self.patterns), tuple(self.only)))
 
 
+def _shared_latest_tag_patterns() -> list[TagPattern]:
+    """Return the LATEST-filtered tag patterns shared by every default-pattern set.
+
+    These patterns don't reference ``Version``, so they're version-shape-agnostic and
+    safe to use for both static-version images (where ``Version`` may be ``"1.2.3"``)
+    and matrix images (where ``Version`` may be a composite like ``"R4.3.3-python3.11.15"``).
+    """
+    return [
+        TagPattern(
+            patterns=["{{ OS }}-{{ Variant }}"],
+            only=[TagPatternFilter.LATEST],
+        ),
+        TagPattern(
+            patterns=["{{ OS }}"],
+            only=[TagPatternFilter.LATEST, TagPatternFilter.PRIMARY_VARIANT],
+        ),
+        TagPattern(
+            patterns=["{{ Variant }}"],
+            only=[TagPatternFilter.LATEST, TagPatternFilter.PRIMARY_OS],
+        ),
+        TagPattern(
+            patterns=["latest"],
+            only=[TagPatternFilter.LATEST, TagPatternFilter.PRIMARY_OS, TagPatternFilter.PRIMARY_VARIANT],
+        ),
+    ]
+
+
 def default_tag_patterns() -> list[TagPattern]:
     """Return the default tag patterns for images in the Bakery configuration.
 
@@ -98,22 +125,7 @@ def default_tag_patterns() -> list[TagPattern]:
             patterns=["{{ Version }}", "{{ Version | stripMetadata }}"],
             only=[TagPatternFilter.PRIMARY_OS, TagPatternFilter.PRIMARY_VARIANT],
         ),
-        TagPattern(
-            patterns=["{{ OS }}-{{ Variant }}"],
-            only=[TagPatternFilter.LATEST],
-        ),
-        TagPattern(
-            patterns=["{{ OS }}"],
-            only=[TagPatternFilter.LATEST, TagPatternFilter.PRIMARY_VARIANT],
-        ),
-        TagPattern(
-            patterns=["{{ Variant }}"],
-            only=[TagPatternFilter.LATEST, TagPatternFilter.PRIMARY_OS],
-        ),
-        TagPattern(
-            patterns=["latest"],
-            only=[TagPatternFilter.LATEST, TagPatternFilter.PRIMARY_OS, TagPatternFilter.PRIMARY_VARIANT],
-        ),
+        *_shared_latest_tag_patterns(),
         TagPattern(
             patterns=["{{ Stream }}-{{ OS }}-{{ Variant }}"],
             only=[TagPatternFilter.ALL],
@@ -160,20 +172,5 @@ def default_matrix_tag_patterns() -> list[TagPattern]:
             patterns=["{{ Version }}"],
             only=[TagPatternFilter.PRIMARY_OS, TagPatternFilter.PRIMARY_VARIANT],
         ),
-        TagPattern(
-            patterns=["{{ OS }}-{{ Variant }}"],
-            only=[TagPatternFilter.LATEST],
-        ),
-        TagPattern(
-            patterns=["{{ OS }}"],
-            only=[TagPatternFilter.LATEST, TagPatternFilter.PRIMARY_VARIANT],
-        ),
-        TagPattern(
-            patterns=["{{ Variant }}"],
-            only=[TagPatternFilter.LATEST, TagPatternFilter.PRIMARY_OS],
-        ),
-        TagPattern(
-            patterns=["latest"],
-            only=[TagPatternFilter.LATEST, TagPatternFilter.PRIMARY_OS, TagPatternFilter.PRIMARY_VARIANT],
-        ),
+        *_shared_latest_tag_patterns(),
     ]

--- a/posit-bakery/posit_bakery/config/tag.py
+++ b/posit-bakery/posit_bakery/config/tag.py
@@ -139,8 +139,7 @@ def default_matrix_tag_patterns() -> list[TagPattern]:
     Matrix images use composite version names (e.g., "R4.3.3-python3.11.15") where the
     hyphen separators conflict with the stripMetadata filter, which strips from the last
     hyphen onward. This set excludes stripMetadata patterns to avoid tag collisions across
-    matrix combinations. It also excludes latest-filtered patterns since matrices are
-    currently naive to the concept of "latest".
+    matrix combinations.
 
     :return: A list of TagPattern objects representing the default matrix tag patterns.
     """
@@ -160,5 +159,21 @@ def default_matrix_tag_patterns() -> list[TagPattern]:
         TagPattern(
             patterns=["{{ Version }}"],
             only=[TagPatternFilter.PRIMARY_OS, TagPatternFilter.PRIMARY_VARIANT],
+        ),
+        TagPattern(
+            patterns=["{{ OS }}-{{ Variant }}"],
+            only=[TagPatternFilter.LATEST],
+        ),
+        TagPattern(
+            patterns=["{{ OS }}"],
+            only=[TagPatternFilter.LATEST, TagPatternFilter.PRIMARY_VARIANT],
+        ),
+        TagPattern(
+            patterns=["{{ Variant }}"],
+            only=[TagPatternFilter.LATEST, TagPatternFilter.PRIMARY_OS],
+        ),
+        TagPattern(
+            patterns=["latest"],
+            only=[TagPatternFilter.LATEST, TagPatternFilter.PRIMARY_OS, TagPatternFilter.PRIMARY_VARIANT],
         ),
     ]

--- a/posit-bakery/test/config/image/test_matrix.py
+++ b/posit-bakery/test/config/image/test_matrix.py
@@ -678,6 +678,51 @@ class TestImageMatrix:
         assert "{{ Image.Name }}" in script_content  # Should be literal
         assert "#!/bin/bash" in script_content
 
+    def test_latest_matrix_target_emits_latest_tag(self, patch_requests_get):
+        """Integration: latest matrix row + primary OS + no variants emits 'latest' tag."""
+        from posit_bakery.config.image.image import Image
+        from posit_bakery.image.image_target import ImageTarget
+        from posit_bakery.config.repository import Repository
+
+        # Minimal Image with a matrix; tagPatterns defaults to default_matrix_tag_patterns()
+        image = Image(
+            name="content",
+            matrix={
+                "namePattern": "python{{ Dependencies.python }}",
+                "dependencies": [
+                    {"dependency": "python", "versions": ["3.11.5", "3.12.3"]},
+                ],
+                "os": [
+                    {"name": "Ubuntu 24.04", "primary": True},
+                ],
+            },
+        )
+
+        # The Image needs a parent (BakeryConfigDocument) for path resolution in
+        # ImageTarget. A mock with a valid path is sufficient for tag rendering.
+        mock_config_parent = MagicMock(spec=BakeryConfigDocument)
+        mock_config_parent.path = Path("/tmp/path")
+        mock_config_parent.registries = []
+        image.parent = mock_config_parent
+
+        repo = Repository(url="https://example.com/repo", vendor="Example", maintainer="dev <dev@example.com>")
+        image_versions = image.matrix.to_image_versions()
+        latest_iv = next(iv for iv in image_versions if iv.latest)
+        primary_os = latest_iv.os[0]
+
+        target = ImageTarget.new_image_target(
+            repository=repo,
+            image_version=latest_iv,
+            image_variant=None,
+            image_os=primary_os,
+        )
+
+        suffixes = set(target.tag_suffixes)
+        # Latest + primary OS + (no variant -> primary by default) yields the bare 'latest' tag.
+        assert "latest" in suffixes
+        # Existing matrix tag still emitted.
+        assert "python3.12.3" in suffixes
+
     def test_render_files_preserves_template_file_mode(self, tmp_path):
         """Test that matrix render_files propagates the template file mode to rendered output."""
         image_dir = tmp_path / "test-image"

--- a/posit-bakery/test/config/image/test_matrix.py
+++ b/posit-bakery/test/config/image/test_matrix.py
@@ -930,3 +930,55 @@ class TestLatestCombination:
         assert "value:flavor" in message
         # Should not be reported as a parse failure — the list is empty, not malformed.
         assert "unparseable" not in message.lower()
+
+    def test_resolved_dependencies_is_cached(self, patch_requests_get):
+        """Repeated reads should reuse the resolved list to avoid re-resolving constraints.
+
+        Constraint resolution (e.g., for Python) hits the network, so callers that
+        access ``resolved_dependencies`` multiple times — directly or via
+        ``latest_combination`` and ``to_image_versions`` — should hit the cache.
+        """
+        matrix = ImageMatrix(
+            dependencyConstraints=[
+                PythonDependencyConstraint(
+                    dependency="python",
+                    constraint={"latest": True, "count": 1},
+                ),
+            ],
+        )
+
+        first = matrix.resolved_dependencies
+        second = matrix.resolved_dependencies
+
+        # Same object reference proves the result was cached, not recomputed.
+        assert first is second
+
+    def test_resolved_dependencies_cache_invalidates_on_assignment(self, patch_requests_get):
+        """Mutating dependency fields should invalidate the cache so callers see fresh data."""
+        matrix = ImageMatrix(
+            dependencyConstraints=[
+                PythonDependencyConstraint(
+                    dependency="python",
+                    constraint={"latest": True, "count": 1},
+                ),
+            ],
+        )
+
+        before = matrix.resolved_dependencies
+        assert len(before) == 1
+
+        # Replace the constraints entirely; the cached list must not be reused.
+        matrix.dependencyConstraints = [
+            PythonDependencyConstraint(
+                dependency="python",
+                constraint={"latest": True, "count": 2},
+            ),
+            RDependencyConstraint(
+                dependency="R",
+                constraint={"latest": True, "count": 1},
+            ),
+        ]
+
+        after = matrix.resolved_dependencies
+        assert after is not before
+        assert {dv.dependency for dv in after} == {"python", "R"}

--- a/posit-bakery/test/config/image/test_matrix.py
+++ b/posit-bakery/test/config/image/test_matrix.py
@@ -16,6 +16,8 @@ from posit_bakery.config.dependencies import (
     QuartoDependencyConstraint,
 )
 from posit_bakery.config.image.matrix import generate_default_name_pattern, ImageMatrix, DEFAULT_MATRIX_SUBPATH
+from posit_bakery.config.repository import Repository
+from posit_bakery.image.image_target import ImageTarget
 
 
 @pytest.mark.parametrize(
@@ -680,10 +682,6 @@ class TestImageMatrix:
 
     def test_latest_matrix_target_emits_latest_tag(self, patch_requests_get):
         """Integration: latest matrix row + primary OS + no variants emits 'latest' tag."""
-        from posit_bakery.config.image.image import Image
-        from posit_bakery.image.image_target import ImageTarget
-        from posit_bakery.config.repository import Repository
-
         # Minimal Image with a matrix; tagPatterns defaults to default_matrix_tag_patterns()
         image = Image(
             name="content",

--- a/posit-bakery/test/config/image/test_matrix.py
+++ b/posit-bakery/test/config/image/test_matrix.py
@@ -913,3 +913,20 @@ class TestLatestCombination:
         assert "python" in message
         assert "3.12.3" in message
         assert "disk on fire" in message
+
+    def test_empty_list_value_returns_none_and_warns(self, caplog):
+        """An empty list-typed value has no candidates; latest is undeterminable."""
+        matrix = ImageMatrix(
+            dependencies=[PythonDependencyVersions(dependency="python", versions=["3.12.3"])],
+            values={"flavor": []},
+        )
+        caplog.clear()
+        with caplog.at_level("WARNING"):
+            result = matrix.latest_combination
+        assert result is None
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warnings) == 1, f"Expected exactly one warning, got: {[r.message for r in warnings]}"
+        message = warnings[0].message
+        assert "value:flavor" in message
+        # Should not be reported as a parse failure — the list is empty, not malformed.
+        assert "unparseable" not in message.lower()

--- a/posit-bakery/test/config/image/test_matrix.py
+++ b/posit-bakery/test/config/image/test_matrix.py
@@ -766,7 +766,8 @@ class TestLatestCombination:
         warnings = [r for r in caplog.records if r.levelname == "WARNING"]
         assert len(warnings) == 1, f"Expected exactly one warning, got: {[r.message for r in warnings]}"
         assert "value:flavor" in warnings[0].message
-        assert "alpha" in warnings[0].message or "beta" in warnings[0].message
+        # Iteration is in-order; the first unparseable candidate ("alpha") is reported.
+        assert "alpha" in warnings[0].message
 
     def test_unparseable_dependency_version_returns_none_and_warns(self, caplog):
         # Build via dict so pydantic discriminator accepts arbitrary version strings.
@@ -784,7 +785,7 @@ class TestLatestCombination:
             result = matrix.latest_combination
         assert result is None
         warnings = [r for r in caplog.records if r.levelname == "WARNING"]
-        assert len(warnings) == 1
+        assert len(warnings) == 1, f"Expected exactly one warning, got: {[r.message for r in warnings]}"
         assert "python" in warnings[0].message
         assert "not-a-version" in warnings[0].message
 
@@ -804,4 +805,6 @@ class TestLatestCombination:
             result = matrix.latest_combination
         assert result is None
         warnings = [r for r in caplog.records if r.levelname == "WARNING"]
-        assert len(warnings) == 1
+        assert len(warnings) == 1, f"Expected exactly one warning, got: {[r.message for r in warnings]}"
+        assert "value:first" in warnings[0].message
+        assert "value:second" not in warnings[0].message

--- a/posit-bakery/test/config/image/test_matrix.py
+++ b/posit-bakery/test/config/image/test_matrix.py
@@ -478,6 +478,45 @@ class TestImageMatrix:
             assert image_version.values["go_version"] in ["1.24", "1.25"]
             assert image_version.values["pro_drivers_version"] in ["2025.07.0", "2025.08.0"]
 
+    def test_to_image_versions_marks_latest_combination(self, patch_requests_get):
+        """Exactly one ImageVersion produced from a fully version-parseable matrix has latest=True."""
+        matrix = ImageMatrix(
+            dependencies=[
+                {"dependency": "python", "versions": ["3.13.7", "3.12.11"]},
+                {"dependency": "R", "versions": ["4.2.3", "4.1.3"]},
+            ],
+            values={
+                "go_version": ["1.24", "1.25"],
+                "pro_drivers_version": "2025.07.0",
+            },
+        )
+
+        image_versions = matrix.to_image_versions()
+        latest_versions = [iv for iv in image_versions if iv.latest]
+        assert len(latest_versions) == 1, (
+            f"expected exactly one latest version, got {len(latest_versions)}: {[iv.name for iv in latest_versions]}"
+        )
+
+        latest = latest_versions[0]
+        dep_versions = {dep.dependency: dep.versions[0] for dep in latest.dependencies}
+        assert dep_versions == {"python": "3.13.7", "R": "4.2.3"}
+        assert latest.values["go_version"] == "1.25"
+        # Scalar values are present but not selecting on them
+        assert latest.values["pro_drivers_version"] == "2025.07.0"
+
+    def test_to_image_versions_no_latest_when_combination_is_none(self):
+        """When latest_combination returns None, no ImageVersion is marked latest."""
+        matrix = ImageMatrix(
+            dependencies=[
+                {"dependency": "python", "versions": ["3.13.7", "3.12.11"]},
+            ],
+            values={"flavor": ["alpha", "beta"]},
+        )
+
+        image_versions = matrix.to_image_versions()
+        assert len(image_versions) == 4  # 2 python * 2 flavor
+        assert not any(iv.latest for iv in image_versions)
+
     def test_check_duplicate_dependency_constraints(self):
         """Test that duplicate dependency constraints raise error."""
         with pytest.raises(

--- a/posit-bakery/test/config/image/test_matrix.py
+++ b/posit-bakery/test/config/image/test_matrix.py
@@ -751,3 +751,57 @@ class TestLatestCombination:
         # "3.12" should be picked; result should preserve "3.12" rather than "3.12.0"
         result = matrix.latest_combination
         assert result == {"python": "3.12"}
+
+    def test_unparseable_list_value_returns_none_and_warns(self, caplog):
+        matrix = ImageMatrix(
+            dependencies=[PythonDependencyVersions(dependency="python", versions=["3.11.5"])],
+            values={"flavor": ["alpha", "beta"]},
+        )
+        # Discard construction-time warnings (e.g., missing OS) so we only assert
+        # on warnings emitted by the latest_combination property itself.
+        caplog.clear()
+        with caplog.at_level("WARNING"):
+            result = matrix.latest_combination
+        assert result is None
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warnings) == 1, f"Expected exactly one warning, got: {[r.message for r in warnings]}"
+        assert "value:flavor" in warnings[0].message
+        assert "alpha" in warnings[0].message or "beta" in warnings[0].message
+
+    def test_unparseable_dependency_version_returns_none_and_warns(self, caplog):
+        # Build via dict so pydantic discriminator accepts arbitrary version strings.
+        matrix = ImageMatrix.model_validate(
+            {
+                "dependencies": [
+                    {"dependency": "python", "versions": ["3.12.3", "not-a-version"]},
+                ],
+            }
+        )
+        # Discard construction-time warnings (e.g., missing OS) so we only assert
+        # on warnings emitted by the latest_combination property itself.
+        caplog.clear()
+        with caplog.at_level("WARNING"):
+            result = matrix.latest_combination
+        assert result is None
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warnings) == 1
+        assert "python" in warnings[0].message
+        assert "not-a-version" in warnings[0].message
+
+    def test_first_failing_axis_short_circuits(self, caplog):
+        # Two unparseable axes: only the first one encountered should produce a warning.
+        matrix = ImageMatrix(
+            dependencies=[PythonDependencyVersions(dependency="python", versions=["3.12.3"])],
+            values={
+                "first": ["x", "y"],
+                "second": ["a", "b"],
+            },
+        )
+        # Discard construction-time warnings (e.g., missing OS) so we only assert
+        # on warnings emitted by the latest_combination property itself.
+        caplog.clear()
+        with caplog.at_level("WARNING"):
+            result = matrix.latest_combination
+        assert result is None
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warnings) == 1

--- a/posit-bakery/test/config/image/test_matrix.py
+++ b/posit-bakery/test/config/image/test_matrix.py
@@ -890,3 +890,26 @@ class TestLatestCombination:
         assert len(warnings) == 1, f"Expected exactly one warning, got: {[r.message for r in warnings]}"
         assert "value:first" in warnings[0].message
         assert "value:second" not in warnings[0].message
+
+    def test_non_parsing_exception_returns_none_with_distinct_warning(self, caplog, mocker):
+        """A non-InvalidVersion exception during construction should not be reported as a parse failure."""
+        matrix = ImageMatrix(
+            dependencies=[PythonDependencyVersions(dependency="python", versions=["3.12.3"])],
+        )
+        mocker.patch(
+            "posit_bakery.config.image.matrix.DependencyVersion",
+            side_effect=RuntimeError("disk on fire"),
+        )
+        caplog.clear()
+        with caplog.at_level("WARNING"):
+            result = matrix.latest_combination
+        assert result is None
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warnings) == 1, f"Expected exactly one warning, got: {[r.message for r in warnings]}"
+        message = warnings[0].message
+        # Should not falsely claim the version is unparseable.
+        assert "unparseable" not in message.lower()
+        # Should still surface the axis, candidate, and underlying error.
+        assert "python" in message
+        assert "3.12.3" in message
+        assert "disk on fire" in message

--- a/posit-bakery/test/config/image/test_matrix.py
+++ b/posit-bakery/test/config/image/test_matrix.py
@@ -678,3 +678,76 @@ class TestImageMatrix:
         plain_out = expected_path / "scripts" / "config.sh"
         assert exec_out.stat().st_mode & stat.S_IXUSR, "executable template should render to executable file"
         assert not (plain_out.stat().st_mode & stat.S_IXUSR), "non-executable template should stay non-executable"
+
+
+class TestLatestCombination:
+    def test_single_dependency_returns_max_version(self):
+        matrix = ImageMatrix(
+            dependencies=[
+                PythonDependencyVersions(dependency="python", versions=["3.11.5", "3.12.3", "3.10.14"]),
+            ],
+        )
+        assert matrix.latest_combination == {"python": "3.12.3"}
+
+    def test_multiple_dependencies_picks_max_per_axis(self):
+        matrix = ImageMatrix(
+            dependencies=[
+                PythonDependencyVersions(dependency="python", versions=["3.11.5", "3.12.3"]),
+                RDependencyVersions(dependency="R", versions=["4.4.1", "4.3.3"]),
+            ],
+        )
+        assert matrix.latest_combination == {"python": "3.12.3", "R": "4.4.1"}
+
+    def test_dependency_constraints_resolve_then_pick_max(self, patch_requests_get):
+        matrix = ImageMatrix(
+            dependencyConstraints=[
+                PythonDependencyConstraint(
+                    dependency="python",
+                    constraint={"latest": True, "count": 2},
+                ),
+            ],
+        )
+        result = matrix.latest_combination
+        assert result is not None
+        assert "python" in result
+        # Highest of the two resolved versions, original-string from the resolved list
+        assert result["python"] == matrix.resolved_dependencies[0].versions[0]
+
+    def test_list_values_included_under_value_namespace(self):
+        matrix = ImageMatrix(
+            values={"go_version": ["1.24", "1.25.1"]},
+        )
+        assert matrix.latest_combination == {"value:go_version": "1.25.1"}
+
+    def test_scalar_values_not_in_returned_dict(self):
+        matrix = ImageMatrix(
+            dependencies=[PythonDependencyVersions(dependency="python", versions=["3.11.5", "3.12.3"])],
+            values={"pro_drivers_version": "2025.07.0"},
+        )
+        result = matrix.latest_combination
+        assert result == {"python": "3.12.3"}
+        assert "value:pro_drivers_version" not in result
+
+    def test_dependencies_and_list_values_combined(self):
+        matrix = ImageMatrix(
+            dependencies=[
+                PythonDependencyVersions(dependency="python", versions=["3.11.5", "3.12.3"]),
+            ],
+            values={
+                "go_version": ["1.24", "1.25.1"],
+                "pro_drivers_version": "2025.07.0",
+            },
+        )
+        assert matrix.latest_combination == {
+            "python": "3.12.3",
+            "value:go_version": "1.25.1",
+        }
+
+    def test_preserves_original_version_string(self):
+        # Verify we record the candidate string, not packaging.Version's normalized form.
+        matrix = ImageMatrix(
+            dependencies=[PythonDependencyVersions(dependency="python", versions=["3.12", "3.11.5"])],
+        )
+        # "3.12" should be picked; result should preserve "3.12" rather than "3.12.0"
+        result = matrix.latest_combination
+        assert result == {"python": "3.12"}

--- a/posit-bakery/test/config/test_tag.py
+++ b/posit-bakery/test/config/test_tag.py
@@ -72,12 +72,31 @@ def test_default_matrix_tag_patterns():
         f"{version}-{variant}",
         f"{version}-{os}",
         version,
+        f"{os}-{variant}",
+        os,
+        variant,
+        "latest",
     ]
     rendered_tags = []
     for pattern in patterns:
         rendered_tags.extend(pattern.render(Version=version, OS=os, Variant=variant))
     for tag in expected_tags:
         assert tag in rendered_tags
+
+
+def test_default_matrix_tag_patterns_includes_latest_filter():
+    """Matrix tag patterns now include LATEST-filtered entries matching default_tag_patterns()."""
+    matrix_patterns = default_matrix_tag_patterns()
+    default_patterns = default_tag_patterns()
+
+    matrix_latest = [p for p in matrix_patterns if TagPatternFilter.LATEST in p.only]
+    default_latest = [p for p in default_patterns if TagPatternFilter.LATEST in p.only]
+
+    # Same set of LATEST-filtered patterns; order-insensitive.
+    assert sorted([(tuple(p.patterns), tuple(p.only)) for p in matrix_latest]) == sorted(
+        [(tuple(p.patterns), tuple(p.only)) for p in default_latest]
+    )
+    assert len(matrix_latest) == 4
 
 
 def test_default_matrix_tag_patterns_no_strip_metadata():
@@ -92,19 +111,6 @@ def test_default_matrix_tag_patterns_no_strip_metadata():
             assert "stripMetadata" not in p, f"Matrix tag pattern should not use stripMetadata: {p}"
 
 
-def test_default_matrix_tag_patterns_no_latest_filter():
-    """Test that default matrix tag patterns do not include latest-filtered patterns.
-
-    Matrices are currently naive to the concept of "latest", so latest-filtered patterns
-    should not be included.
-    """
-    patterns = default_matrix_tag_patterns()
-    for pattern in patterns:
-        assert TagPatternFilter.LATEST not in pattern.only, (
-            f"Matrix tag pattern should not filter by latest: {pattern.patterns}"
-        )
-
-
 def test_default_matrix_tag_patterns_no_tag_collisions():
     """Test that matrix tag patterns do not produce colliding tags across different matrix combinations.
 
@@ -113,9 +119,11 @@ def test_default_matrix_tag_patterns_no_tag_collisions():
 
     Checks that different versions within the same OS produce unique tags. Cross-OS overlap
     (e.g., the PRIMARY_OS pattern producing "R4.3.3-python3.11.15" for both OSes) is expected
-    and handled by tag pattern filters at the ImageTarget level.
+    and handled by tag pattern filters at the ImageTarget level. LATEST-filtered patterns
+    are similarly filter-handled (only applied to the latest combination), so they are
+    excluded here.
     """
-    patterns = default_matrix_tag_patterns()
+    patterns = [p for p in default_matrix_tag_patterns() if TagPatternFilter.LATEST not in p.only]
     versions = ["R4.3.3-python3.11.15", "R4.3.3-python3.12.13", "R4.3.3-python3.13.12"]
     os_values = ["ubuntu2404", "ubuntu2204"]
 
@@ -124,7 +132,7 @@ def test_default_matrix_tag_patterns_no_tag_collisions():
         for version in versions:
             tags = []
             for pattern in patterns:
-                tags.extend(pattern.render(Version=version, OS=os, Variant=""))
+                tags.extend(pattern.render(Version=version, OS=os, Variant="min"))
             tags_by_version[version] = set(tags)
 
         # Verify no two different versions within the same OS share any tags


### PR DESCRIPTION
Closes #498.

## Summary

- Adds `ImageMatrix.latest_combination` that resolves the cartesian-product row at the maximum version of every dependency and list-typed value, returning `None` (with a warning) for non-version-parseable axes.
- `ImageMatrix.to_image_versions()` now sets `latest=True` on the single matching row via a new `_matches_latest` static helper.
- `default_matrix_tag_patterns()` gains the four `LATEST`-filtered patterns from `default_tag_patterns()`, so the existing `ImageTarget.tag_patterns` filter machinery emits `latest`, `<os>`, `<variant>`, and `<os>-<variant>` on the right rows.

No changes to `ImageTarget`, README push, CI workflows, or other consumers — they already handle `latest=True` correctly.

This unblocks #484 (push-order in CI) by giving matrix images a meaningful `latest` signal.

## Test Plan

- [x] Unit tests cover happy path, `None`-on-unparseable, short-circuit, scalar/list value distinction, original-string preservation, `latest=True` propagation, default-pattern parity (1439 tests pass)
- [x] Integration test asserts `ImageTarget.tag_suffixes` emits the bare `latest` tag for the latest matrix row + primary OS + primary variant
- [x] Empirical validation against `images-connect/connect-content`:
  - Latest combination (R4.6.0/python3.14.4/base/ubuntu-24.04) → emits `latest`, `base`, `ubuntu-24.04`, `ubuntu-24.04-base` (+ existing matrix tags)
  - Latest deps + non-primary variant (pro) → emits `pro`, `ubuntu-24.04-pro` only
  - Latest deps + non-primary OS (22.04) → emits `ubuntu-22.04`, `ubuntu-22.04-base` only
  - Older deps (R4.3.3/python3.11.15) → no \`latest\`-family tags
- [x] Documentation updated (`posit-bakery/docs/configuration.qmd` ImageMatrix section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)