### PR TITLE
Suppress Docker build output when --quiet flag is set

### DIFF
--- a/posit-bakery/posit_bakery/image/bake/bake.py
+++ b/posit-bakery/posit_bakery/image/bake/bake.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from pathlib import Path
 from typing import Annotated, Any
@@ -7,6 +8,7 @@ from pydantic import BaseModel, Field, field_serializer
 
 from posit_bakery.config.image.build_os import TargetPlatform, DEFAULT_PLATFORMS
 from posit_bakery.image.image_target import ImageTarget
+from posit_bakery.settings import SETTINGS
 
 
 class BakeGroup(BaseModel):
@@ -281,7 +283,13 @@ class BakePlan(BaseModel):
         _set = self._set_opts_dict_to_str(_set)
 
         python_on_whales.docker.buildx.bake(
-            files=[self.bake_file.name], load=load, push=push, pull=pull, cache=cache, set=_set
+            files=[self.bake_file.name],
+            load=load,
+            push=push,
+            pull=pull,
+            cache=cache,
+            set=_set,
+            progress=False if SETTINGS.log_level >= logging.ERROR else "auto",
         )
         if clean_bakefile:
             self.remove()

--- a/posit-bakery/posit_bakery/image/image_target.py
+++ b/posit-bakery/posit_bakery/image/image_target.py
@@ -624,6 +624,7 @@ class ImageTarget(BaseModel):
                     platforms=platforms or self.image_os.platforms,
                     target=self.build_target,
                     secrets=[s.as_cli_option() for s in self.resolved_build_secrets],
+                    progress=False if SETTINGS.log_level >= logging.ERROR else "auto",
                 )
             except python_on_whales.exceptions.DockerException as e:
                 raise BakeryToolRuntimeError(

--- a/posit-bakery/test/image/bake/test_bake.py
+++ b/posit-bakery/test/image/bake/test_bake.py
@@ -329,6 +329,7 @@ class TestBakePlan:
             "pull": False,
             "cache": True,
             "set": {},
+            "progress": "auto",
         }
 
         with patch("python_on_whales.docker.buildx.bake") as mock_bake:

--- a/posit-bakery/test/image/test_image_target.py
+++ b/posit-bakery/test/image/test_image_target.py
@@ -637,6 +637,7 @@ class TestImageTarget:
             "platforms": ["linux/amd64"],
             "target": None,
             "secrets": [],
+            "progress": "auto",
         }
 
         with patch("python_on_whales.docker.build") as mock_build:
@@ -670,6 +671,7 @@ class TestImageTarget:
             "platforms": ["linux/amd64"],
             "target": None,
             "secrets": [],
+            "progress": "auto",
         }
 
         with patch("python_on_whales.docker.build") as mock_build:
@@ -699,6 +701,7 @@ class TestImageTarget:
             "platforms": ["linux/amd64"],
             "target": None,
             "secrets": [],
+            "progress": "auto",
         }
 
         with patch("python_on_whales.docker.build") as mock_build:
@@ -728,6 +731,7 @@ class TestImageTarget:
             "platforms": ["linux/amd64"],
             "target": None,
             "secrets": [],
+            "progress": "auto",
         }
 
         with patch("python_on_whales.docker.build") as mock_build:
@@ -756,6 +760,7 @@ class TestImageTarget:
             "platforms": ["linux/amd64"],
             "target": None,
             "secrets": [],
+            "progress": "auto",
         }
 
         with patch("python_on_whales.docker.build") as mock_build:
@@ -785,6 +790,7 @@ class TestImageTarget:
             "platforms": ["linux/amd64"],
             "target": "my-stage",
             "secrets": [],
+            "progress": "auto",
         }
 
         with patch("python_on_whales.docker.build") as mock_build:
@@ -814,6 +820,7 @@ class TestImageTarget:
             "platforms": ["linux/amd64"],
             "target": "image-stage",
             "secrets": [],
+            "progress": "auto",
         }
 
         with patch("python_on_whales.docker.build") as mock_build:
@@ -844,6 +851,7 @@ class TestImageTarget:
             "platforms": ["linux/amd64"],
             "target": "version-stage",
             "secrets": [],
+            "progress": "auto",
         }
 
         with patch("python_on_whales.docker.build") as mock_build:
@@ -912,6 +920,7 @@ class TestImageTarget:
             "platforms": ["linux/amd64"],
             "target": None,
             "secrets": ["id=github_token,env=GITHUB_TOKEN"],
+            "progress": "auto",
         }
 
         with patch("python_on_whales.docker.build") as mock_build:


### PR DESCRIPTION
## Summary
- Pass `progress=False` to `docker.build` and `docker.buildx.bake` when `SETTINGS.log_level >= logging.ERROR` (i.e. the user passed `--quiet`), otherwise use `progress="auto"`.
- Update the affected `assert_called_once_with(**expected_build_args)` test expectations in `test_image_target.py` and `test_bake.py` to include the new `progress` kwarg.

## Test plan
- [x] `uv run pytest -m build test/image/test_image_target.py test/image/bake/test_bake.py` passes (15/15).
- [x] Manual: run `bakery build --quiet ...` and confirm buildx progress output is suppressed.
- [x] Manual: run `bakery build ...` (default) and `bakery build --verbose ...` and confirm progress output is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)