### PR TITLE
Forward GITHUB_TOKEN to bakery Build/Push steps

### DIFF
--- a/.github/workflows/bakery-build-native.yml
+++ b/.github/workflows/bakery-build-native.yml
@@ -226,6 +226,7 @@ jobs:
           NORMALIZED_PLATFORM: ${{ steps.normalize-platform.outputs.platform }}
           CONTEXT: ${{ inputs.context }}
           CACHE: ${{ inputs.cache }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # Cache-to is conditional on --push (handled by bakery internally)
         run: |
           CACHE_FLAGS=()

--- a/.github/workflows/bakery-build-pr.yml
+++ b/.github/workflows/bakery-build-pr.yml
@@ -193,6 +193,7 @@ jobs:
           BAKERY_CONTEXT: ${{ inputs.context }}
           REGISTRY_OWNER: ${{ github.repository_owner }}
           CACHE: ${{ inputs.cache }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           CACHE_FLAGS=()
           if [ "$IS_FORK" != "true" ] && [ "$CACHE" = "true" ]; then

--- a/.github/workflows/bakery-build.yml
+++ b/.github/workflows/bakery-build.yml
@@ -199,6 +199,7 @@ jobs:
           REGISTRY: ghcr.io/${{ github.repository_owner }}
           CONTEXT: ${{ inputs.context }}
           CACHE: ${{ inputs.cache }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           CACHE_FLAGS=()
           if [ "$CACHE" = "true" ]; then
@@ -244,6 +245,7 @@ jobs:
           DEV_VERSIONS: ${{ inputs.dev-versions }}
           MATRIX_VERSIONS: ${{ inputs.matrix-versions }}
           CONTEXT: ${{ inputs.context }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           bakery build --push --pull \
             --retry "$RETRY" \


### PR DESCRIPTION
PR #543 forwarded `GITHUB_TOKEN` into the dgoss Test step so that
`quarto check` / `quarto list tools` could authenticate against
api.github.com. The same 60/hr anonymous rate limit also breaks the
Build step's `quarto install tinytex` RUN inside the `connect` and
`connect-content` Containerfiles.

Bakery's `resolved_build_secrets` reads `os.environ["GITHUB_TOKEN"]`
and skips the `github_token` build secret when unset, leaving the
RUN's `GH_TOKEN` empty and `quarto install tinytex` exposed to the
anonymous limit during concurrent matrix builds.

Add `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to the Build step env
(all three workflows) and the Push step env (`bakery-build.yml`) so
bakery can forward the secret into the build via the existing
`--mount=type=secret,id=github_token` plumbing.

Follow-up to:

- https://github.com/posit-dev/images-shared/pull/543

Surfaced by:

- https://github.com/posit-dev/images-connect/pull/101