### PR TITLE
Generate API reference in docs publish workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,8 @@ on:
   push:
     branches: main
     paths:
-      - 'posit-bakery/docs/**'
+      - 'posit-bakery/**'
+      - '.github/workflows/docs.yml'
 
 name: Publish Docs
 
@@ -15,6 +16,24 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          python-version-file: posit-bakery/pyproject.toml
+          enable-cache: false
+
+      - name: Install docs dependencies
+        working-directory: posit-bakery
+        run: uv sync --group docs
+
+      - name: Generate API reference
+        working-directory: posit-bakery
+        run: |
+          uv run --group docs great-docs build --project-path .
+          rm -rf docs/reference
+          cp -r great-docs/reference docs/reference
+          rm -rf great-docs
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@8a96df13519ee81fd526f2dfca5962811136661b  # v2.2.0

--- a/posit-bakery/docs/architecture.qmd
+++ b/posit-bakery/docs/architecture.qmd
@@ -188,12 +188,12 @@ flowchart TD
     results[/"Test & Scan Results"/]
 
     lint[[hadolint]]
-    runLint[[bakery run lint]]
+    runLint[[bakery hadolint run]]
     runLint --> lint
     containerfile -.-> lint -.-> results
 
     dgoss[[dgoss]]
-    runDgoss[[bakery run dgoss]]
+    runDgoss[[bakery dgoss run]]
     image & tests -.-> dgoss
     runDgoss --> dgoss
     dgoss -.-> results
@@ -208,7 +208,7 @@ flowchart TD
 
     %% Mark what we are working on and is in flight %%
     class inprogress,snyk progress
-    class planned,lint,openscap,results todo
+    class planned,openscap,results todo
 ```
 
 ### Run Security Scans
@@ -221,17 +221,17 @@ flowchart TD
     results[/"Test & Scan results"/]
 
     trivy[[trivy]]
-    runTrivy[[bakery run trivy]]
+    runTrivy[[bakery trivy run]]
     runTrivy --> trivy
     image -.-> trivy -.-> results
 
     wizcli[[wizcli]]
-    runWizcli[[bakery run wiz]]
+    runWizcli[[bakery wizcli scan]]
     runWizcli --> wizcli
     image -.-> wizcli -.-> results
 
     openscap[[openscap]]
-    runOpenscap[[bakery run openscap]]
+    runOpenscap[[bakery openscap run]]
     runOpenscap --> openscap
     image -.-> openscap -.-> results
 
@@ -244,7 +244,7 @@ flowchart TD
     class trivy,openscap,wizcli external
 
     %% Mark what we are working on and is in flight %%
-    class inprogress,trivy,wizcli todo
+    class inprogress,trivy todo
     class openscap,results todo
 ```
 
@@ -288,7 +288,7 @@ flowchart TD
 
     sign["Sign Image(s)"]
     push_temp["Push to Temporary Registry"]
-    merge["Merge to OCI Index"]
+    merge[["bakery oras merge"]]
     push["Push Artifacts to Final Registry & Reporting Platform"]
     amd64_image -.-> push_temp
     arm64_image -.-> push_temp
@@ -303,6 +303,8 @@ flowchart TD
     classDef external fill:grey,color:#fff
     classDef progress stroke-dasharray: 2 2
     classDef todo stroke-dasharray: 3 8
+
+    class merge tooling
 
     %% Mark what we are working on and is in flight %%
     class results,sign todo

--- a/posit-bakery/docs/index.qmd
+++ b/posit-bakery/docs/index.qmd
@@ -15,10 +15,13 @@ Bakery is a CLI tool that binds together various tools to manage a matrixed buil
 |:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:--------------------------------|:-------------------------------------------------------------------|
 | [docker buildx bake](https://github.com/docker/buildx#installing)                                                                                                         | `bakery build --strategy bake`  | Build containers in parallel                                       |
 | [docker](https://github.com/docker/buildx#installing), [podman](https://podman-desktop.io/docs/installation), or [nerdctl](https://github.com/containerd/nerdctl#install) | `bakery build --strategy build` | Build containers in series                                         |
-| [dgoss](https://github.com/goss-org/goss#installation)                                                                                                                    | `bakery run dgoss`              | Test container images for expected content & behavior              |
+| [dgoss](https://github.com/goss-org/goss#installation)                                                                                                                    | `bakery dgoss run`              | Test container images for expected content & behavior              |
+| [hadolint](https://github.com/hadolint/hadolint#install)                                                                                                                  | `bakery hadolint run`           | Lint Containerfiles for best practices                             |
+| [oras](https://oras.land/)                                                                                                                                                | `bakery oras merge`             | Merge multi-platform images into an OCI index                      |
+| [wizcli](https://www.wiz.io/)                                                                                                                                             | `bakery wizcli scan`            | Scan container images for vulnerabilities                          |
 
 ::: {.callout-note}
-Additional tool integrations (hadolint, trivy, wizcli, openscap) are planned. See the [architecture diagrams](architecture.qmd) for the full roadmap.
+Additional tool integrations (trivy, openscap) are planned. See the [architecture diagrams](architecture.qmd) for the full roadmap.
 :::
 
 ## Installation
@@ -155,7 +158,7 @@ bakery help
 * Run the `dgoss` tests against all the images
 
     ```shell
-    bakery run dgoss
+    bakery dgoss run
     ```
 
     Additional run options can be specified using [Goss options](configuration.qmd#gossoptions) in `bakery.yaml` on a per image or per variant basis


### PR DESCRIPTION
The great-docs migration added `posit-bakery/docs/reference/` to .gitignore so reference pages are generated rather than checked in. The publish workflow rendered with Quarto directly and never invoked great-docs, so gh-pages lost the API/CLI reference section.

Workflow:

- Install uv, sync the docs dependency group, and run `great-docs build` before Quarto renders — mirrors `just docs-reference`
- Broaden the path trigger from `posit-bakery/docs/**` to `posit-bakery/**` (plus the workflow file) so source changes also republish the API reference

Docs:

- Mark hadolint, oras, and wizcli as implemented in the landing-page tool table and drop them from the planned-integrations callout
- Update commands across docs to the plugin form (`bakery <tool> <subcommand>`): `bakery run dgoss` → `bakery dgoss run`, `bakery run wiz` → `bakery wizcli scan`, and align still-planned trivy/openscap labels with the same order
- In the Run Tests and Run Security Scans diagrams, drop hadolint and wizcli from the planned/todo class so they render with a solid border
- In the Multiplatform Publishing diagram, label the merge step as `bakery oras merge` and apply the tooling class

Related:

- https://github.com/posit-dev/images-shared/pull/488