### PR TITLE
Remove --quiet from quarto tinytex install macro

### DIFF
--- a/posit-bakery/posit_bakery/config/templating/macros/quarto.j2
+++ b/posit-bakery/posit_bakery/config/templating/macros/quarto.j2
@@ -51,10 +51,9 @@ backward compatibility but is ignored.
 :param quarto_binary: The path to the Quarto binary.
 :param update_path: Adds --update-path to the command to add TinyTeX binaries to the PATH. Defaults to False.
 :param home_path: An optional path to set the HOME environment variable for the command, which controls where TinyTeX is installed. If not provided, TinyTeX will be installed to the default location under the current user's home directory.
-:param quiet: Whether to suppress TinyTeX install output. Defaults to True.
 #}
-{% macro install_tinytex_command(quarto_binary, update_path = False, home_path = None, quiet = True) -%}
-GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" {% if home_path %}HOME="{{ home_path }}" {% endif %}{{ quarto_binary }} install tinytex --no-prompt{% if quiet %} --quiet{% endif %}{% if update_path %} --update-path{% endif %}
+{% macro install_tinytex_command(quarto_binary, update_path = False, home_path = None) -%}
+GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" {% if home_path %}HOME="{{ home_path }}" {% endif %}{{ quarto_binary }} install tinytex --no-prompt{% if update_path %} --update-path{% endif %}
 {%- endmacro %}
 
 {# Command to install a specific version of Quarto from the Posit Open

--- a/posit-bakery/test/config/templating/test_macros.py
+++ b/posit-bakery/test/config/templating/test_macros.py
@@ -1940,25 +1940,25 @@ class TestQuartoMacros:
             pytest.param(
                 True,
                 None,
-                'GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path',
+                'GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --update-path',
                 id="with-update-path",
             ),
             pytest.param(
                 False,
                 None,
-                'GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet',
+                'GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt',
                 id="without-update-path",
             ),
             pytest.param(
                 False,
                 "/root",
-                'GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet',
+                'GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt',
                 id="with-home-path",
             ),
             pytest.param(
                 True,
                 "/root",
-                'GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --quiet --update-path',
+                'GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --update-path',
                 id="with-home-path-and-update-path",
             ),
         ],
@@ -2018,7 +2018,7 @@ class TestQuartoMacros:
                     apt-mark hold quarto && \\
                     apt-get clean -yqq && \\
                     rm -rf /var/lib/apt/lists/* && \\
-                    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet"""
+                    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/bin/quarto install tinytex --no-prompt"""
                 ),
                 id="with-tinytex",
             ),
@@ -2035,7 +2035,7 @@ class TestQuartoMacros:
                     apt-mark hold quarto && \\
                     apt-get clean -yqq && \\
                     rm -rf /var/lib/apt/lists/* && \\
-                    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path"""
+                    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path"""
                 ),
                 id="with-tinytex-update-path",
             ),
@@ -2052,7 +2052,7 @@ class TestQuartoMacros:
                     apt-mark hold quarto && \\
                     apt-get clean -yqq && \\
                     rm -rf /var/lib/apt/lists/* && \\
-                    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet"""
+                    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/bin/quarto install tinytex --no-prompt"""
                 ),
                 id="with-tinytex-home-path",
             ),
@@ -2069,7 +2069,7 @@ class TestQuartoMacros:
                     apt-mark hold quarto && \\
                     apt-get clean -yqq && \\
                     rm -rf /var/lib/apt/lists/* && \\
-                    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path"""
+                    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path"""
                 ),
                 id="with-tinytex-home-path-update-path",
             ),
@@ -2122,7 +2122,7 @@ class TestQuartoMacros:
                 xz && \\
             dnf versionlock add quarto && \\
             dnf clean all -yq && \\
-            GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet"""
+            GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/bin/quarto install tinytex --no-prompt"""
         )
         rendered = environment_with_macros.from_string(template).render()
         assert rendered == expected
@@ -2163,7 +2163,7 @@ class TestQuartoMacros:
                         apt-mark hold quarto && \\
                         apt-get clean -yqq && \\
                         rm -rf /var/lib/apt/lists/* && \\
-                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet"""
+                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/bin/quarto install tinytex --no-prompt"""
                 ),
                 id="single-version-with-tinytex",
             ),
@@ -2178,7 +2178,7 @@ class TestQuartoMacros:
                         apt-mark hold quarto && \\
                         apt-get clean -yqq && \\
                         rm -rf /var/lib/apt/lists/* && \\
-                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path"""
+                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path"""
                 ),
                 id="single-version-with-tinytex-update-path",
             ),
@@ -2193,7 +2193,7 @@ class TestQuartoMacros:
                         apt-mark hold quarto && \\
                         apt-get clean -yqq && \\
                         rm -rf /var/lib/apt/lists/* && \\
-                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet"""
+                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/bin/quarto install tinytex --no-prompt"""
                 ),
                 id="single-version-with-tinytex-home-path",
             ),
@@ -2208,7 +2208,7 @@ class TestQuartoMacros:
                         apt-mark hold quarto && \\
                         apt-get clean -yqq && \\
                         rm -rf /var/lib/apt/lists/* && \\
-                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path"""
+                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path"""
                 ),
                 id="single-version-with-tinytex-home-path-update-path",
             ),

--- a/posit-bakery/test/config/test_config.py
+++ b/posit-bakery/test/config/test_config.py
@@ -1086,7 +1086,7 @@ class TestBakeryConfig:
                 apt-mark hold quarto && \\
                 apt-get clean -yqq && \\
                 rm -rf /var/lib/apt/lists/* && \\
-                GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet
+                GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/bin/quarto install tinytex --no-prompt
         """)
         assert (
             expected_std_containerfile

--- a/posit-bakery/test/resources/matrix/test-matrix/matrix/Containerfile.ubuntu2404
+++ b/posit-bakery/test/resources/matrix/test-matrix/matrix/Containerfile.ubuntu2404
@@ -57,4 +57,4 @@ RUN --mount=type=secret,id=github_token,required=false bash -c "$(curl -1fsSL 'h
     apt-mark hold quarto && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/* && \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/bin/quarto install tinytex --no-prompt

--- a/posit-bakery/test/resources/with-macros/test-image/1.0.0/Containerfile.ubuntu2204.std
+++ b/posit-bakery/test/resources/with-macros/test-image/1.0.0/Containerfile.ubuntu2204.std
@@ -59,4 +59,4 @@ RUN --mount=type=secret,id=github_token,required=false bash -c "$(curl -1fsSL 'h
     apt-mark hold quarto && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/* && \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/bin/quarto install tinytex --no-prompt


### PR DESCRIPTION
The `--quiet` flag suppresses `quarto install tinytex` output,
including the actual error message when the install fails. Recent
CI flakes caused by GitHub API rate limits during the install were
nearly impossible to diagnose because of this — the build log
showed only `exit code: 1` with no detail.

No caller passes `quiet=` explicitly, so drop the parameter from
the `install_tinytex_command` signature and the `--quiet` flag from
the rendered command. Update the test expectations to match.

Pairs with:

- https://github.com/posit-dev/images-shared/pull/545

Companion PRs in product repos that drop `--quiet` from
already-rendered Containerfiles:

- https://github.com/posit-dev/images-connect/pull/102
- https://github.com/posit-dev/images-workbench/pull/108
- https://github.com/posit-dev/images-examples/pull/34