### PR TITLE
Strip trailing whitespace from bakery.yaml writes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,14 @@ Template variables available:
 
 Custom Jinja2 filters: `tagSafe`, `stripMetadata`, `condense`, `regexReplace`, `quote`, `split`
 
+## Pre-commit
+
+A pre-commit hook is installed and runs automatically on `git commit`. If the hook fails,
+read the output — many hooks (trailing whitespace, end-of-file fixer, ruff format, shfmt)
+auto-fix files in place. After a hook failure, re-stage the fixed files and commit again.
+
+Do not skip hooks with `--no-verify`.
+
 ## Python Coding Conventions
 
 ### Imports

--- a/posit-bakery/posit_bakery/config/config.py
+++ b/posit-bakery/posit_bakery/config/config.py
@@ -1,4 +1,5 @@
 import atexit
+import io
 import json
 import logging
 import os
@@ -394,7 +395,10 @@ class BakeryConfig:
 
     def write(self) -> None:
         """Write the bakery config to the config file."""
-        self.yaml.dump(self._config_yaml, self.config_file)
+        stream = io.StringIO()
+        self.yaml.dump(self._config_yaml, stream)
+        text = re.sub(r"[ \t]+$", "", stream.getvalue(), flags=re.MULTILINE)
+        self.config_file.write_text(text)
 
     def _get_image_index(self, image_name: str) -> int:
         """Returns the index of the image with the given name in the config.


### PR DESCRIPTION
## Summary

- ruamel.yaml's round-trip serializer adds trailing spaces after YAML keys whose block scalar values continue on the next line (e.g. `documentationUrl: \n  https://...`)
- Every `bakery create version` / `bakery patch version` call triggers `BakeryConfig.write()`, which round-trips the entire `bakery.yaml` through ruamel — reintroducing the trailing whitespace
- This causes pre-commit `trailing-whitespace` failures on every release commit from the bot, requiring manual cleanup each time

The fix dumps to a `StringIO` buffer, strips trailing whitespace with a regex, then writes the cleaned text to disk.

## Test plan

- [x] Verified against `images-connect/bakery.yaml` — ruamel produces trailing space on `documentationUrl:` line; the fix removes it
- [x] Existing bakery tests pass