### PR TITLE
Forward GITHUB_TOKEN to dgoss as GH_TOKEN in GitHub Actions

### DIFF
--- a/.github/workflows/bakery-build-native.yml
+++ b/.github/workflows/bakery-build-native.yml
@@ -254,6 +254,7 @@ jobs:
           MATRIX_VERSIONS: ${{ inputs.matrix-versions }}
           NORMALIZED_PLATFORM: ${{ steps.normalize-platform.outputs.platform }}
           CONTEXT: ${{ inputs.context }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           GOSS_PATH=${GITHUB_WORKSPACE}/tools/goss \
           DGOSS_PATH=${GITHUB_WORKSPACE}/tools/dgoss \

--- a/.github/workflows/bakery-build-pr.yml
+++ b/.github/workflows/bakery-build-pr.yml
@@ -217,6 +217,7 @@ jobs:
           DEV_VERSIONS: ${{ inputs.dev-versions }}
           MATRIX_VERSIONS: ${{ inputs.matrix-versions }}
           BAKERY_CONTEXT: ${{ inputs.context }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           GOSS_PATH=${GITHUB_WORKSPACE}/tools/goss \
           DGOSS_PATH=${GITHUB_WORKSPACE}/tools/dgoss \

--- a/.github/workflows/bakery-build.yml
+++ b/.github/workflows/bakery-build.yml
@@ -220,6 +220,7 @@ jobs:
           DEV_VERSIONS: ${{ inputs.dev-versions }}
           MATRIX_VERSIONS: ${{ inputs.matrix-versions }}
           CONTEXT: ${{ inputs.context }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           GOSS_PATH=${GITHUB_WORKSPACE}/tools/goss \
           DGOSS_PATH=${GITHUB_WORKSPACE}/tools/dgoss \

--- a/posit-bakery/posit_bakery/plugins/builtin/dgoss/command.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/dgoss/command.py
@@ -1,3 +1,4 @@
+import os
 import re
 from pathlib import Path
 from typing import Annotated, Self, Literal
@@ -91,6 +92,18 @@ class DGossCommand(BaseModel):
             for arg, value in self.image_target.build_args.items():
                 env_var = f"BUILD_ARG_{arg.upper()}"
                 e[env_var] = value
+
+        # Forward the runner's GITHUB_TOKEN as GH_TOKEN so `quarto list tools`
+        # (and similar) can authenticate api.github.com calls and avoid the
+        # 60/hr anonymous rate limit that intermittently fails dgoss runs.
+        # Gate on GITHUB_ACTIONS=true so we only forward in environments where
+        # GitHub's automatic log masking redacts the value — a local run that
+        # happens to have GITHUB_TOKEN set (e.g. a developer's gh CLI session)
+        # would echo the raw token into the `-e GH_TOKEN=…` command logging.
+        if os.environ.get("GITHUB_ACTIONS") == "true":
+            github_token = os.environ.get("GITHUB_TOKEN")
+            if github_token:
+                e["GH_TOKEN"] = github_token
 
         return e
 

--- a/posit-bakery/test/plugins/builtin/dgoss/conftest.py
+++ b/posit-bakery/test/plugins/builtin/dgoss/conftest.py
@@ -3,6 +3,15 @@ import pytest
 from posit_bakery.image import ImageTarget
 
 
+@pytest.fixture(autouse=True)
+def _clear_github_env(monkeypatch):
+    """Drop the runner's GITHUB_ACTIONS and GITHUB_TOKEN so the dgoss command's
+    GH_TOKEN forwarding does not leak into tests that assert exact env/cmd
+    contents. Tests that exercise the forwarding behaviour set them explicitly."""
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+
 @pytest.fixture
 def basic_standard_image_target(get_config_obj):
     """Return a standard ImageTarget object for testing."""

--- a/posit-bakery/test/plugins/builtin/dgoss/test_command.py
+++ b/posit-bakery/test/plugins/builtin/dgoss/test_command.py
@@ -55,6 +55,27 @@ class TestDGossCommand:
         }
         assert dgoss_command.image_environment == expected_env
 
+    def test_image_environment_forwards_github_token_in_actions(self, basic_standard_image_target, monkeypatch):
+        """Inside a GitHub Actions run GITHUB_TOKEN is forwarded as GH_TOKEN."""
+        monkeypatch.setenv("GITHUB_ACTIONS", "true")
+        monkeypatch.setenv("GITHUB_TOKEN", "ghs_test_value")
+        dgoss_command = DGossCommand.from_image_target(image_target=basic_standard_image_target)
+        assert dgoss_command.image_environment["GH_TOKEN"] == "ghs_test_value"
+
+    def test_image_environment_skips_github_token_outside_actions(self, basic_standard_image_target, monkeypatch):
+        """Local runs with GITHUB_TOKEN set (e.g. from gh CLI) do not forward it,
+        so the raw token never appears in the dgoss command line outside the
+        GitHub Actions log-masking environment."""
+        monkeypatch.setenv("GITHUB_TOKEN", "ghs_developer_pat")
+        dgoss_command = DGossCommand.from_image_target(image_target=basic_standard_image_target)
+        assert "GH_TOKEN" not in dgoss_command.image_environment
+
+    def test_image_environment_omits_gh_token_when_token_unset(self, basic_standard_image_target, monkeypatch):
+        """In GitHub Actions but with no token (rare, but possible) GH_TOKEN is omitted."""
+        monkeypatch.setenv("GITHUB_ACTIONS", "true")
+        dgoss_command = DGossCommand.from_image_target(image_target=basic_standard_image_target)
+        assert "GH_TOKEN" not in dgoss_command.image_environment
+
     def test_volume_mounts(self, basic_standard_image_target):
         """Test that DGossCommand volume_mounts returns the expected volume mounts."""
         dgoss_command = DGossCommand.from_image_target(image_target=basic_standard_image_target)


### PR DESCRIPTION
`quarto list tools` (and other quarto-managed tool checks) calls `api.github.com/repos/.../releases/latest` for every installable tool to populate the status column. Inside the dgoss container these calls run unauthenticated and share the 60/hr anonymous limit with every other container on the same runner IP, so concurrent matrix builds intermittently hit 429 and the test exits non-zero — surfacing as flaky `Verify Quarto has TinyTeX installed` / `Ensure TinyTeX is installed` failures across product repos.

When `GITHUB_ACTIONS=true` and `GITHUB_TOKEN` is set on the host, `DGossCommand.image_environment` forwards the token as `GH_TOKEN` (the name quarto's `getLatestRelease()` reads) via the existing `-e` flag plumbing. The shared `bakery-build`, `bakery-build-native`, and `bakery-build-pr` workflows expose `secrets.GITHUB_TOKEN` to the Test step so the runner token reaches bakery.

The `GITHUB_ACTIONS=true` gate keeps the raw token off the dgoss command line in any environment that does not auto-mask secrets in logs. A local developer run with a personal `gh` CLI token set, for example, will not forward it — only GitHub Actions runs do, where the secret is automatically redacted from log output.

Authenticated requests get 5000/hr per token — large enough that the matrix can no longer exhaust it.

Tests cover all three branches (set-in-actions, set-outside-actions, unset-in-actions) and use an autouse fixture in the dgoss conftest to keep existing exact-cmd assertions stable regardless of the host env.