### PR TITLE
Migrate cross-repo workflows to GitHub Markdown

### DIFF
--- a/CI.md
+++ b/CI.md
@@ -8,7 +8,7 @@ This repository provides reusable GitHub Actions workflows and composite actions
 - [images-examples](https://github.com/posit-dev/images-examples)
 - [images-specialized](https://github.com/posit-dev/images-specialized)
 
-For the cross-repo dispatch chain (product repo → image repo → helm chart), see [Cross-Repository Workflows](https://posit-dev.github.io/images-shared/cross-repo-workflows.html).
+For the cross-repo dispatch chain (product repo → image repo → helm chart), see [Cross-repository workflows](./CI_CROSS_REPO_WORKFLOWS.md).
 
 ## Reusable workflows
 

--- a/CI_CROSS_REPO_WORKFLOWS.md
+++ b/CI_CROSS_REPO_WORKFLOWS.md
@@ -19,7 +19,7 @@ graph TD
 |---|---|
 | Thick line | `workflow_dispatch` (cross-repo trigger via GitHub App) |
 | Dashed line | `workflow_call` (reusable workflow in the same CI run) |
-| Thin line | Direct action: push, Flux sync, or PR merge |
+| Thin line | Direct action: push, Flux sync, or pull request merge |
 | Rectangle | Repository or workflow |
 | Cylinder | Registry |
 | Stadium | Environment |
@@ -34,7 +34,7 @@ graph TD
 | **posit-package-manager-automation** | `posit-dev/images-package-manager`<br/>`rstudio/package-manager`<br/>`rstudio/helm` | Dispatches downstream from Posit Package Manager (PPM) releases |
 | **posit-platform** | `posit-dev/images-shared`<br/>`rstudio/helm` | Platform team operations, centralized dispatch |
 
-Product GitHub Apps own the dispatch chain from product release through to Helm chart update. **posit-platform** handles platform-team-owned operations (e.g., scheduled rebuilds, cache cleanup).
+Product GitHub Apps own the dispatch chain from product release through to Helm chart update. `posit-platform` handles platform-team-owned operations (e.g., scheduled rebuilds, cache cleanup).
 
 ## Production release flow
 

--- a/CI_CROSS_REPO_WORKFLOWS.md
+++ b/CI_CROSS_REPO_WORKFLOWS.md
@@ -4,9 +4,6 @@ Repository relationships and workflow dispatch chains for the Posit container im
 
 For the reusable workflows that these dispatch chains call (inputs, secrets, examples), see [`CI.md`](./CI.md).
 
-> [!NOTE]
-> This document represents the **desired future state** of the cross-repo workflow architecture. Not all workflows shown here are implemented yet. See [posit-dev/images-shared#302](https://github.com/posit-dev/images-shared/issues/302) for implementation status and open PRs.
-
 ## Legend
 
 ```mermaid

--- a/CI_CROSS_REPO_WORKFLOWS.md
+++ b/CI_CROSS_REPO_WORKFLOWS.md
@@ -1,32 +1,15 @@
----
-title: "Cross-Repository Workflows"
-filters:
-    - mermaid-lightbox
----
+# Cross-repository workflows
 
-```{=html}
-<style>
-.cell.mermaid-lightbox-target a.glightbox {
-  display: block;
-  width: 100%;
-}
-</style>
-```
+Repository relationships and workflow dispatch chains for the Posit container image ecosystem, including dogfooding and internal deployment paths.
 
-Repository relationships and workflow dispatch chains for the Posit container
-image ecosystem, including dogfooding and internal deployment paths.
+For the reusable workflows that these dispatch chains call (inputs, secrets, examples), see [`CI.md`](./CI.md).
 
-::: {.callout-note}
-This document represents the **desired future state** of the cross-repo
-workflow architecture. Not all workflows shown here are implemented yet.
-See [posit-dev/images-shared#302](https://github.com/posit-dev/images-shared/issues/302)
-for implementation status and open PRs.
-:::
+> [!NOTE]
+> This document represents the **desired future state** of the cross-repo workflow architecture. Not all workflows shown here are implemented yet. See [posit-dev/images-shared#302](https://github.com/posit-dev/images-shared/issues/302) for implementation status and open PRs.
 
 ## Legend
 
-```{mermaid}
-%%| fig-cap: "Legend"
+```mermaid
 graph TD
     A["Repository"] ==>|"workflow_dispatch"| B["Repository"]
     C["Repository"] -.->|"workflow_call"| D["Repository"]
@@ -37,31 +20,28 @@ graph TD
 
 | Symbol | Meaning |
 |---|---|
-| Thick line | `workflow_dispatch` — cross-repo trigger via GitHub App |
-| Dashed line | `workflow_call` — reusable workflow (same CI run) |
-| Thin line | Direct action: push, Flux sync, PR merge |
+| Thick line | `workflow_dispatch` (cross-repo trigger via GitHub App) |
+| Dashed line | `workflow_call` (reusable workflow in the same CI run) |
+| Thin line | Direct action: push, Flux sync, or PR merge |
 | Rectangle | Repository or workflow |
 | Cylinder | Registry |
 | Stadium | Environment |
 | Hexagon | GitHub App identity |
 
-### GitHub Apps {.unnumbered}
+### GitHub Apps
 
 | App | Installed on | Role |
 |---|---|---|
-| **posit-connect-projects** | `posit-dev/connect`<br/>`posit-dev/images-connect`<br/>`rstudio/helm` | Dispatches downstream from Connect releases |
-| **workbench-ide-release** | `posit-dev/images-workbench`<br/>`rstudio/rstudio-pro`<br/>`rstudio/helm` | Dispatches downstream from Workbench releases |
-| **posit-package-manager-automation** | `posit-dev/images-package-manager`<br/>`rstudio/package-manager`<br/>`rstudio/helm` | Dispatches downstream from PPM releases |
+| **posit-connect-projects** | `posit-dev/connect`<br/>`posit-dev/images-connect`<br/>`rstudio/helm` | Dispatches downstream from Posit Connect releases |
+| **workbench-ide-release** | `posit-dev/images-workbench`<br/>`rstudio/rstudio-pro`<br/>`rstudio/helm` | Dispatches downstream from Posit Workbench releases |
+| **posit-package-manager-automation** | `posit-dev/images-package-manager`<br/>`rstudio/package-manager`<br/>`rstudio/helm` | Dispatches downstream from Posit Package Manager (PPM) releases |
 | **posit-platform** | `posit-dev/images-shared`<br/>`rstudio/helm` | Platform team operations, centralized dispatch |
 
-Product GitHub Apps own the dispatch chain from product release through
-to Helm chart update. **posit-platform** handles platform-team-owned
-operations (e.g., scheduled rebuilds, cache cleanup).
+Product GitHub Apps own the dispatch chain from product release through to Helm chart update. **posit-platform** handles platform-team-owned operations (e.g., scheduled rebuilds, cache cleanup).
 
-## Production Release Flow
+## Production release flow
 
-```{mermaid}
-%%| fig-cap: "Production Release Flow"
+```mermaid
 graph TD
     subgraph "Product Repos"
         CONNECT_PROD["connect"]
@@ -98,10 +78,9 @@ graph TD
     HELM["helm"] --> K8S(["K8s Dogfood Sites"])
 ```
 
-## Development / Preview Flow
+## Development and preview flow
 
-```{mermaid}
-%%| fig-cap: "Development / Preview Flow"
+```mermaid
 graph TD
     subgraph "Product Repos"
         CONNECT_PROD["connect"]
@@ -136,14 +115,13 @@ graph TD
     GHCR --> EKS_REF(["EKS Reference Architecture"])
 ```
 
-## Per-Product Diagrams
+## Per-product diagrams
 
 ### Connect
 
-#### Production {.unnumbered}
+#### Production
 
-```{mermaid}
-%%| fig-cap: "Connect Production Flow"
+```mermaid
 graph TD
     subgraph connect
         SCRIPTS["release-scripts.yml<br/>publish_release.py"]
@@ -182,20 +160,21 @@ graph TD
     end
 
     HELM_WF --> K8S(["K8s Dogfood Sites"])
-
-    click SCRIPTS "https://github.com/posit-dev/connect/blob/main/.github/workflows/release-scripts.yml" _blank
-    click REL "https://github.com/posit-dev/images-connect/blob/main/.github/workflows/release.yml" _blank
-    click PROD_WF "https://github.com/posit-dev/images-connect/blob/main/.github/workflows/production.yml" _blank
-    click CONTENT "https://github.com/posit-dev/images-connect/blob/main/.github/workflows/content.yml" _blank
-    click PRODUCT_REL "https://github.com/posit-dev/images-shared/blob/main/.github/workflows/product-release.yml" _blank
-    click SHARED "https://github.com/posit-dev/images-shared/blob/main/.github/workflows/bakery-build-native.yml" _blank
-    click HELM_WF "https://github.com/rstudio/helm/blob/main/.github/workflows/product-release.yml" _blank
 ```
 
-#### Development {.unnumbered}
+Source files:
 
-```{mermaid}
-%%| fig-cap: "Connect Development Flow"
+- [`release-scripts.yml`](https://github.com/posit-dev/connect/blob/main/.github/workflows/release-scripts.yml) (connect)
+- [`release.yml`](https://github.com/posit-dev/images-connect/blob/main/.github/workflows/release.yml) (images-connect)
+- [`production.yml`](https://github.com/posit-dev/images-connect/blob/main/.github/workflows/production.yml) (images-connect)
+- [`content.yml`](https://github.com/posit-dev/images-connect/blob/main/.github/workflows/content.yml) (images-connect)
+- [`product-release.yml`](https://github.com/posit-dev/images-shared/blob/main/.github/workflows/product-release.yml) (images-shared)
+- [`bakery-build-native.yml`](https://github.com/posit-dev/images-shared/blob/main/.github/workflows/bakery-build-native.yml) (images-shared)
+- [`product-release.yml`](https://github.com/rstudio/helm/blob/main/.github/workflows/product-release.yml) (helm)
+
+#### Development
+
+```mermaid
 graph TD
     subgraph connect
         CI["ci.yml"]
@@ -216,18 +195,19 @@ graph TD
 
     DEV -->|push| GHCR[("GHCR<br/>connect-preview")]
     GHCR --> K8S(["K8s Dogfood Sites"])
-
-    click CI "https://github.com/posit-dev/connect/blob/main/.github/workflows/ci.yml" _blank
-    click DEV "https://github.com/posit-dev/images-connect/blob/main/.github/workflows/development.yml" _blank
-    click SHARED "https://github.com/posit-dev/images-shared/blob/main/.github/workflows/bakery-build-native.yml" _blank
 ```
+
+Source files:
+
+- [`ci.yml`](https://github.com/posit-dev/connect/blob/main/.github/workflows/ci.yml) (connect)
+- [`development.yml`](https://github.com/posit-dev/images-connect/blob/main/.github/workflows/development.yml) (images-connect)
+- [`bakery-build-native.yml`](https://github.com/posit-dev/images-shared/blob/main/.github/workflows/bakery-build-native.yml) (images-shared)
 
 ### Workbench
 
-#### Production {.unnumbered}
+#### Production
 
-```{mermaid}
-%%| fig-cap: "Workbench Production Flow"
+```mermaid
 graph TD
     subgraph rstudio-pro
         RELEASE_ALL["release-all.yml"]
@@ -268,21 +248,22 @@ graph TD
     end
 
     HELM_WF --> K8S(["K8s Dogfood Sites"])
-
-    click RELEASE_ALL "https://github.com/rstudio/rstudio-pro/blob/main/.github/workflows/release-all.yml" _blank
-    click UPDATE_IMG "https://github.com/rstudio/rstudio-pro/blob/main/.github/workflows/release-update-images-workbench.yml" _blank
-    click REL "https://github.com/posit-dev/images-workbench/blob/main/.github/workflows/release.yml" _blank
-    click PROD_WF "https://github.com/posit-dev/images-workbench/blob/main/.github/workflows/production.yml" _blank
-    click SESSION "https://github.com/posit-dev/images-workbench/blob/main/.github/workflows/session.yml" _blank
-    click PRODUCT_REL "https://github.com/posit-dev/images-shared/blob/main/.github/workflows/product-release.yml" _blank
-    click SHARED "https://github.com/posit-dev/images-shared/blob/main/.github/workflows/bakery-build-native.yml" _blank
-    click HELM_WF "https://github.com/rstudio/helm/blob/main/.github/workflows/product-release.yml" _blank
 ```
 
-#### Development {.unnumbered}
+Source files:
 
-```{mermaid}
-%%| fig-cap: "Workbench Development Flow"
+- [`release-all.yml`](https://github.com/rstudio/rstudio-pro/blob/main/.github/workflows/release-all.yml) (rstudio-pro)
+- [`release-update-images-workbench.yml`](https://github.com/rstudio/rstudio-pro/blob/main/.github/workflows/release-update-images-workbench.yml) (rstudio-pro)
+- [`release.yml`](https://github.com/posit-dev/images-workbench/blob/main/.github/workflows/release.yml) (images-workbench)
+- [`production.yml`](https://github.com/posit-dev/images-workbench/blob/main/.github/workflows/production.yml) (images-workbench)
+- [`session.yml`](https://github.com/posit-dev/images-workbench/blob/main/.github/workflows/session.yml) (images-workbench)
+- [`product-release.yml`](https://github.com/posit-dev/images-shared/blob/main/.github/workflows/product-release.yml) (images-shared)
+- [`bakery-build-native.yml`](https://github.com/posit-dev/images-shared/blob/main/.github/workflows/bakery-build-native.yml) (images-shared)
+- [`product-release.yml`](https://github.com/rstudio/helm/blob/main/.github/workflows/product-release.yml) (helm)
+
+#### Development
+
+```mermaid
 graph TD
     subgraph rstudio-pro
         NIGHTLY["release-nightly-test.yml"]
@@ -305,18 +286,19 @@ graph TD
     GHCR --> K8S(["K8s Dogfood Sites"])
     GHCR --> FUZZBUCKET(["Fuzzbucket"])
     GHCR --> EKS_REF(["EKS Reference Architecture"])
-
-    click NIGHTLY "https://github.com/rstudio/rstudio-pro/blob/main/.github/workflows/release-nightly-test.yml" _blank
-    click DEV "https://github.com/posit-dev/images-workbench/blob/main/.github/workflows/development.yml" _blank
-    click SHARED "https://github.com/posit-dev/images-shared/blob/main/.github/workflows/bakery-build-native.yml" _blank
 ```
+
+Source files:
+
+- [`release-nightly-test.yml`](https://github.com/rstudio/rstudio-pro/blob/main/.github/workflows/release-nightly-test.yml) (rstudio-pro)
+- [`development.yml`](https://github.com/posit-dev/images-workbench/blob/main/.github/workflows/development.yml) (images-workbench)
+- [`bakery-build-native.yml`](https://github.com/posit-dev/images-shared/blob/main/.github/workflows/bakery-build-native.yml) (images-shared)
 
 ### Package Manager
 
-#### Production {.unnumbered}
+#### Production
 
-```{mermaid}
-%%| fig-cap: "Package Manager Production Flow"
+```mermaid
 graph TD
     subgraph package-manager
         CI["ci.yml (publish job)"]
@@ -350,19 +332,20 @@ graph TD
     end
 
     HELM_WF --> K8S(["K8s Dogfood Sites"])
-
-    click CI "https://github.com/rstudio/package-manager/blob/main/.github/workflows/ci.yml" _blank
-    click REL "https://github.com/posit-dev/images-package-manager/blob/main/.github/workflows/release.yml" _blank
-    click PROD_WF "https://github.com/posit-dev/images-package-manager/blob/main/.github/workflows/production.yml" _blank
-    click PRODUCT_REL "https://github.com/posit-dev/images-shared/blob/main/.github/workflows/product-release.yml" _blank
-    click SHARED "https://github.com/posit-dev/images-shared/blob/main/.github/workflows/bakery-build-native.yml" _blank
-    click HELM_WF "https://github.com/rstudio/helm/blob/main/.github/workflows/product-release.yml" _blank
 ```
 
-#### Development {.unnumbered}
+Source files:
 
-```{mermaid}
-%%| fig-cap: "Package Manager Development Flow"
+- [`ci.yml`](https://github.com/rstudio/package-manager/blob/main/.github/workflows/ci.yml) (package-manager)
+- [`release.yml`](https://github.com/posit-dev/images-package-manager/blob/main/.github/workflows/release.yml) (images-package-manager)
+- [`production.yml`](https://github.com/posit-dev/images-package-manager/blob/main/.github/workflows/production.yml) (images-package-manager)
+- [`product-release.yml`](https://github.com/posit-dev/images-shared/blob/main/.github/workflows/product-release.yml) (images-shared)
+- [`bakery-build-native.yml`](https://github.com/posit-dev/images-shared/blob/main/.github/workflows/bakery-build-native.yml) (images-shared)
+- [`product-release.yml`](https://github.com/rstudio/helm/blob/main/.github/workflows/product-release.yml) (helm)
+
+#### Development
+
+```mermaid
 graph TD
     subgraph package-manager
         CI["ci.yml (publish job)"]
@@ -383,8 +366,10 @@ graph TD
 
     DEV -->|push| GHCR[("GHCR<br/>package-manager-preview")]
     GHCR --> K8S(["K8s Dogfood Sites"])
-
-    click CI "https://github.com/rstudio/package-manager/blob/main/.github/workflows/ci.yml" _blank
-    click DEV "https://github.com/posit-dev/images-package-manager/blob/main/.github/workflows/development.yml" _blank
-    click SHARED "https://github.com/posit-dev/images-shared/blob/main/.github/workflows/bakery-build-native.yml" _blank
 ```
+
+Source files:
+
+- [`ci.yml`](https://github.com/rstudio/package-manager/blob/main/.github/workflows/ci.yml) (package-manager)
+- [`development.yml`](https://github.com/posit-dev/images-package-manager/blob/main/.github/workflows/development.yml) (images-package-manager)
+- [`bakery-build-native.yml`](https://github.com/posit-dev/images-shared/blob/main/.github/workflows/bakery-build-native.yml) (images-shared)

--- a/posit-bakery/docs/_quarto.yml
+++ b/posit-bakery/docs/_quarto.yml
@@ -26,8 +26,6 @@ website:
         href: "templating.qmd"
       - text: "Architecture"
         href: "architecture.qmd"
-      - text: "Cross-Repository Workflows"
-        href: "cross-repo-workflows.qmd"
 
   page-footer:
     left:


### PR DESCRIPTION
## Summary

`cross-repo-workflows.qmd` documents the cross-repo dispatch chain (product → image → helm), not bakery itself, so it sits awkwardly in the Posit Bakery quarto docs site. The audience is also already GitHub-native, so the quarto features in use (mermaid lightbox, clickable `click NODE "URL"` directives, callout blocks) cost more than they earn.

This PR moves the doc to `CI_CROSS_REPO_WORKFLOWS.md` at the repo root next to `CI.md`:

- Converts `::: {.callout-note}` to `> [!NOTE]`.
- Converts each diagram's `click NODE "URL" _blank` directives to a "Source files" bulleted list under the diagram. One extra click but the URLs stay discoverable next to the diagram.
- Strips Quarto-only frontmatter, `{=html}` lightbox CSS, `%%| fig-cap` mermaid directives, and `{.unnumbered}` heading attributes.
- Applies sentence-case headings and long-form product names on first mention (matching the style applied to `CI.md` in #526).
- Updates the inbound reference in `CI.md` to point at the new file.
- Removes the sidebar entry from `posit-bakery/docs/_quarto.yml` and deletes the qmd source.

Stacked on top of #526 — base is `refresh-ci-md`. Retarget to `main` after #526 merges.