### PR TITLE
Add stream-based floating tags for dev versions

### DIFF
--- a/posit-bakery/posit_bakery/config/tag.py
+++ b/posit-bakery/posit_bakery/config/tag.py
@@ -52,6 +52,8 @@ class TagPattern(BakeryYAMLModel):
                 continue
             if "{{ Variant }}" in pattern and not kwargs.get("Variant"):
                 continue
+            if "{{ Stream }}" in pattern and not kwargs.get("Stream"):
+                continue
 
             env = jinja2_env()
             template = env.from_string(pattern)
@@ -111,6 +113,22 @@ def default_tag_patterns() -> list[TagPattern]:
         TagPattern(
             patterns=["latest"],
             only=[TagPatternFilter.LATEST, TagPatternFilter.PRIMARY_OS, TagPatternFilter.PRIMARY_VARIANT],
+        ),
+        TagPattern(
+            patterns=["{{ Stream }}-{{ OS }}-{{ Variant }}"],
+            only=[TagPatternFilter.ALL],
+        ),
+        TagPattern(
+            patterns=["{{ Stream }}-{{ Variant }}"],
+            only=[TagPatternFilter.PRIMARY_OS],
+        ),
+        TagPattern(
+            patterns=["{{ Stream }}-{{ OS }}"],
+            only=[TagPatternFilter.PRIMARY_VARIANT],
+        ),
+        TagPattern(
+            patterns=["{{ Stream }}"],
+            only=[TagPatternFilter.PRIMARY_OS, TagPatternFilter.PRIMARY_VARIANT],
         ),
     ]
 

--- a/posit-bakery/posit_bakery/image/image_target.py
+++ b/posit-bakery/posit_bakery/image/image_target.py
@@ -341,6 +341,7 @@ class ImageTarget(BaseModel):
             "Variant": self.image_variant.tagDisplayName if self.image_variant else "",
             "OS": self.image_os.tagDisplayName if self.image_os else "",
             "Name": self.image_name,
+            "Stream": getattr(self.image_version.metadata.get("release_stream"), "value", ""),
         }
 
     @property

--- a/posit-bakery/posit_bakery/image/image_target.py
+++ b/posit-bakery/posit_bakery/image/image_target.py
@@ -341,7 +341,9 @@ class ImageTarget(BaseModel):
             "Variant": self.image_variant.tagDisplayName if self.image_variant else "",
             "OS": self.image_os.tagDisplayName if self.image_os else "",
             "Name": self.image_name,
-            "Stream": getattr(self.image_version.metadata.get("release_stream"), "value", ""),
+            "Stream": str(v.value if hasattr(v, "value") else v)
+            if (v := self.image_version.metadata.get("release_stream"))
+            else "",
         }
 
     @property

--- a/posit-bakery/test/image/test_image_target.py
+++ b/posit-bakery/test/image/test_image_target.py
@@ -112,7 +112,7 @@ class TestImageTarget:
         assert target.image_version == version
         assert target.image_variant == variant
         assert target.image_os == os
-        assert len(target.tag_patterns) == 8
+        assert len(target.tag_patterns) == 12
 
     def test_str(self, get_config_obj, basic_standard_image_target):
         """Test the string representation of an ImageTarget."""
@@ -228,6 +228,7 @@ class TestImageTarget:
             "Version": basic_standard_image_target.image_version.name,
             "Variant": basic_standard_image_target.image_variant.tagDisplayName,
             "OS": basic_standard_image_target.image_os.tagDisplayName,
+            "Stream": "",
         }
         assert basic_standard_image_target.tag_template_values == expected_values
 
@@ -237,6 +238,7 @@ class TestImageTarget:
             "Version": basic_standard_image_target.image_version.name,
             "Variant": "",
             "OS": "",
+            "Stream": "",
         }
         basic_standard_image_target.image_variant = None
         basic_standard_image_target.image_os = None
@@ -258,8 +260,9 @@ class TestImageTarget:
             image_variant=variant,
             image_os=os,
         )
-        # Check that the tag patterns are deduplicated to 8, the default tag patterns length
-        assert len(target.tag_patterns) == 8
+        # Check that the tag patterns are deduplicated to 12, the default tag patterns length
+        # (8 version-based + 4 stream-based)
+        assert len(target.tag_patterns) == 12
 
     def test_tag_patterns_filtering(self, get_config_obj):
         """Test the filter_tag_patterns method of an ImageTarget."""
@@ -276,7 +279,9 @@ class TestImageTarget:
             image_variant=variant,
             image_os=os,
         )
-        assert len(target.tag_patterns) == 8
+        # 8 version-based + 4 stream-based (stream patterns pass filtering
+        # even when Stream is empty; they produce nothing during rendering)
+        assert len(target.tag_patterns) == 12
 
         # Test primary variant and primary OS, but not latest
         version.latest = False
@@ -287,7 +292,7 @@ class TestImageTarget:
             image_variant=variant,
             image_os=os,
         )
-        assert len(target.tag_patterns) == 4
+        assert len(target.tag_patterns) == 8
         assert not any(TagPatternFilter.LATEST in pattern.only for pattern in target.tag_patterns)
 
         # Test latest and primary OS, but not primary variant
@@ -300,7 +305,7 @@ class TestImageTarget:
             image_variant=variant,
             image_os=os,
         )
-        assert len(target.tag_patterns) == 4
+        assert len(target.tag_patterns) == 6
         assert not any(TagPatternFilter.PRIMARY_VARIANT in pattern.only for pattern in target.tag_patterns)
 
         # Test latest and primary variant, but not primary OS
@@ -313,7 +318,7 @@ class TestImageTarget:
             image_variant=variant,
             image_os=os,
         )
-        assert len(target.tag_patterns) == 4
+        assert len(target.tag_patterns) == 6
         assert not any(TagPatternFilter.PRIMARY_OS in pattern.only for pattern in target.tag_patterns)
 
     @pytest.mark.parametrize(

--- a/posit-bakery/test/image/test_image_target.py
+++ b/posit-bakery/test/image/test_image_target.py
@@ -244,6 +244,35 @@ class TestImageTarget:
         basic_standard_image_target.image_os = None
         assert basic_standard_image_target.tag_template_values == expected_values
 
+    def test_stream_tags(self, basic_standard_image_target):
+        """Test that release_stream metadata produces stream-based floating tags."""
+        from posit_bakery.config.image.posit_product.const import ReleaseStreamEnum
+
+        target = basic_standard_image_target
+
+        # No stream → no stream tags
+        assert target.image_version.metadata.get("release_stream") is None
+        stream_suffixes = [s for s in target.tag_suffixes if "daily" in s]
+        assert stream_suffixes == []
+
+        # Enum stream value
+        target.image_version.metadata["release_stream"] = ReleaseStreamEnum.DAILY
+        assert target.tag_template_values["Stream"] == "daily"
+        stream_suffixes = sorted([s for s in target.tag_suffixes if "daily" in s])
+        assert "daily" in stream_suffixes
+        assert "daily-ubuntu-22.04" in stream_suffixes
+        assert "daily-std" in stream_suffixes
+        assert "daily-ubuntu-22.04-std" in stream_suffixes
+
+        # Plain string stream value
+        target.image_version.metadata["release_stream"] = "preview"
+        assert target.tag_template_values["Stream"] == "preview"
+        stream_suffixes = sorted([s for s in target.tag_suffixes if "preview" in s])
+        assert "preview" in stream_suffixes
+
+        # Clean up
+        del target.image_version.metadata["release_stream"]
+
     def test_tag_patterns_deduplication(self, get_config_obj):
         """Test the deduplicate_tag_patterns method of an ImageTarget."""
         basic_config_obj = get_config_obj("basic")


### PR DESCRIPTION
## Summary

- Dev versions from named release streams (daily, preview) now automatically produce floating tags using the stream name
- Adds ``Stream`` to tag template values from ``ImageVersion.metadata["release_stream"]``
- Adds ``{{ Stream }}``-based patterns to the default tag patterns, mirroring the ``{{ Version }}`` pattern structure
- Skips rendering when ``Stream`` is empty, so release versions are unaffected

### Example output

Connect daily stream produces:
- ``ghcr.io/posit-dev/connect-preview:daily``
- ``ghcr.io/posit-dev/connect-preview:daily-ubuntu-24.04``
- ``ghcr.io/posit-dev/connect-preview:daily-ubuntu-22.04``
- ``ghcr.io/posit-dev/connect-preview:daily-std``
- ``ghcr.io/posit-dev/connect-preview:daily-min``
- etc.

PPM gets both ``daily`` and ``preview`` floating tags.

This replaces the old ``ubuntu2204-daily`` style floating tags that were managed outside of bakery in the ``rstudio-docker-products`` build system.

Part of #279, #326.

## Test plan

- [x] Existing tag tests updated and passing
- [x] Verify ``bakery get tags --dev-versions only`` produces stream tags for Connect, PPM, and Workbench
- [x] Verify ``bakery get tags --dev-versions exclude`` produces no stream tags for release versions