### PR TITLE
Slow dependabot actions group to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       - "/.github/actions/*"
       - "/setup-*"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       actions:
         patterns:


### PR DESCRIPTION
Change the dependabot github-actions ecosystem schedule from weekly to monthly to reduce churn from action bumps.