### PR TITLE
Install Quarto before generating API reference

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,6 +27,9 @@ jobs:
         working-directory: posit-bakery
         run: uv sync --group docs
 
+      - name: Set up Quarto
+        uses: quarto-dev/quarto-actions/setup@8a96df13519ee81fd526f2dfca5962811136661b  # v2.2.0
+
       - name: Generate API reference
         working-directory: posit-bakery
         run: |
@@ -34,9 +37,6 @@ jobs:
           rm -rf docs/reference
           cp -r great-docs/reference docs/reference
           rm -rf great-docs
-
-      - name: Set up Quarto
-        uses: quarto-dev/quarto-actions/setup@8a96df13519ee81fd526f2dfca5962811136661b  # v2.2.0
 
       - name: Render and Publish
         uses: quarto-dev/quarto-actions/publish@8a96df13519ee81fd526f2dfca5962811136661b  # v2.2.0


### PR DESCRIPTION
`great-docs build` invokes Quarto during reference generation. After PR #537, the docs publish workflow installed Quarto *after* the generation step, so the first run on `main` failed with "Quarto was not found on your system." Move `Set up Quarto` before `Generate API reference`.

Related:

- https://github.com/posit-dev/images-shared/pull/537
- https://github.com/posit-dev/images-shared/actions/runs/26117859578