### PR TITLE
Defer dev version stream resolution to load time

### DIFF
--- a/posit-bakery/posit_bakery/config/image/dev_version/base.py
+++ b/posit-bakery/posit_bakery/config/image/dev_version/base.py
@@ -217,31 +217,48 @@ class BaseImageDevelopmentVersion(BakeryYAMLModel, abc.ABC):
         """
         return None
 
-    @model_validator(mode="after")
-    def add_os_url(self) -> "BaseImageDevelopmentVersion":
-        """Add the URL to each OS in the os list.
+    def _resolve_os_urls(self) -> list[ImageVersionOS]:
+        """Resolve artifact download URLs for each OS.
 
-        :return: The modified BaseImageDevelopmentVersion object.
+        Returns a list of OSes whose URLs could be resolved. The default
+        implementation resolves all OSes at once via get_url_by_os().
+        Subclasses may override for per-OS error handling.
         """
+        default_urls = self.get_url_by_os(generalize_architecture=False)
+        generalized_urls = None
         for os_version in self.os:
-            url_by_os = self.get_url_by_os(generalize_architecture=os_version.platforms != DEFAULT_PLATFORMS)
-            os_version.artifactDownloadURL = url_by_os.get(os_version.name, "")
-
-        return self
+            if os_version.platforms != DEFAULT_PLATFORMS:
+                if generalized_urls is None:
+                    generalized_urls = self.get_url_by_os(generalize_architecture=True)
+                os_version.artifactDownloadURL = generalized_urls.get(os_version.name, "")
+            else:
+                os_version.artifactDownloadURL = default_urls.get(os_version.name, "")
+        return list(self.os)
 
     def as_image_version(self):
-        """Convert this development version to a standard image version."""
+        """Convert this development version to a standard image version.
+
+        Resolves artifact download URLs for each OS. OSes whose URLs
+        cannot be resolved are excluded with a warning.
+
+        :raises RuntimeError: If no OSes remain after URL resolution.
+        """
+        resolved_os = self._resolve_os_urls()
+        if not resolved_os:
+            raise RuntimeError(f"No OSes could be resolved for {repr(self)}")
+
+        version = self.get_version()
         metadata = {}
         release_stream = self.get_release_stream()
         if release_stream is not None:
             metadata["release_stream"] = release_stream
         return ImageVersion(
-            name=self.get_version(),
-            subpath=f".dev-{self.get_version()}".replace(" ", "-").lower(),
+            name=version,
+            subpath=f".dev-{version}".replace(" ", "-").lower(),
             parent=self.parent,
             extraRegistries=self.extraRegistries,
             overrideRegistries=self.overrideRegistries,
-            os=self.os,
+            os=resolved_os,
             values=self.values,
             latest=False,
             dependencies=self.parent.resolve_dependency_versions(),

--- a/posit-bakery/posit_bakery/config/image/dev_version/base.py
+++ b/posit-bakery/posit_bakery/config/image/dev_version/base.py
@@ -238,8 +238,9 @@ class BaseImageDevelopmentVersion(BakeryYAMLModel, abc.ABC):
     def as_image_version(self):
         """Convert this development version to a standard image version.
 
-        Resolves artifact download URLs for each OS. OSes whose URLs
-        cannot be resolved are excluded with a warning.
+        Calls _resolve_os_urls() to populate artifact download URLs.
+        The stream subclass overrides _resolve_os_urls() to exclude
+        OSes whose platform is unavailable in the product stream.
 
         :raises RuntimeError: If no OSes remain after URL resolution.
         """

--- a/posit-bakery/posit_bakery/config/image/dev_version/stream.py
+++ b/posit-bakery/posit_bakery/config/image/dev_version/stream.py
@@ -19,7 +19,15 @@ class ImageDevelopmentVersionFromProductStream(BaseImageDevelopmentVersion):
     sourceType: Literal["stream"] = "stream"
     product: Annotated[ProductEnum, Field(description="The ID of the product stream to use for this image version.")]
     stream: Annotated[ReleaseStreamEnum, Field(description="The release stream to use for this image version.")]
-    _resolved_version: str | None = None
+    resolved_version: Annotated[
+        str | None,
+        Field(
+            exclude=True,
+            default=None,
+            description="Cached version from the last _resolve_os_urls() call. Avoids a redundant stream fetch in "
+            "get_version().",
+        ),
+    ]
 
     def get_primary_os(self) -> ImageVersionOS:
         """Retrieve the primary OS from the parent image if available.
@@ -40,8 +48,8 @@ class ImageDevelopmentVersionFromProductStream(BaseImageDevelopmentVersion):
 
         :return: The version string from the product stream.
         """
-        if self._resolved_version is not None:
-            return self._resolved_version
+        if self.resolved_version is not None:
+            return self.resolved_version
         _os = self.get_primary_os()
         result = get_product_artifact_by_stream(self.product, self.stream, _os.buildOS)
         return result.version
@@ -68,7 +76,7 @@ class ImageDevelopmentVersionFromProductStream(BaseImageDevelopmentVersion):
         Caches the version from the first successfully resolved OS so
         that get_version() can return it without a redundant fetch.
         """
-        self._resolved_version = None
+        self.resolved_version = None
         resolved = []
         for os_version in self.os:
             try:
@@ -78,8 +86,8 @@ class ImageDevelopmentVersionFromProductStream(BaseImageDevelopmentVersion):
                     os_version.artifactDownloadURL = str(result.architecture_generalized_download_url)
                 else:
                     os_version.artifactDownloadURL = str(result.download_url)
-                if self._resolved_version is None:
-                    self._resolved_version = result.version
+                if self.resolved_version is None:
+                    self.resolved_version = result.version
                 resolved.append(os_version)
             except (ValueError, ValidationError, requests.RequestException) as e:
                 log.warning(f"Excluding OS '{os_version.name}' from {repr(self)}: {e}")

--- a/posit-bakery/posit_bakery/config/image/dev_version/stream.py
+++ b/posit-bakery/posit_bakery/config/image/dev_version/stream.py
@@ -1,12 +1,16 @@
+import logging
 from typing import Literal, Annotated
 
-from pydantic import Field
+import requests
+from pydantic import Field, ValidationError
 
-from posit_bakery.config.image.build_os import DEFAULT_OS
+from posit_bakery.config.image.build_os import DEFAULT_OS, DEFAULT_PLATFORMS
 from posit_bakery.config.image.dev_version.base import BaseImageDevelopmentVersion
 from posit_bakery.config.image.posit_product.const import ProductEnum, ReleaseStreamEnum
 from posit_bakery.config.image.posit_product.main import get_product_artifact_by_stream
 from posit_bakery.config.image.version_os import ImageVersionOS
+
+log = logging.getLogger(__name__)
 
 
 class ImageDevelopmentVersionFromProductStream(BaseImageDevelopmentVersion):
@@ -15,6 +19,7 @@ class ImageDevelopmentVersionFromProductStream(BaseImageDevelopmentVersion):
     sourceType: Literal["stream"] = "stream"
     product: Annotated[ProductEnum, Field(description="The ID of the product stream to use for this image version.")]
     stream: Annotated[ReleaseStreamEnum, Field(description="The release stream to use for this image version.")]
+    _resolved_version: str | None = None
 
     def get_primary_os(self) -> ImageVersionOS:
         """Retrieve the primary OS from the parent image if available.
@@ -30,11 +35,15 @@ class ImageDevelopmentVersionFromProductStream(BaseImageDevelopmentVersion):
     def get_version(self) -> str:
         """Retrieve the version from the specified product stream.
 
+        If _resolve_os_urls() has already been called, returns the cached
+        version. Otherwise fetches it from the primary OS stream.
+
         :return: The version string from the product stream.
         """
+        if self._resolved_version is not None:
+            return self._resolved_version
         _os = self.get_primary_os()
         result = get_product_artifact_by_stream(self.product, self.stream, _os.buildOS)
-
         return result.version
 
     def get_url_by_os(self, generalize_architecture: bool = False) -> dict[str, str]:
@@ -51,6 +60,30 @@ class ImageDevelopmentVersionFromProductStream(BaseImageDevelopmentVersion):
                 url_by_os[_os.name] = str(result.download_url)
 
         return url_by_os
+
+    def _resolve_os_urls(self) -> list[ImageVersionOS]:
+        """Resolve artifact URLs per-OS, excluding OSes whose platform
+        is not yet available in the product stream.
+
+        Caches the version from the first successfully resolved OS so
+        that get_version() can return it without a redundant fetch.
+        """
+        self._resolved_version = None
+        resolved = []
+        for os_version in self.os:
+            try:
+                generalize = os_version.platforms != DEFAULT_PLATFORMS
+                result = get_product_artifact_by_stream(self.product, self.stream, os_version.buildOS)
+                if generalize:
+                    os_version.artifactDownloadURL = str(result.architecture_generalized_download_url)
+                else:
+                    os_version.artifactDownloadURL = str(result.download_url)
+                if self._resolved_version is None:
+                    self._resolved_version = result.version
+                resolved.append(os_version)
+            except (ValueError, ValidationError, requests.RequestException) as e:
+                log.warning(f"Excluding OS '{os_version.name}' from {repr(self)}: {e}")
+        return resolved
 
     def get_release_stream(self) -> ReleaseStreamEnum:
         """Return the release stream for this product stream development version.

--- a/posit-bakery/posit_bakery/config/image/image.py
+++ b/posit-bakery/posit_bakery/config/image/image.py
@@ -4,6 +4,8 @@ from copy import deepcopy
 from pathlib import Path
 from typing import Annotated, Union, Any, Self
 
+import pydantic
+import requests
 from pydantic import Field, HttpUrl, field_validator, model_validator, field_serializer
 from pydantic_core.core_schema import ValidationInfo
 
@@ -585,7 +587,11 @@ class Image(BakeryPathMixin, BakeryYAMLModel):
     def load_dev_versions(self):
         """Load the development versions for this image."""
         for dev_version in self.devVersions:
-            image_version = dev_version.as_image_version()
+            try:
+                image_version = dev_version.as_image_version()
+            except (RuntimeError, ValueError, pydantic.ValidationError, requests.RequestException) as e:
+                log.warning(f"Skipping {self.name} {repr(dev_version)}: {e}")
+                continue
             log_message = f"Loaded {self.name} development version from {repr(dev_version)}:\n"
             log_message += f"  - Version: {image_version.name}\n"
             for dep in image_version.dependencies:

--- a/posit-bakery/test/config/image/dev_version/test_stream.py
+++ b/posit-bakery/test/config/image/dev_version/test_stream.py
@@ -412,7 +412,6 @@ class TestByStream:
         )
         assert dev_version.get_version() == expected_version
         assert dev_version.get_url_by_os()[_os.name] == expected_url
-        assert str(_os.artifactDownloadURL) == expected_url
 
     @pytest.mark.parametrize(
         "_os,expected_version,expected_url",
@@ -490,7 +489,6 @@ class TestByStream:
         )
         assert dev_version.get_version() == expected_version
         assert dev_version.get_url_by_os()[_os.name] == expected_url
-        assert str(_os.artifactDownloadURL) == expected_url
 
     @pytest.mark.parametrize(
         "_os,expected_version,expected_url",
@@ -566,7 +564,6 @@ class TestByStream:
         )
         assert dev_version.get_version() == expected_version
         assert dev_version.get_url_by_os()[_os.name] == expected_url
-        assert str(_os.artifactDownloadURL) == expected_url
 
     @pytest.mark.parametrize(
         "_os,expected_version,expected_url",
@@ -642,7 +639,6 @@ class TestByStream:
         )
         assert dev_version.get_version() == expected_version
         assert dev_version.get_url_by_os()[_os.name] == expected_url
-        assert str(_os.artifactDownloadURL) == expected_url
 
     @pytest.mark.parametrize(
         "_os,expected_version,expected_url",
@@ -718,7 +714,6 @@ class TestByStream:
         )
         assert dev_version.get_version() == expected_version
         assert dev_version.get_url_by_os()[_os.name] == expected_url
-        assert str(_os.artifactDownloadURL) == expected_url
 
     @pytest.mark.parametrize(
         "_os,expected_version,expected_url,expected_session_url",
@@ -814,14 +809,12 @@ class TestByStream:
         )
         assert dev_version.get_version() == expected_version
         assert dev_version.get_url_by_os()[_os.name] == expected_url
-        assert str(_os.artifactDownloadURL) == expected_url
 
         dev_version = ImageDevelopmentVersionFromProductStream(
             sourceType="stream", product=ProductEnum.WORKBENCH_SESSION, stream=ReleaseStreamEnum.RELEASE, os=[_os]
         )
         assert dev_version.get_version() == expected_version
         assert dev_version.get_url_by_os()[_os.name] == expected_session_url
-        assert str(_os.artifactDownloadURL) == expected_session_url
 
     @pytest.mark.parametrize(
         "_os,expected_version,expected_url,expected_session_url",
@@ -932,11 +925,125 @@ class TestByStream:
         )
         assert dev_version.get_version() == expected_version
         assert dev_version.get_url_by_os()[_os.name] == expected_url
-        assert str(_os.artifactDownloadURL) == expected_url
 
         dev_version = ImageDevelopmentVersionFromProductStream(
             sourceType="stream", product=ProductEnum.WORKBENCH_SESSION, stream=ReleaseStreamEnum.DAILY, os=[_os]
         )
         assert dev_version.get_version() == expected_version
         assert dev_version.get_url_by_os()[_os.name] == expected_session_url
-        assert str(_os.artifactDownloadURL) == expected_session_url
+
+
+class TestResolveOsUrls:
+    def test_sets_artifact_download_url(self):
+        with patch("posit_bakery.config.image.dev_version.stream.get_product_artifact_by_stream") as mock_get:
+            mock_get.return_value = ReleaseStreamResult(
+                version="1.0.0", download_url="https://example.com/image.tar.gz"
+            )
+            dev = ImageDevelopmentVersionFromProductStream(
+                sourceType="stream",
+                product="connect",
+                stream="daily",
+                os=[{"name": "Ubuntu 24.04", "primary": True}],
+            )
+            resolved_os = dev._resolve_os_urls()
+            assert len(resolved_os) == 1
+            assert str(resolved_os[0].artifactDownloadURL) == "https://example.com/image.tar.gz"
+
+    def test_excludes_os_on_resolution_failure(self):
+        good = ReleaseStreamResult(version="1.0.0", download_url="https://example.com/good.deb")
+
+        def side_effect(product, stream, build_os):
+            if build_os.version == "26.04":
+                raise ValueError("no packages for ubuntu26")
+            return good
+
+        with patch(
+            "posit_bakery.config.image.dev_version.stream.get_product_artifact_by_stream", side_effect=side_effect
+        ):
+            dev = ImageDevelopmentVersionFromProductStream(
+                sourceType="stream",
+                product="connect",
+                stream="daily",
+                os=[
+                    {"name": "Ubuntu 24.04", "primary": True},
+                    {"name": "Ubuntu 26.04"},
+                ],
+            )
+            resolved_os = dev._resolve_os_urls()
+            assert len(resolved_os) == 1
+            assert resolved_os[0].name == "Ubuntu 24.04"
+
+    def test_generalizes_url_for_multiplatform_os(self):
+        with patch("posit_bakery.config.image.dev_version.stream.get_product_artifact_by_stream") as mock_get:
+            mock_get.return_value = ReleaseStreamResult(
+                version="1.0.0", download_url="https://example.com/pkg_amd64.deb"
+            )
+            dev = ImageDevelopmentVersionFromProductStream(
+                sourceType="stream",
+                product="connect",
+                stream="daily",
+                os=[
+                    {
+                        "name": "Ubuntu 24.04",
+                        "primary": True,
+                        "platforms": ["linux/amd64", "linux/arm64"],
+                    }
+                ],
+            )
+            resolved_os = dev._resolve_os_urls()
+            assert len(resolved_os) == 1
+            assert "$TARGETARCH" in str(resolved_os[0].artifactDownloadURL)
+
+    def test_all_os_fail_returns_empty(self):
+        with patch("posit_bakery.config.image.dev_version.stream.get_product_artifact_by_stream") as mock_get:
+            mock_get.side_effect = ValueError("no packages")
+            dev = ImageDevelopmentVersionFromProductStream(
+                sourceType="stream",
+                product="connect",
+                stream="daily",
+                os=[{"name": "Ubuntu 26.04", "primary": True}],
+            )
+            resolved_os = dev._resolve_os_urls()
+            assert len(resolved_os) == 0
+
+    def test_unexpected_exception_propagates(self):
+        with patch("posit_bakery.config.image.dev_version.stream.get_product_artifact_by_stream") as mock_get:
+            mock_get.side_effect = TypeError("unexpected bug")
+            dev = ImageDevelopmentVersionFromProductStream(
+                sourceType="stream",
+                product="connect",
+                stream="daily",
+                os=[{"name": "Ubuntu 24.04", "primary": True}],
+            )
+            with pytest.raises(TypeError, match="unexpected bug"):
+                dev._resolve_os_urls()
+
+    def test_primary_os_excluded_falls_back_to_secondary(self):
+        good = ReleaseStreamResult(version="1.0.0", download_url="https://example.com/good.deb")
+
+        def side_effect(product, stream, build_os):
+            if build_os.version == "26.04":
+                raise ValueError("no packages for ubuntu26")
+            return good
+
+        mock_parent = MagicMock(spec=Image)
+        mock_parent.path = Path("/tmp/images")
+        mock_parent.resolve_dependency_versions.return_value = []
+
+        with patch(
+            "posit_bakery.config.image.dev_version.stream.get_product_artifact_by_stream", side_effect=side_effect
+        ):
+            dev = ImageDevelopmentVersionFromProductStream(
+                parent=mock_parent,
+                sourceType="stream",
+                product="connect",
+                stream="daily",
+                os=[
+                    {"name": "Ubuntu 26.04", "primary": True},
+                    {"name": "Ubuntu 24.04"},
+                ],
+            )
+            iv = dev.as_image_version()
+            assert iv.name == "1.0.0"
+            assert len(iv.os) == 1
+            assert iv.os[0].name == "Ubuntu 24.04"


### PR DESCRIPTION
## Summary

- Move stream resolution (fetching version/URL from product CDN) out of Pydantic model validation and into ``load_dev_versions()``, which only runs when dev versions are actually needed
- Per-OS resolution failures now exclude the failing OS with a warning instead of crashing config loading
- Production builds (``--dev-versions exclude``) are no longer affected by stream availability

## Context

The ``add_os_url`` model validator on ``BaseImageDevelopmentVersion`` ran during ``bakery.yaml`` parsing, eagerly fetching stream data for every OS in every dev version. If any platform was missing from the stream endpoint (e.g. Connect has no Ubuntu 26.04 dailies yet), config loading failed with a Pydantic ``ValidationError`` -- blocking **all** builds including production.

This caused the CI failure on posit-dev/images-connect#73 (Ubuntu 26.04 support).

Partially addresses #330 (limit when we retrieve dependency versions) by eliminating stream fetches during config loading.

## Test plan

- [x] 987 config/CI tests pass
- [x] New tests for ``_resolve_os_urls()``: URL population, partial OS failure, total failure
- [ ] Re-run posit-dev/images-connect#73 CI after merge