### PR TITLE
Parse docstrings with the Sphinx parser

### DIFF
--- a/posit-bakery/great-docs.yml
+++ b/posit-bakery/great-docs.yml
@@ -7,6 +7,7 @@ markdown_pages: false
 source:
   branch: main
 
+parser: sphinx
 inline_methods: true
 
 auto_include:


### PR DESCRIPTION
posit-bakery docstrings use Sphinx/reST field markers (`:param x:`, `:return:`), but great-docs defaults to the numpy parser. The numpy parser fails to recognize the markers, so they render as literal text on the API reference pages instead of a formatted Parameters/Returns table.

Set `parser: sphinx` in `great-docs.yml` so the existing docstrings are parsed and rendered correctly.