### PR TITLE
Add cache input to bakery build workflows

### DIFF
--- a/.github/workflows/bakery-build-native.yml
+++ b/.github/workflows/bakery-build-native.yml
@@ -47,6 +47,11 @@ on:
         default: 1
         required: false
         type: number
+      cache:
+        description: "Whether to use registry caching for builds [default: true]"
+        default: true
+        required: false
+        type: boolean
       merge-builder:
         description: "The type of runner to use for merging [default: ubuntu-latest-4x]"
         default: "ubuntu-latest-4x"
@@ -220,8 +225,13 @@ jobs:
           REGISTRY: ghcr.io/${{ github.repository_owner }}
           NORMALIZED_PLATFORM: ${{ steps.normalize-platform.outputs.platform }}
           CONTEXT: ${{ inputs.context }}
+          CACHE: ${{ inputs.cache }}
         # Cache-to is conditional on --push (handled by bakery internally)
         run: |
+          CACHE_FLAGS=()
+          if [ "$CACHE" = "true" ]; then
+            CACHE_FLAGS=(--cache-registry "$REGISTRY")
+          fi
           bakery build \
             --strategy build --pull \
             --retry "$RETRY" \
@@ -230,7 +240,7 @@ jobs:
             --image-platform "$IMAGE_PLATFORM" \
             --dev-versions "$DEV_VERSIONS" \
             --matrix-versions "$MATRIX_VERSIONS" \
-            --cache-registry "$REGISTRY" \
+            "${CACHE_FLAGS[@]}" \
             --temp-registry "$REGISTRY" \
             --metadata-file "./${IMAGE_NAME}-${IMAGE_VERSION}-${NORMALIZED_PLATFORM}-metadata.json" \
             --context "$CONTEXT" \

--- a/.github/workflows/bakery-build-pr.yml
+++ b/.github/workflows/bakery-build-pr.yml
@@ -40,6 +40,11 @@ on:
         default: 1
         required: false
         type: number
+      cache:
+        description: "Whether to use registry caching for builds [default: true]"
+        default: true
+        required: false
+        type: boolean
       amd64-builder:
         description: "Runner label for amd64 builds"
         default: "ubuntu-latest-4x"
@@ -187,9 +192,10 @@ jobs:
           MATRIX_VERSIONS: ${{ inputs.matrix-versions }}
           BAKERY_CONTEXT: ${{ inputs.context }}
           REGISTRY_OWNER: ${{ github.repository_owner }}
+          CACHE: ${{ inputs.cache }}
         run: |
           CACHE_FLAGS=()
-          if [ "$IS_FORK" != "true" ]; then
+          if [ "$IS_FORK" != "true" ] && [ "$CACHE" = "true" ]; then
             CACHE_FLAGS=(--cache-registry "ghcr.io/${REGISTRY_OWNER}")
           fi
           bakery build \

--- a/.github/workflows/bakery-build.yml
+++ b/.github/workflows/bakery-build.yml
@@ -48,6 +48,11 @@ on:
         default: 1
         required: false
         type: number
+      cache:
+        description: "Whether to use registry caching for builds [default: true]"
+        default: true
+        required: false
+        type: boolean
       runs-on:
         description: "The type of runner to use [default: ubuntu-latest]"
         default: "ubuntu-latest"
@@ -193,14 +198,19 @@ jobs:
           MATRIX_VERSIONS: ${{ inputs.matrix-versions }}
           REGISTRY: ghcr.io/${{ github.repository_owner }}
           CONTEXT: ${{ inputs.context }}
+          CACHE: ${{ inputs.cache }}
         run: |
+          CACHE_FLAGS=()
+          if [ "$CACHE" = "true" ]; then
+            CACHE_FLAGS=(--cache-registry "$REGISTRY")
+          fi
           bakery build --load --pull \
             --retry "$RETRY" \
             --image-name "^${IMAGE_NAME}$" \
             --image-version "$IMAGE_VERSION" \
             --dev-versions "$DEV_VERSIONS" \
             --matrix-versions "$MATRIX_VERSIONS" \
-            --cache-registry "$REGISTRY" \
+            "${CACHE_FLAGS[@]}" \
             --context "$CONTEXT"
 
       - name: Test


### PR DESCRIPTION
## Summary
- Adds a `cache` boolean input (default `true`) to `bakery-build.yml`, `bakery-build-native.yml`, and `bakery-build-pr.yml`.
- When `cache: false`, the `--cache-registry` flag is omitted from bakery build invocations. `--temp-registry` is left untouched in the native workflow because it's required for the merge flow, not caching.
- In `bakery-build-pr.yml`, the new input combines with the existing fork check — caching applies only for non-fork PRs *and* when `cache` is true.

## Motivation
The `posit-dev/images-specialized` repository cannot use registry caching: its caches exceed 10GB, so cache creation silently fails during builds and loudly fails on cleanup. This input lets that repo's workflow calls disable caching.

## Test plan
- [ ] Verify default behavior (cache enabled) is unchanged in an existing caller repo.
- [ ] Verify a caller passing `cache: false` produces a `bakery build` invocation without `--cache-registry`.
- [ ] Verify `bakery-build-pr.yml` still skips caching on fork PRs regardless of the input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)