### PR TITLE
Polish posit-bakery for PyPI publishing

### DIFF
--- a/posit-bakery/LICENSE.md
+++ b/posit-bakery/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Posit Software, PBC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/posit-bakery/README.md
+++ b/posit-bakery/README.md
@@ -27,7 +27,13 @@ Full documentation is available at **[posit-dev.github.io/images-shared](https:/
 
 ## Installation
 
-Install `bakery` using `uv tool`:
+Install `bakery` from [PyPI](https://pypi.org/project/posit-bakery/) using `uv tool`:
+
+```bash
+uv tool install posit-bakery
+```
+
+To install an unreleased development version directly from GitHub:
 
 ```bash
 uv tool install 'git+https://github.com/posit-dev/images-shared.git@main#subdirectory=posit-bakery&egg=posit-bakery'

--- a/posit-bakery/docs/index.qmd
+++ b/posit-bakery/docs/index.qmd
@@ -23,7 +23,13 @@ Additional tool integrations (hadolint, trivy, wizcli, openscap) are planned. Se
 
 ## Installation
 
-Install `bakery` using `uv tool`:
+Install `bakery` from [PyPI](https://pypi.org/project/posit-bakery/) using `uv tool`:
+
+```bash
+uv tool install posit-bakery
+```
+
+To install an unreleased development version directly from GitHub:
 
 ```bash
 uv tool install 'git+https://github.com/posit-dev/images-shared.git@main#subdirectory=posit-bakery&egg=posit-bakery'

--- a/posit-bakery/pyproject.toml
+++ b/posit-bakery/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "posit-bakery"
-description = "Tools for extracting and manipulating image build artifacts for various commands"
+description = "CLI for building, testing, and managing matrixed container images with variant, version, and OS support via Docker Buildx Bake."
 authors = [
     { name = "Ian H. Pittwood", email = "ian.pittwood@posit.co" },
     { name = "Ben Schwedler", email = "ben@posit.co" },
@@ -9,9 +9,26 @@ maintainers = [
     { name = "Posit Container Team", email = "docker@posit.co" },
 ]
 license = "MIT"
+license-files = ["LICENSE.md"]
 readme = "README.md"
+keywords = ["docker", "container", "image", "build", "bake", "buildx", "posit", "cli"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: MacOS",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Build Tools",
+    "Topic :: System :: Software Distribution",
+]
 
-requires-python = "<4,>=3.10"
+requires-python = ">=3.10"
 dependencies = [
     "typer~=0.21.1",
     "jinja2~=3.1.6",
@@ -26,6 +43,13 @@ dependencies = [
     "pygithub>=2.8.1,<3.0.0",
 ]
 dynamic = ["version"]
+
+[project.urls]
+Homepage = "https://posit-dev.github.io/images-shared/"
+Documentation = "https://posit-dev.github.io/images-shared/"
+Repository = "https://github.com/posit-dev/images-shared"
+Issues = "https://github.com/posit-dev/images-shared/issues"
+Changelog = "https://github.com/posit-dev/images-shared/releases"
 
 [project.scripts]
 bakery = "posit_bakery.cli.main:app"
@@ -42,6 +66,17 @@ build-backend = "hatchling.build"
 
 [tool.hatch.version]
 source = "uv-dynamic-versioning"
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "posit_bakery/",
+    "README.md",
+    "LICENSE.md",
+    "pyproject.toml",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["posit_bakery"]
 
 [tool.ruff]
 line-length = 120

--- a/posit-bakery/pyproject.toml
+++ b/posit-bakery/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Build Tools",
     "Topic :: System :: Software Distribution",
 ]

--- a/posit-bakery/pyproject.toml
+++ b/posit-bakery/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "posit-bakery"
-description = "CLI for building, testing, and managing matrixed container images with variant, version, and OS support via Docker Buildx Bake."
+description = "CLI for building, testing, and managing multidimensional container images with variant, version, and OS support."
 authors = [
     { name = "Ian H. Pittwood", email = "ian.pittwood@posit.co" },
     { name = "Ben Schwedler", email = "ben@posit.co" },


### PR DESCRIPTION
Stacked on #532.

## Summary
Prepare `posit-bakery` for a clean first PyPI publish:

### Docs
- Update `posit-bakery/README.md` and `posit-bakery/docs/index.qmd` to recommend `uv tool install posit-bakery` from PyPI as the primary install path. Keep the `git+https://...` command as a documented fallback for unreleased development versions.

### Project metadata (`pyproject.toml`)
- Rewrite the `description` to actually describe what bakery does.
- Add `[project.urls]` (Homepage, Documentation, Repository, Issues, Changelog) so the PyPI sidebar shows links.
- Add `keywords` and trove `classifiers` (development status, OS, supported Python versions, topic).
- Add `license-files = ["LICENSE.md"]` and vendor `LICENSE.md` into the package directory so the dist actually ships the license (PEP 639 resolves relative to `pyproject.toml`).
- Configure `[tool.hatch.build.targets.sdist]` include list so the sdist stops shipping `docs/`, the quarto cache, `justfile`, and `uv.lock`. Sdist drops from multi-MB to ~120K.
- Drop the meaningless `<4` upper bound on `requires-python`.

## Verification
Local `uv build` produces a wheel whose `METADATA` includes all new fields, with `LICENSE.md` inside `*.dist-info/licenses/`. Sdist top-level contents are now just: `posit_bakery/`, `README.md`, `LICENSE.md`, `pyproject.toml`, `PKG-INFO`, `.gitignore`.

## Follow-ups (not in this PR)
- Sibling repo justfiles — separate PRs already opened: posit-dev/images-connect#97, posit-dev/images-package-manager#94, posit-dev/images-workbench#104.
- `setup-bakery/action.yml` — needs a design decision on how the `version` input maps between git refs and PyPI releases.

## Test plan
- [ ] After this PR + #532 land and the first `v*` tag is pushed, confirm the PyPI project page renders the sidebar links, classifiers, keywords, and description correctly.
- [ ] Confirm the published wheel includes `LICENSE.md` in `dist-info/licenses/`.
- [ ] Confirm `uv tool install posit-bakery` works as documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)