### PR TITLE
Fix setup-goss ref to use main

### DIFF
--- a/.github/workflows/bakery-build-native.yml
+++ b/.github/workflows/bakery-build-native.yml
@@ -163,7 +163,7 @@ jobs:
           version: ${{ inputs.version }}
 
       - name: Setup goss
-        uses: "posit-dev/images-shared/setup-goss@ci-native-multiplatform"
+        uses: "posit-dev/images-shared/setup-goss@main"
 
       - name: Set up Docker
         uses: docker/setup-docker-action@1a6edb0ba9ac496f6850236981f15d8f9a82254d  # v5.0.0


### PR DESCRIPTION
## Summary

- Fix ``setup-goss`` action reference from ``@ci-native-multiplatform`` to ``@main`` in ``bakery-build-native.yml``
- The stale branch ref was introduced in ``a9389a9`` (Dec 2025) during initial development of the native builder workflow
- A fix was made in ``4ee5430`` (Apr 2026) but the branch was never merged
- This causes transient arm64 goss setup failures since the ``ci-native-multiplatform`` branch may diverge from ``main``