### PR TITLE
Override stream dev versions via --image-version

### DIFF
--- a/posit-bakery/posit_bakery/cli/ci.py
+++ b/posit-bakery/posit_bakery/cli/ci.py
@@ -102,7 +102,7 @@ def matrix(
 
     try:
         settings = BakerySettings(
-            filter=BakeryConfigFilter(image_name=image_name),
+            filter=BakeryConfigFilter(image_name=image_name, image_version=image_version),
             dev_versions=dev_versions,
             dev_stream=dev_stream,
         )

--- a/posit-bakery/posit_bakery/config/config.py
+++ b/posit-bakery/posit_bakery/config/config.py
@@ -20,6 +20,7 @@ from ruamel.yaml import YAML
 from posit_bakery import util
 from posit_bakery.config.dependencies import DependencyConstraint, DependencyVersions
 from posit_bakery.config.image import Image
+from posit_bakery.config.image.dev_version import ImageDevelopmentVersionFromProductStream
 from posit_bakery.config.image.matrix import DEFAULT_MATRIX_SUBPATH
 from posit_bakery.config.registry import BaseRegistry
 from posit_bakery.config.repository import Repository
@@ -327,6 +328,58 @@ class BakerySettings(BaseModel):
     cache_registry: Annotated[str | None, Field(description="Registry to use for image build cache.", default=None)]
     temp_registry: Annotated[str | None, Field(description="Registry to use for image build temp cache.", default=None)]
 
+    @model_validator(mode="after")
+    def validate_dev_version_override(self) -> Self:
+        """Validate the inputs that activate dev version override mode.
+
+        Override mode (treating --image-version as authoritative for stream dev versions)
+        requires the full triplet:
+          - --dev-versions=only
+          - --image-version=<full version, YYYY.MM.PATCH at minimum>
+          - --dev-stream=<stream>
+
+        With --dev-versions=only set, the other two are mandatory: --image-version because
+        there is nothing to override otherwise, and --dev-stream because an image may declare
+        dev versions across multiple streams and we don't try to pick one. A prefix-only
+        --image-version is rejected because it can't unambiguously identify an artifact.
+        """
+        if self.dev_versions != DevVersionInclusionEnum.ONLY:
+            return self
+        if self.filter.image_version is None:
+            return self
+        # --dev-versions=only with --image-version set: override mode is engaged.
+        if self.dev_stream is None:
+            raise ValueError(
+                "--image-version with --dev-versions=only also requires --dev-stream. "
+                "Override mode uses the explicit triplet (dev-versions=only, image-version, "
+                "dev-stream) to identify exactly which dev artifact to build."
+            )
+        parsed = ParsedVersion.parse(self.filter.image_version)
+        if parsed is None or len(parsed.release) < 3:
+            raise ValueError(
+                f"--image-version '{self.filter.image_version}' must be a full version "
+                f"(YYYY.MM.PATCH at minimum) when used with --dev-versions=only. "
+                f"A prefix can't unambiguously identify a single artifact."
+            )
+        return self
+
+    @property
+    def dev_version_override(self) -> str | None:
+        """The authoritative dev version when override mode is active, else ``None``.
+
+        Override mode activates when --dev-versions=only, --image-version, and --dev-stream
+        are all set. The value flows into ``ImageDevelopmentVersionFromProductStream.version_override``
+        so the matrix entry's ``name`` is the dispatched version rather than whatever the
+        upstream stream currently reports.
+        """
+        if (
+            self.dev_versions == DevVersionInclusionEnum.ONLY
+            and self.filter.image_version is not None
+            and self.dev_stream is not None
+        ):
+            return self.filter.image_version
+        return None
+
 
 class BakeryConfig:
     """Manager for the bakery.yaml configuration file and operations against the configuration.
@@ -371,6 +424,8 @@ class BakeryConfig:
             )
 
         if self.settings.dev_versions in [DevVersionInclusionEnum.ONLY, DevVersionInclusionEnum.INCLUDE]:
+            if self.settings.dev_version_override is not None:
+                self._apply_dev_version_override()
             for image in self.model.images:
                 image.load_dev_versions()
                 image.render_ephemeral_version_files()
@@ -379,6 +434,25 @@ class BakeryConfig:
 
         self.targets = []
         self.generate_image_targets(self.settings)
+
+    def _apply_dev_version_override(self) -> None:
+        """Propagate ``settings.dev_version_override`` to stream-based dev versions.
+
+        Scoped by ``settings.filter.image_name`` and ``settings.dev_stream``. The
+        validator on ``BakerySettings`` guarantees ``dev_stream`` is set whenever
+        ``dev_version_override`` is set, so there's no ambiguity to guard against
+        here — each image has at most one stream-based dev version matching the
+        selected stream.
+        """
+        override = self.settings.dev_version_override
+        dev_stream = self.settings.dev_stream
+        image_name_filter = self.settings.filter.image_name
+        for image in self.model.images:
+            if image_name_filter is not None and re.search(image_name_filter, image.name) is None:
+                continue
+            for dv in image.devVersions:
+                if isinstance(dv, ImageDevelopmentVersionFromProductStream) and dv.stream == dev_stream:
+                    dv.version_override = override
 
     @classmethod
     def from_context(cls, context: str | Path | os.PathLike, settings: BakerySettings | None = None) -> "BakeryConfig":

--- a/posit-bakery/posit_bakery/config/image/dev_version/stream.py
+++ b/posit-bakery/posit_bakery/config/image/dev_version/stream.py
@@ -28,6 +28,17 @@ class ImageDevelopmentVersionFromProductStream(BaseImageDevelopmentVersion):
             "get_version().",
         ),
     ]
+    version_override: Annotated[
+        str | None,
+        Field(
+            exclude=True,
+            default=None,
+            description="Authoritative version supplied by the caller (e.g. a CI dispatch). When set, skips the "
+            "upstream version fetch and uses this value as ImageVersion.name. URL resolution is unchanged: the "
+            "build runner's CDN fetch resolves URLs against whatever the upstream has at build time, which by "
+            "then has propagated past the dispatch.",
+        ),
+    ]
 
     def get_primary_os(self) -> ImageVersionOS:
         """Retrieve the primary OS from the parent image if available.
@@ -43,11 +54,15 @@ class ImageDevelopmentVersionFromProductStream(BaseImageDevelopmentVersion):
     def get_version(self) -> str:
         """Retrieve the version from the specified product stream.
 
-        If _resolve_os_urls() has already been called, returns the cached
-        version. Otherwise fetches it from the primary OS stream.
+        If ``version_override`` is set, returns it directly without contacting
+        the upstream stream. Otherwise, if ``_resolve_os_urls()`` has already
+        been called, returns the cached version; else fetches it from the
+        primary OS stream.
 
         :return: The version string from the product stream.
         """
+        if self.version_override is not None:
+            return self.version_override
         if self.resolved_version is not None:
             return self.resolved_version
         _os = self.get_primary_os()
@@ -74,7 +89,9 @@ class ImageDevelopmentVersionFromProductStream(BaseImageDevelopmentVersion):
         is not yet available in the product stream.
 
         Caches the version from the first successfully resolved OS so
-        that get_version() can return it without a redundant fetch.
+        that get_version() can return it without a redundant fetch. The
+        cache is only consulted when ``version_override`` is unset — an
+        override always wins in ``get_version()``.
         """
         self.resolved_version = None
         resolved = []

--- a/posit-bakery/posit_bakery/config/image/dev_version/stream.py
+++ b/posit-bakery/posit_bakery/config/image/dev_version/stream.py
@@ -33,10 +33,11 @@ class ImageDevelopmentVersionFromProductStream(BaseImageDevelopmentVersion):
         Field(
             exclude=True,
             default=None,
-            description="Authoritative version supplied by the caller (e.g. a CI dispatch). When set, skips the "
-            "upstream version fetch and uses this value as ImageVersion.name. URL resolution is unchanged: the "
-            "build runner's CDN fetch resolves URLs against whatever the upstream has at build time, which by "
-            "then has propagated past the dispatch.",
+            description="Authoritative version supplied by the caller (e.g. a CI dispatch). When set, "
+            "``get_version()`` returns this value directly (no upstream fetch), and during URL resolution "
+            "the upstream version embedded in ``download_url`` is rewritten to point at the override's "
+            "artifact. If that artifact has not propagated to the CDN, the build fails loudly at curl time "
+            "rather than silently downloading the stale upstream artifact.",
         ),
     ]
 
@@ -76,7 +77,9 @@ class ImageDevelopmentVersionFromProductStream(BaseImageDevelopmentVersion):
         """
         url_by_os = {}
         for _os in self.os:
-            result = get_product_artifact_by_stream(self.product, self.stream, _os.buildOS)
+            result = get_product_artifact_by_stream(
+                self.product, self.stream, _os.buildOS, version_override=self.version_override
+            )
             if generalize_architecture:
                 url_by_os[_os.name] = str(result.architecture_generalized_download_url)
             else:
@@ -98,7 +101,9 @@ class ImageDevelopmentVersionFromProductStream(BaseImageDevelopmentVersion):
         for os_version in self.os:
             try:
                 generalize = os_version.platforms != DEFAULT_PLATFORMS
-                result = get_product_artifact_by_stream(self.product, self.stream, os_version.buildOS)
+                result = get_product_artifact_by_stream(
+                    self.product, self.stream, os_version.buildOS, version_override=self.version_override
+                )
                 if generalize:
                     os_version.artifactDownloadURL = str(result.architecture_generalized_download_url)
                 else:

--- a/posit-bakery/posit_bakery/config/image/posit_product/main.py
+++ b/posit-bakery/posit_bakery/config/image/posit_product/main.py
@@ -41,8 +41,15 @@ class ReleaseStreamPath:
         self.stream_url = stream_url
         self.resolver_map = resolver_map
 
-    def get(self, metadata: dict) -> ReleaseStreamResult:
-        """Fetches data from the stream URL and resolves the data using the given resolvers."""
+    def get(self, metadata: dict, version_override: str | None = None) -> ReleaseStreamResult:
+        """Fetches data from the stream URL and resolves the data using the given resolvers.
+
+        When ``version_override`` is set, resolvers still run unchanged (we need the upstream
+        version to know what to rewrite). After resolution, ``result["version"]`` is replaced
+        with the override and any occurrence of the upstream version in ``download_url`` is
+        rewritten to the override form. See :func:`_apply_version_override` for the encodings
+        we handle.
+        """
         session = cached_session()
         response = session.get(self.stream_url)
         response.raise_for_status()
@@ -61,7 +68,37 @@ class ReleaseStreamPath:
                 resolver.set_metadata(metadata)
                 result[key] = resolver.resolve(data)
 
+        if version_override is not None:
+            _apply_version_override(result, version_override)
+
         return ReleaseStreamResult(**result)
+
+
+def _apply_version_override(result: dict, version_override: str) -> None:
+    """Rewrite ``result`` in place to reflect a caller-supplied version override.
+
+    Replaces ``result["version"]`` with the override and rewrites every occurrence of
+    the upstream version in ``download_url`` so the URL points at the override's artifact.
+    The rewrite covers the three encodings products embed the version in URLs:
+
+      - **raw** (e.g. ``2026.05.0-dev+148-gSHA``) — rare in URLs but possible
+      - **URL-encoded** (e.g. ``2026.05.0-dev%2B148-gSHA``) — Connect, PPM
+      - **tag-safe** with ``+`` replaced by ``-`` (e.g. ``2026.05.0-dev-148-gSHA``) — Workbench
+
+    Resolvers themselves remain declarative and untouched; this is a pure post-resolution
+    rewrite. If the upstream version doesn't appear in the URL in any of these forms,
+    the URL is left as-is and the build will download the upstream artifact — at which
+    point the caller can detect the mismatch via the resulting image's contents.
+    """
+    upstream_version = result.get("version", "")
+    result["version"] = version_override
+    if not upstream_version or not isinstance(result.get("download_url"), str):
+        return
+    url = result["download_url"]
+    url = url.replace(upstream_version, version_override)
+    url = url.replace(quote(upstream_version, safe=""), quote(version_override, safe=""))
+    url = url.replace(upstream_version.replace("+", "-"), version_override.replace("+", "-"))
+    result["download_url"] = url
 
 
 # This map connects products to their respective release streams. Each release stream has a ReleaseStreamPath object
@@ -257,9 +294,18 @@ def _make_resolver_metadata(_os: BuildOS, product: ProductEnum):
 
 
 def get_product_artifact_by_stream(
-    product: ProductEnum, stream: ReleaseStreamEnum, os: BuildOS, generalize_arch: bool = True
+    product: ProductEnum,
+    stream: ReleaseStreamEnum,
+    os: BuildOS,
+    generalize_arch: bool = True,
+    version_override: str | None = None,
 ) -> ReleaseStreamResult:
-    """Fetches the version and download URL for a given product, release stream, and OS."""
+    """Fetches the version and download URL for a given product, release stream, and OS.
+
+    When ``version_override`` is set, the returned ``version`` is the override and the
+    ``download_url`` is rewritten so it points at the override's artifact (across all
+    three URL encoding styles products use).
+    """
     if product not in product_release_stream_url_map:
         raise ValueError(f"Product {product} is not supported.")
     if stream not in product_release_stream_url_map[product]:
@@ -267,4 +313,4 @@ def get_product_artifact_by_stream(
 
     metadata = _make_resolver_metadata(os, product)
 
-    return product_release_stream_url_map[product][stream].get(metadata)
+    return product_release_stream_url_map[product][stream].get(metadata, version_override=version_override)

--- a/posit-bakery/test/config/image/dev_version/test_stream.py
+++ b/posit-bakery/test/config/image/dev_version/test_stream.py
@@ -952,7 +952,7 @@ class TestResolveOsUrls:
     def test_excludes_os_on_resolution_failure(self):
         good = ReleaseStreamResult(version="1.0.0", download_url="https://example.com/good.deb")
 
-        def side_effect(product, stream, build_os):
+        def side_effect(product, stream, build_os, **kwargs):
             if build_os.version == "26.04":
                 raise ValueError("no packages for ubuntu26")
             return good
@@ -1021,7 +1021,7 @@ class TestResolveOsUrls:
     def test_primary_os_excluded_falls_back_to_secondary(self):
         good = ReleaseStreamResult(version="1.0.0", download_url="https://example.com/good.deb")
 
-        def side_effect(product, stream, build_os):
+        def side_effect(product, stream, build_os, **kwargs):
             if build_os.version == "26.04":
                 raise ValueError("no packages for ubuntu26")
             return good
@@ -1047,3 +1047,76 @@ class TestResolveOsUrls:
             assert iv.name == "1.0.0"
             assert len(iv.os) == 1
             assert iv.os[0].name == "Ubuntu 24.04"
+
+
+class TestVersionOverride:
+    """Override mode forces the dev version's name to the caller-supplied value.
+
+    URL resolution is unchanged: at matrix-gen time the matrix only carries
+    ``image``/``version``/``platform``, and at build time the runner's CDN
+    fetch picks up whatever the upstream has — which by build time has
+    propagated past the dispatch.
+    """
+
+    OVERRIDE = "2026.05.0-dev+224-g92e78b4eda"
+    STALE_CDN_VERSION = "2026.05.0-dev+153-g571063894f"
+
+    def test_field_defaults_to_none(self):
+        dev = ImageDevelopmentVersionFromProductStream(
+            sourceType="stream",
+            product="connect",
+            stream="daily",
+            os=[{"name": "Ubuntu 24.04", "primary": True}],
+        )
+        assert dev.version_override is None
+
+    def test_get_version_returns_override_without_fetch(self):
+        """``get_version()`` short-circuits the CDN fetch when an override is set."""
+        with patch("posit_bakery.config.image.dev_version.stream.get_product_artifact_by_stream") as mock_get:
+            dev = ImageDevelopmentVersionFromProductStream(
+                sourceType="stream",
+                product="connect",
+                stream="daily",
+                os=[{"name": "Ubuntu 24.04", "primary": True}],
+                version_override=self.OVERRIDE,
+            )
+            assert dev.get_version() == self.OVERRIDE
+            mock_get.assert_not_called()
+
+    def test_get_version_uses_cdn_when_override_unset(self):
+        with patch("posit_bakery.config.image.dev_version.stream.get_product_artifact_by_stream") as mock_get:
+            mock_get.return_value = ReleaseStreamResult(
+                version=self.STALE_CDN_VERSION, download_url="https://example.com/stale.deb"
+            )
+            dev = ImageDevelopmentVersionFromProductStream(
+                sourceType="stream",
+                product="connect",
+                stream="daily",
+                os=[{"name": "Ubuntu 24.04", "primary": True}],
+            )
+            assert dev.get_version() == self.STALE_CDN_VERSION
+
+    def test_as_image_version_name_is_override_even_with_stale_cdn(self):
+        """``ImageVersion.name`` reflects the override even when CDN returns a different version.
+
+        The URL fields still come from CDN — that's intentional. At build time the
+        CDN will have propagated and the runner will resolve a URL for the override.
+        """
+        mock_parent = MagicMock(spec=Image)
+        mock_parent.path = Path("/tmp/images")
+        mock_parent.resolve_dependency_versions.return_value = []
+        with patch("posit_bakery.config.image.dev_version.stream.get_product_artifact_by_stream") as mock_get:
+            mock_get.return_value = ReleaseStreamResult(
+                version=self.STALE_CDN_VERSION, download_url="https://example.com/stale.deb"
+            )
+            dev = ImageDevelopmentVersionFromProductStream(
+                parent=mock_parent,
+                sourceType="stream",
+                product="package-manager",
+                stream="daily",
+                os=[{"name": "Ubuntu 24.04", "primary": True}],
+                version_override=self.OVERRIDE,
+            )
+            iv = dev.as_image_version()
+            assert iv.name == self.OVERRIDE
+            assert iv.isDevelopmentVersion is True

--- a/posit-bakery/test/config/image/posit_products/test_main.py
+++ b/posit-bakery/test/config/image/posit_products/test_main.py
@@ -773,3 +773,95 @@ class TestGetProductArtifactByStream:
         output = get_product_artifact_by_stream(ProductEnum.WORKBENCH_SESSION, ReleaseStreamEnum.DAILY, _os)
         assert output.version == expected_version
         assert str(output.download_url) == expected_session_url
+
+
+class TestVersionOverrideRewrite:
+    """version_override flows through to every product's download_url after resolution.
+
+    Each product embeds the version in URLs in a slightly different way; the post-resolution
+    rewrite handles raw, URL-encoded, and tag-safe (``+`` → ``-``) forms so the same code
+    works uniformly across templated and payload-sourced URLs.
+    """
+
+    def test_ppm_daily_url_rewritten_to_override(self, patch_requests_get):
+        """PPM daily URLs embed the version URL-encoded (``+`` → ``%2B``)."""
+        override = "2026.05.0-dev+999-gffffffffff"
+        output = get_product_artifact_by_stream(
+            ProductEnum.PACKAGE_MANAGER,
+            ReleaseStreamEnum.DAILY,
+            SUPPORTED_OS["ubuntu"]["24"],
+            version_override=override,
+        )
+        assert output.version == override
+        assert "2026.05.0-dev%2B999-gffffffffff" in str(output.download_url)
+        # The upstream version (from the fixture) should no longer appear in the URL.
+        assert "2026.02.0-dev%2B89-ga1b2c3d4e5" not in str(output.download_url)
+
+    def test_ppm_preview_url_rewritten_to_override(self, patch_requests_get):
+        """PPM preview URLs are templated the same way as daily."""
+        override = "2026.05.0-dev+999-gffffffffff"
+        output = get_product_artifact_by_stream(
+            ProductEnum.PACKAGE_MANAGER,
+            ReleaseStreamEnum.PREVIEW,
+            SUPPORTED_OS["ubuntu"]["24"],
+            version_override=override,
+        )
+        assert output.version == override
+        assert "2026.05.0-dev%2B999-gffffffffff" in str(output.download_url)
+
+    def test_connect_daily_url_rewritten_to_override(self, patch_requests_get):
+        """Connect daily URLs come verbatim from the JSON payload with URL-encoded versions."""
+        override = "2026.05.0-dev+999-gffffffffff"
+        output = get_product_artifact_by_stream(
+            ProductEnum.CONNECT,
+            ReleaseStreamEnum.DAILY,
+            SUPPORTED_OS["ubuntu"]["24"],
+            version_override=override,
+        )
+        assert output.version == override
+        assert "2026.05.0-dev%2B999-gffffffffff" in str(output.download_url)
+        # The upstream version embedded in the fixture URL should no longer appear.
+        assert "2026.04.0-dev%2B10-gbe0a4a3d31" not in str(output.download_url)
+
+    def test_workbench_daily_url_rewritten_to_override(self, patch_requests_get):
+        """Workbench daily URLs embed the version in tag-safe form (``+`` → ``-``)."""
+        override = "2026.05.0-daily+999.pro7"
+        output = get_product_artifact_by_stream(
+            ProductEnum.WORKBENCH,
+            ReleaseStreamEnum.DAILY,
+            SUPPORTED_OS["ubuntu"]["24"],
+            version_override=override,
+        )
+        assert output.version == override
+        # Tag-safe form: + → -
+        assert "2026.05.0-daily-999.pro7" in str(output.download_url)
+        # The upstream version (from the fixture) should no longer appear in tag-safe form.
+        assert "2025.04.0-daily-404.pro4" not in str(output.download_url)
+
+    def test_workbench_session_daily_url_rewritten_to_override(self, patch_requests_get):
+        """Workbench-session daily URLs follow the same tag-safe pattern as Workbench."""
+        override = "2026.05.0-daily+999.pro7"
+        output = get_product_artifact_by_stream(
+            ProductEnum.WORKBENCH_SESSION,
+            ReleaseStreamEnum.DAILY,
+            SUPPORTED_OS["ubuntu"]["24"],
+            version_override=override,
+        )
+        assert output.version == override
+        assert "2026.05.0-daily-999.pro7" in str(output.download_url)
+
+    def test_no_override_leaves_url_unchanged(self, patch_requests_get):
+        """Without an override, both the version and URL come from the upstream payload verbatim."""
+        without = get_product_artifact_by_stream(
+            ProductEnum.PACKAGE_MANAGER,
+            ReleaseStreamEnum.DAILY,
+            SUPPORTED_OS["ubuntu"]["24"],
+        )
+        explicit_none = get_product_artifact_by_stream(
+            ProductEnum.PACKAGE_MANAGER,
+            ReleaseStreamEnum.DAILY,
+            SUPPORTED_OS["ubuntu"]["24"],
+            version_override=None,
+        )
+        assert without.version == explicit_none.version
+        assert str(without.download_url) == str(explicit_none.download_url)

--- a/posit-bakery/test/config/test_config.py
+++ b/posit-bakery/test/config/test_config.py
@@ -12,6 +12,7 @@ from pydantic import ValidationError
 import posit_bakery
 from posit_bakery.config.config import BakeryConfigDocument, BakeryConfig, BakeryConfigFilter, BakerySettings
 from posit_bakery.config.dependencies import PythonDependencyConstraint, RDependencyVersions
+from posit_bakery.config.image.dev_version import ImageDevelopmentVersionFromProductStream
 from posit_bakery.config.image.posit_product.const import ReleaseStreamEnum
 from posit_bakery.const import DevVersionInclusionEnum, MatrixVersionInclusionEnum
 from posit_bakery.image.image_metadata import BuildMetadata
@@ -389,23 +390,83 @@ class TestBakeryConfig:
         assert "Image 'package-manager' matches --image-name filter but is being skipped" in caplog.text
         assert "non-matrix image excluded by --matrix-versions only" in caplog.text
 
+    def test_dev_version_override_requires_dev_stream(self):
+        """Override mode requires --dev-stream alongside --dev-versions=only and --image-version."""
+        with pytest.raises(ValidationError, match="also requires --dev-stream"):
+            BakerySettings(
+                filter=BakeryConfigFilter(image_version="2026.05.0-dev+148-g1e590bacf9"),
+                dev_versions=DevVersionInclusionEnum.ONLY,
+            )
+
     @pytest.mark.usefixtures("patch_requests_get")
-    def test_filter_warning_version_excluded_by_dev_versions_only(self, caplog, testdata_path):
-        """Test that a warning is logged when --image-version matches but --dev-versions only excludes it."""
+    def test_dev_version_override_applied_with_triplet(self, testdata_path):
+        """With the full triplet (dev-versions=only, image-version, dev-stream), override applies cleanly.
+
+        The matching stream's dev version on the targeted image gets ``version_override``
+        set; other streams' dev versions are left alone.
+        """
         yaml_file = testdata_path / "valid" / "complex.yaml"
+        override = "2026.05.0-dev+999-gffffffffff"
         with patch.object(posit_bakery.config.image.Image, "render_ephemeral_version_files"):
             config = BakeryConfig(
                 yaml_file,
                 BakerySettings(
-                    filter=BakeryConfigFilter(image_name="^package-manager$", image_version="2025.04.2-8"),
+                    filter=BakeryConfigFilter(image_name="^package-manager$", image_version=override),
                     dev_versions=DevVersionInclusionEnum.ONLY,
+                    dev_stream=ReleaseStreamEnum.DAILY,
                 ),
             )
-        assert config is not None
-        assert len(config.targets) == 0
-        assert "WARNING" in caplog.text
-        assert "Version '2025.04.2-8' in image 'package-manager' matches --image-version filter" in caplog.text
-        assert "not a development version" in caplog.text
+        pm = next(i for i in config.model.images if i.name == "package-manager")
+        daily_dvs = [
+            dv
+            for dv in pm.devVersions
+            if isinstance(dv, ImageDevelopmentVersionFromProductStream) and dv.stream == ReleaseStreamEnum.DAILY
+        ]
+        preview_dvs = [
+            dv
+            for dv in pm.devVersions
+            if isinstance(dv, ImageDevelopmentVersionFromProductStream) and dv.stream == ReleaseStreamEnum.PREVIEW
+        ]
+        assert all(dv.version_override == override for dv in daily_dvs)
+        assert all(dv.version_override is None for dv in preview_dvs)
+        # The loaded dev version reflects the override as its name.
+        assert any(v.name == override and v.isDevelopmentVersion for v in pm.versions)
+
+    def test_dev_version_override_rejects_prefix(self):
+        """Prefix-only --image-version cannot be used as an override; reject at settings validation."""
+        with pytest.raises(ValidationError, match="must be a full version"):
+            BakerySettings(
+                filter=BakeryConfigFilter(image_version="2026.05"),
+                dev_versions=DevVersionInclusionEnum.ONLY,
+                dev_stream=ReleaseStreamEnum.DAILY,
+            )
+
+    def test_dev_version_override_unset_when_dev_versions_not_only(self):
+        """Override only activates with --dev-versions=only; other modes don't derive an override."""
+        for mode in (DevVersionInclusionEnum.EXCLUDE, DevVersionInclusionEnum.INCLUDE):
+            settings = BakerySettings(
+                filter=BakeryConfigFilter(image_version="2026.05.0-dev+148-g1e590bacf9"),
+                dev_versions=mode,
+                dev_stream=ReleaseStreamEnum.DAILY,
+            )
+            assert settings.dev_version_override is None
+
+    def test_dev_version_override_unset_when_image_version_missing(self):
+        """Override requires --image-version; --dev-versions=only alone leaves it unset."""
+        settings = BakerySettings(
+            dev_versions=DevVersionInclusionEnum.ONLY,
+            dev_stream=ReleaseStreamEnum.DAILY,
+        )
+        assert settings.dev_version_override is None
+
+    def test_dev_version_override_returns_full_version(self):
+        """The property returns the image_version when the triplet is complete."""
+        settings = BakerySettings(
+            filter=BakeryConfigFilter(image_version="2026.05.0-dev+148-g1e590bacf9"),
+            dev_versions=DevVersionInclusionEnum.ONLY,
+            dev_stream=ReleaseStreamEnum.DAILY,
+        )
+        assert settings.dev_version_override == "2026.05.0-dev+148-g1e590bacf9"
 
     @pytest.mark.usefixtures("patch_requests_get")
     def test_filter_warning_image_matches_but_no_targets(self, caplog, testdata_path):


### PR DESCRIPTION
## Why

bakery's stream resolver discovers the "current" dev version from the CDN at matrix-gen time. The upstream CI's CDN upload is asynchronous, so during the propagation window the resolver can return the previous build while a dispatch fires for a newer one — the matrix entry's name disagrees with what was dispatched, and (worse) the build can download the older artifact while tagging the image with the dispatched version.

## Behavior

With `--dev-versions=only` + `--image-version=<full>` + `--dev-stream=<stream>`, treat `--image-version` as authoritative for stream dev versions: skip the upstream version lookup, use it as `ImageVersion.name`, and rewrite occurrences of the upstream version in `download_url` so the URL points at the override's artifact. If the dispatched artifact hasn't propagated yet, `curl -fsSL "$DOWNLOAD_URL"` 404s loudly at build time instead of silently downloading stale contents under the override's tag.

All three encodings products use to embed the version in URLs are handled (raw, URL-encoded `%2B`, tag-safe `+`→`-`), so PPM, Connect, Workbench, and Workbench-Session all behave the same. Resolvers in `product_release_stream_url_map` stay declarative — the rewrite is post-resolution.

The triplet is mandatory and validated at settings construction; prefix `--image-version` values are rejected. Every current upstream dispatcher (Connect `update-dev-images`, PPM `update-images`, the open rstudio-pro dev-image-dispatch PR) already passes all three.

- https://github.com/posit-dev/images-shared/issues/527