### PR TITLE
Configure apt retries and timeout in image builds

### DIFF
--- a/posit-bakery/posit_bakery/config/templating/macros/apt.j2
+++ b/posit-bakery/posit_bakery/config/templating/macros/apt.j2
@@ -37,6 +37,19 @@ apt-get clean {{ global_options }} && \
 rm -rf /var/lib/apt/lists/*
 {%- endmacro %}
 
+{# Write apt retries and timeout config.
+Retries without a lowered Timeout makes stalls take longer, not shorter.
+Called once inside setup() so the file persists across subsequent layers.
+Subsequent apt macros do not re-emit this, keeping rendered Containerfiles
+readable for downstream consumers.
+
+:param retries: Retry attempts on transient errors. Defaults to 3.
+:param timeout: Per-fetch timeout in seconds. Defaults to 30.
+#}
+{% macro configure_retries(retries = 3, timeout = 30) -%}
+echo 'Acquire::Retries "{{ retries }}"; Acquire::http::Timeout "{{ timeout }}"; Acquire::https::Timeout "{{ timeout }}";' > /etc/apt/apt.conf.d/99-retries
+{%- endmacro %}
+
 {# Commands for updating the apt cache, upgrading packages, running dist-upgrade, removing unneeded packages,
 and cleaning the apt cache.
 
@@ -150,6 +163,7 @@ optionally adding the Posit Pro and/or Open apt repositories.
 :param open_repo: Whether to add the Posit Open apt repository. Defaults to False.
 #}
 {% macro setup(clean = True, codename = None, pro_repo = True, open_repo = False) -%}
+{{ configure_retries() }} && \
 {{ update_upgrade(False) }} && \
 apt-get install -yqq --no-install-recommends \
     curl \

--- a/posit-bakery/test/config/templating/test_macros.py
+++ b/posit-bakery/test/config/templating/test_macros.py
@@ -578,6 +578,7 @@ class TestAptMacros:
                 False,
                 textwrap.dedent(
                     """\
+                    echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \\
                     apt-get update -yqq --fix-missing && \\
                     apt-get upgrade -yqq && \\
                     apt-get dist-upgrade -yqq && \\
@@ -600,6 +601,7 @@ class TestAptMacros:
                 False,
                 textwrap.dedent(
                     """\
+                    echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \\
                     apt-get update -yqq --fix-missing && \\
                     apt-get upgrade -yqq && \\
                     apt-get dist-upgrade -yqq && \\
@@ -620,6 +622,7 @@ class TestAptMacros:
                 True,
                 textwrap.dedent(
                     """\
+                    echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \\
                     apt-get update -yqq --fix-missing && \\
                     apt-get upgrade -yqq && \\
                     apt-get dist-upgrade -yqq && \\
@@ -643,6 +646,7 @@ class TestAptMacros:
                 True,
                 textwrap.dedent(
                     """\
+                    echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \\
                     apt-get update -yqq --fix-missing && \\
                     apt-get upgrade -yqq && \\
                     apt-get dist-upgrade -yqq && \\
@@ -665,6 +669,7 @@ class TestAptMacros:
                 False,
                 textwrap.dedent(
                     """\
+                    echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \\
                     apt-get update -yqq --fix-missing && \\
                     apt-get upgrade -yqq && \\
                     apt-get dist-upgrade -yqq && \\
@@ -695,7 +700,8 @@ class TestAptMacros:
         rendered = environment_with_macros.from_string(template).render()
         expected = textwrap.dedent(
             """\
-            RUN apt-get update -yqq --fix-missing && \\
+            RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \\
+                apt-get update -yqq --fix-missing && \\
                 apt-get upgrade -yqq && \\
                 apt-get dist-upgrade -yqq && \\
                 apt-get autoremove -yqq --purge && \\
@@ -716,7 +722,8 @@ class TestAptMacros:
         rendered = environment_with_macros.from_string(template).render()
         expected = textwrap.dedent(
             """\
-            RUN apt-get update -yqq --fix-missing && \\
+            RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \\
+                apt-get update -yqq --fix-missing && \\
                 apt-get upgrade -yqq && \\
                 apt-get dist-upgrade -yqq && \\
                 apt-get autoremove -yqq --purge && \\
@@ -738,7 +745,8 @@ class TestAptMacros:
         rendered = environment_with_macros.from_string(template).render()
         expected = textwrap.dedent(
             """\
-            RUN apt-get update -yqq --fix-missing && \\
+            RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \\
+                apt-get update -yqq --fix-missing && \\
                 apt-get upgrade -yqq && \\
                 apt-get dist-upgrade -yqq && \\
                 apt-get autoremove -yqq --purge && \\

--- a/posit-bakery/test/config/test_config.py
+++ b/posit-bakery/test/config/test_config.py
@@ -999,7 +999,8 @@ class TestBakeryConfig:
             ARG TARGETARCH=${BUILDARCH}
 
             ### Install Apt Packages ###
-            RUN apt-get update -yqq --fix-missing && \\
+            RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \\
+                apt-get update -yqq --fix-missing && \\
                 apt-get upgrade -yqq && \\
                 apt-get dist-upgrade -yqq && \\
                 apt-get autoremove -yqq --purge && \\
@@ -1044,7 +1045,8 @@ class TestBakeryConfig:
             ARG TARGETARCH=${BUILDARCH}
 
             ### Install Apt Packages ###
-            RUN apt-get update -yqq --fix-missing && \\
+            RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \\
+                apt-get update -yqq --fix-missing && \\
                 apt-get upgrade -yqq && \\
                 apt-get dist-upgrade -yqq && \\
                 apt-get autoremove -yqq --purge && \\

--- a/posit-bakery/test/resources/matrix/test-matrix/matrix/Containerfile.ubuntu2404
+++ b/posit-bakery/test/resources/matrix/test-matrix/matrix/Containerfile.ubuntu2404
@@ -22,7 +22,8 @@ ARG PYTHON_VERSION
 ARG QUARTO_VERSION
 
 ### Install Apt Packages ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/posit-bakery/test/resources/with-macros/test-image/1.0.0/Containerfile.ubuntu2204.min
+++ b/posit-bakery/test/resources/with-macros/test-image/1.0.0/Containerfile.ubuntu2204.min
@@ -8,7 +8,8 @@ ARG BUILDARCH
 ARG TARGETARCH=${BUILDARCH}
 
 ### Install Apt Packages ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/posit-bakery/test/resources/with-macros/test-image/1.0.0/Containerfile.ubuntu2204.std
+++ b/posit-bakery/test/resources/with-macros/test-image/1.0.0/Containerfile.ubuntu2204.std
@@ -18,7 +18,8 @@ ARG BUILDARCH
 ARG TARGETARCH=${BUILDARCH}
 
 ### Install Apt Packages ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \
@@ -51,11 +52,11 @@ RUN RUN_UNATTENDED=1 R_VERSION=4.5.1 bash -c "$(curl -fsSL https://rstd.io/r-ins
     find . -type f -name '[rR]-4.5.1.*\.(deb|rpm)' -delete
 
 # Install Quarto
-RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
+RUN --mount=type=secret,id=github_token,required=false bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
     apt-get install -yqq --no-install-recommends \
         quarto=1.8.27 \
         xz-utils && \
     apt-mark hold quarto && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/* && \
-    /opt/quarto/bin/quarto install tinytex --no-prompt --quiet
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet


### PR DESCRIPTION
## Why

CI builds keep failing on `archive.ubuntu.com` and `ports.ubuntu.com` timeouts during `apt-get update`. apt's defaults are one attempt with a 120s timeout and zero retries — any transient hiccup becomes a hard failure.

This adds `Acquire::Retries=3` and `Acquire::http(s)::Timeout=30` via a new `configure_retries` macro. It is called once inside `setup()`, so the config file is written by the first apt RUN of every product Containerfile and persists across subsequent layers. Downstream apt RUNs benefit from the same resilience without re-emitting the echo line, which keeps the rendered Containerfile readable for image consumers who use the published file directly.

Retries and Timeout move together by design. Bumping `Retries` alone with the default 120s timeout turns one long hang into four, so the macro always writes both.

The `99-retries` file persists in the final image. The same resilience helps anyone running `apt` at container runtime, so leaving it in the image is a feature rather than build-time pollution.

## Sibling repos

This only changes the bakery tool itself. Product image repos pick up the new rendering on their next `bakery update files`.