### PR TITLE
Fix double linux/ prefix in dgoss --image-platform

### DIFF
--- a/posit-bakery/posit_bakery/cli/run.py
+++ b/posit-bakery/posit_bakery/cli/run.py
@@ -141,7 +141,8 @@ def dgoss(
 
     # Autoselect host architecture platform if not specified.
     image_platform = image_platform or SETTINGS.architecture
-    image_platform = f"linux/{image_platform}"
+    if not image_platform.startswith("linux/"):
+        image_platform = f"linux/{image_platform}"
 
     settings = BakerySettings(
         filter=BakeryConfigFilter(

--- a/posit-bakery/posit_bakery/plugins/builtin/dgoss/__init__.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/dgoss/__init__.py
@@ -140,7 +140,8 @@ class DGossPlugin(BakeryToolPlugin):
             """
             # Autoselect host architecture platform if not specified.
             platform = image_platform or SETTINGS.architecture
-            platform = f"linux/{platform}"
+            if not platform.startswith("linux/"):
+                platform = f"linux/{platform}"
 
             settings = BakerySettings(
                 filter=BakeryConfigFilter(

--- a/posit-bakery/test/cli/test_run_dgoss.py
+++ b/posit-bakery/test/cli/test_run_dgoss.py
@@ -1,0 +1,60 @@
+"""Unit tests for the deprecated `bakery run dgoss` CLI command.
+
+Guards the same platform normalization behavior as `bakery dgoss run`. See
+`test/plugins/builtin/dgoss/test_init.py` for the equivalent coverage on the
+non-deprecated command path.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from posit_bakery.cli.main import app
+
+runner = CliRunner()
+
+BASIC_CONTEXT = str(Path(__file__).parent.parent / "resources" / "basic")
+
+
+@pytest.fixture
+def mocked_bakery_run_dgoss():
+    """Mock BakeryConfig and the DGoss plugin's execute method so the CLI can
+    run end-to-end without needing a Docker daemon or built images."""
+    with patch("posit_bakery.cli.run.BakeryConfig") as mock_config:
+        instance = MagicMock()
+        instance.base_path = Path(BASIC_CONTEXT)
+        instance.targets = []
+        mock_config.from_context.return_value = instance
+        with patch("posit_bakery.cli.run.get_plugin") as mock_get_plugin:
+            mock_plugin = MagicMock()
+            mock_plugin.execute.return_value = []
+            mock_get_plugin.return_value = mock_plugin
+            yield mock_config, mock_plugin
+
+
+class TestRunDgossPlatformNormalization:
+    """Regression coverage: `--image-platform linux/amd64` must not become
+    `linux/linux/amd64`."""
+
+    @pytest.mark.parametrize(
+        "given,expected",
+        [
+            ("amd64", "linux/amd64"),
+            ("arm64", "linux/arm64"),
+            ("linux/amd64", "linux/amd64"),
+            ("linux/arm64", "linux/arm64"),
+        ],
+    )
+    def test_normalizes_platform(self, mocked_bakery_run_dgoss, given, expected):
+        mock_config, mock_plugin = mocked_bakery_run_dgoss
+        result = runner.invoke(
+            app,
+            ["run", "dgoss", "--context", BASIC_CONTEXT, "--image-platform", given],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.stdout
+        settings = mock_config.from_context.call_args[0][1]
+        assert settings.filter.image_platform == [expected]
+        assert mock_plugin.execute.call_args[1]["platform"] == expected

--- a/posit-bakery/test/plugins/builtin/dgoss/test_init.py
+++ b/posit-bakery/test/plugins/builtin/dgoss/test_init.py
@@ -1,0 +1,64 @@
+"""Unit tests for the `bakery dgoss run` CLI command.
+
+Specifically guards the platform normalization step. If the caller passes a
+value that already includes the `linux/` prefix, the command must not prepend
+the prefix a second time. The shared GitHub Actions workflows pass platform
+values straight through from `bakery ci matrix` output (e.g. `linux/amd64`),
+and a double-prefixed value (e.g. `linux/linux/amd64`) causes Docker to
+reject the run.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from posit_bakery.cli.main import app
+
+runner = CliRunner()
+
+BASIC_CONTEXT = str(Path(__file__).parent.parent.parent.parent / "resources" / "basic")
+
+
+@pytest.fixture
+def mocked_dgoss_run():
+    """Mock BakeryConfig and DGossPlugin.execute so the CLI can run end-to-end
+    without needing a Docker daemon or built images."""
+    with patch("posit_bakery.plugins.builtin.dgoss.BakeryConfig") as mock_config:
+        instance = MagicMock()
+        instance.base_path = Path(BASIC_CONTEXT)
+        instance.targets = []
+        mock_config.from_context.return_value = instance
+        with (
+            patch("posit_bakery.plugins.builtin.dgoss.DGossPlugin.execute") as mock_execute,
+            patch("posit_bakery.plugins.builtin.dgoss.DGossPlugin.results"),
+        ):
+            mock_execute.return_value = []
+            yield mock_config, mock_execute
+
+
+class TestDgossRunPlatformNormalization:
+    """Regression coverage: `--image-platform linux/amd64` must not become
+    `linux/linux/amd64`."""
+
+    @pytest.mark.parametrize(
+        "given,expected",
+        [
+            ("amd64", "linux/amd64"),
+            ("arm64", "linux/arm64"),
+            ("linux/amd64", "linux/amd64"),
+            ("linux/arm64", "linux/arm64"),
+        ],
+    )
+    def test_normalizes_platform(self, mocked_dgoss_run, given, expected):
+        mock_config, mock_execute = mocked_dgoss_run
+        result = runner.invoke(
+            app,
+            ["dgoss", "run", "--context", BASIC_CONTEXT, "--image-platform", given],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.stdout
+        settings = mock_config.from_context.call_args[0][1]
+        assert settings.filter.image_platform == [expected]
+        assert mock_execute.call_args[1]["platform"] == expected


### PR DESCRIPTION
Both `bakery dgoss run` and the deprecated `bakery run dgoss` unconditionally prepended `linux/` to the `--image-platform` value, turning `linux/amd64` into `linux/linux/amd64`. The shared `bakery-build-pr.yml` workflow passes the platform straight through from `bakery ci matrix` output, which is already `linux/`-prefixed. The double prefix reached `dgoss run --platform ...` and Docker rejected it with exit code 125.

Product repos masked the bug because their bakery.yaml files declare explicit platforms, so the bad filter excluded every target. The dgoss step reported `0 tests completed` and passed without running anything. A consumer with no explicit platforms surfaced it.

The shared workflow contract is unchanged.

Discovered while building https://github.com/posit-dev/images-examples/pull/33.