### PR TITLE
Cache dependency version fetches per invocation

### DIFF
--- a/.github/workflows/bakery-build-native.yml
+++ b/.github/workflows/bakery-build-native.yml
@@ -139,6 +139,7 @@ jobs:
         uses: "posit-dev/images-shared/setup-bakery@main"
         with:
           version: ${{ inputs.version }}
+          cache-scope: ${{ toJSON(inputs) }}
 
       - name: Resolve dev-spec
         id: resolve-dev-spec
@@ -208,6 +209,7 @@ jobs:
         uses: "posit-dev/images-shared/setup-bakery@main"
         with:
           version: ${{ inputs.version }}
+          cache-scope: ${{ toJSON(inputs) }}
 
       - name: Setup goss
         uses: "posit-dev/images-shared/setup-goss@main"
@@ -383,6 +385,7 @@ jobs:
         uses: "posit-dev/images-shared/setup-bakery@main"
         with:
           version: ${{ inputs.version }}
+          cache-scope: ${{ toJSON(inputs) }}
 
       - name: Set up Docker
         uses: docker/setup-docker-action@0234bb73ccb40f0c430b795634f9247e2b5c2d23  # v5.2.0
@@ -511,6 +514,7 @@ jobs:
         uses: "posit-dev/images-shared/setup-bakery@main"
         with:
           version: ${{ inputs.version }}
+          cache-scope: ${{ toJSON(inputs) }}
 
       - name: Push READMEs to Docker Hub
         env:

--- a/.github/workflows/bakery-build-native.yml
+++ b/.github/workflows/bakery-build-native.yml
@@ -198,6 +198,7 @@ jobs:
           name: ${{ steps.setup-bakery.outputs.cache-artifact-name }}
           path: /tmp/bakery_cache
           if-no-files-found: ignore
+          retention-days: 1
 
   build-test:
     name: "Build/Test ${{ matrix.img.image }}:${{ matrix.img.version }} (${{ matrix.img.platform }})"
@@ -520,6 +521,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
+      # Restores the shared cache like every other job but never saves it:
+      # bakery ci readme has no --image-name filter and always resolves
+      # every image in bakery.yaml, so its results aren't a subset of what
+      # matrix already covered. It's also last in the job DAG, so nothing
+      # would ever restore a save from here anyway.
       - name: Setup bakery
         uses: "posit-dev/images-shared/setup-bakery@main"
         with:

--- a/.github/workflows/bakery-build-native.yml
+++ b/.github/workflows/bakery-build-native.yml
@@ -136,6 +136,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Install
+        id: setup-bakery
         uses: "posit-dev/images-shared/setup-bakery@main"
         with:
           version: ${{ inputs.version }}
@@ -189,6 +190,15 @@ jobs:
           echo "platform_matrix=$(echo "$result" | jq --compact-output .)" >> "$GITHUB_OUTPUT"
           echo "image_matrix=$(echo "$result" | jq --compact-output '[.[].image] | unique')" >> "$GITHUB_OUTPUT"
 
+      - name: Save dependency version cache
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: "${{ steps.setup-bakery.outputs.cache-artifact-name }}-matrix"
+          path: /tmp/bakery_cache
+          if-no-files-found: ignore
+
   build-test:
     name: "Build/Test ${{ matrix.img.image }}:${{ matrix.img.version }} (${{ matrix.img.platform }})"
     permissions:
@@ -206,6 +216,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Setup bakery
+        id: setup-bakery
         uses: "posit-dev/images-shared/setup-bakery@main"
         with:
           version: ${{ inputs.version }}
@@ -365,6 +376,15 @@ jobs:
           path: "./${{ matrix.img.image }}-${{ matrix.img.version }}-${{ steps.normalize-platform.outputs.platform }}-metadata.json"
           overwrite: 'true'
 
+      - name: Save dependency version cache
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: "${{ steps.setup-bakery.outputs.cache-artifact-name }}-build-test-${{ strategy.job-index }}"
+          path: /tmp/bakery_cache
+          if-no-files-found: ignore
+
   merge:
     name: "Merge/Push ${{ matrix.image }}"
     permissions:
@@ -382,6 +402,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Setup bakery
+        id: setup-bakery
         uses: "posit-dev/images-shared/setup-bakery@main"
         with:
           version: ${{ inputs.version }}
@@ -497,6 +518,15 @@ jobs:
             $PUSH_FLAG \
             ./*-metadata.json
 
+      - name: Save dependency version cache
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: "${{ steps.setup-bakery.outputs.cache-artifact-name }}-merge-${{ strategy.job-index }}"
+          path: /tmp/bakery_cache
+          if-no-files-found: ignore
+
   readme:
     name: Push READMEs
     permissions:
@@ -511,6 +541,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Setup bakery
+        id: setup-bakery
         uses: "posit-dev/images-shared/setup-bakery@main"
         with:
           version: ${{ inputs.version }}
@@ -528,3 +559,12 @@ jobs:
             --context "$CONTEXT" \
             --dev-versions "$DEV_VERSIONS" \
             --matrix-versions "$MATRIX_VERSIONS"
+
+      - name: Save dependency version cache
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: "${{ steps.setup-bakery.outputs.cache-artifact-name }}-readme"
+          path: /tmp/bakery_cache
+          if-no-files-found: ignore

--- a/.github/workflows/bakery-build-native.yml
+++ b/.github/workflows/bakery-build-native.yml
@@ -141,6 +141,7 @@ jobs:
         with:
           version: ${{ inputs.version }}
           cache-scope: ${{ toJSON(inputs) }}
+          is-writer: "true"
 
       - name: Resolve dev-spec
         id: resolve-dev-spec

--- a/.github/workflows/bakery-build-native.yml
+++ b/.github/workflows/bakery-build-native.yml
@@ -195,7 +195,7 @@ jobs:
         continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: "${{ steps.setup-bakery.outputs.cache-artifact-name }}-matrix"
+          name: ${{ steps.setup-bakery.outputs.cache-artifact-name }}
           path: /tmp/bakery_cache
           if-no-files-found: ignore
 
@@ -216,7 +216,6 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Setup bakery
-        id: setup-bakery
         uses: "posit-dev/images-shared/setup-bakery@main"
         with:
           version: ${{ inputs.version }}
@@ -376,15 +375,6 @@ jobs:
           path: "./${{ matrix.img.image }}-${{ matrix.img.version }}-${{ steps.normalize-platform.outputs.platform }}-metadata.json"
           overwrite: 'true'
 
-      - name: Save dependency version cache
-        if: always()
-        continue-on-error: true
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: "${{ steps.setup-bakery.outputs.cache-artifact-name }}-build-test-${{ strategy.job-index }}"
-          path: /tmp/bakery_cache
-          if-no-files-found: ignore
-
   merge:
     name: "Merge/Push ${{ matrix.image }}"
     permissions:
@@ -402,7 +392,6 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Setup bakery
-        id: setup-bakery
         uses: "posit-dev/images-shared/setup-bakery@main"
         with:
           version: ${{ inputs.version }}
@@ -518,15 +507,6 @@ jobs:
             $PUSH_FLAG \
             ./*-metadata.json
 
-      - name: Save dependency version cache
-        if: always()
-        continue-on-error: true
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: "${{ steps.setup-bakery.outputs.cache-artifact-name }}-merge-${{ strategy.job-index }}"
-          path: /tmp/bakery_cache
-          if-no-files-found: ignore
-
   readme:
     name: Push READMEs
     permissions:
@@ -541,7 +521,6 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Setup bakery
-        id: setup-bakery
         uses: "posit-dev/images-shared/setup-bakery@main"
         with:
           version: ${{ inputs.version }}
@@ -559,12 +538,3 @@ jobs:
             --context "$CONTEXT" \
             --dev-versions "$DEV_VERSIONS" \
             --matrix-versions "$MATRIX_VERSIONS"
-
-      - name: Save dependency version cache
-        if: always()
-        continue-on-error: true
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: "${{ steps.setup-bakery.outputs.cache-artifact-name }}-readme"
-          path: /tmp/bakery_cache
-          if-no-files-found: ignore

--- a/.github/workflows/bakery-build-pr.yml
+++ b/.github/workflows/bakery-build-pr.yml
@@ -97,6 +97,7 @@ jobs:
         uses: "posit-dev/images-shared/setup-bakery@main"
         with:
           version: ${{ inputs.version }}
+          cache-scope: ${{ toJSON(inputs) }}
 
       - name: Images by Version/Platform
         id: images-by-platform
@@ -191,6 +192,7 @@ jobs:
         uses: "posit-dev/images-shared/setup-bakery@main"
         with:
           version: ${{ inputs.version }}
+          cache-scope: ${{ toJSON(inputs) }}
 
       - name: Setup goss
         uses: "posit-dev/images-shared/setup-goss@main"

--- a/.github/workflows/bakery-build-pr.yml
+++ b/.github/workflows/bakery-build-pr.yml
@@ -147,6 +147,7 @@ jobs:
           name: ${{ steps.setup-bakery.outputs.cache-artifact-name }}
           path: /tmp/bakery_cache
           if-no-files-found: ignore
+          retention-days: 1
 
   readme-check:
     name: README Length Check

--- a/.github/workflows/bakery-build-pr.yml
+++ b/.github/workflows/bakery-build-pr.yml
@@ -99,6 +99,7 @@ jobs:
         with:
           version: ${{ inputs.version }}
           cache-scope: ${{ toJSON(inputs) }}
+          is-writer: "true"
 
       - name: Images by Version/Platform
         id: images-by-platform

--- a/.github/workflows/bakery-build-pr.yml
+++ b/.github/workflows/bakery-build-pr.yml
@@ -144,7 +144,7 @@ jobs:
         continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: "${{ steps.setup-bakery.outputs.cache-artifact-name }}-matrix"
+          name: ${{ steps.setup-bakery.outputs.cache-artifact-name }}
           path: /tmp/bakery_cache
           if-no-files-found: ignore
 
@@ -199,7 +199,6 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Setup bakery
-        id: setup-bakery
         uses: "posit-dev/images-shared/setup-bakery@main"
         with:
           version: ${{ inputs.version }}
@@ -299,15 +298,6 @@ jobs:
             --dev-versions "$DEV_VERSIONS" \
             --matrix-versions "$MATRIX_VERSIONS" \
             --context "$BAKERY_CONTEXT"
-
-      - name: Save dependency version cache
-        if: always()
-        continue-on-error: true
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: "${{ steps.setup-bakery.outputs.cache-artifact-name }}-build-test-${{ strategy.job-index }}"
-          path: /tmp/bakery_cache
-          if-no-files-found: ignore
 
   build-test-result:
     name: Build/Test result

--- a/.github/workflows/bakery-build-pr.yml
+++ b/.github/workflows/bakery-build-pr.yml
@@ -94,6 +94,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install
+        id: setup-bakery
         uses: "posit-dev/images-shared/setup-bakery@main"
         with:
           version: ${{ inputs.version }}
@@ -137,6 +138,15 @@ jobs:
           fi
           result=$(bakery ci matrix --quiet --dev-versions "$DEV_VERSIONS" --matrix-versions "$MATRIX_VERSIONS" "${BASE_FLAG[@]}" --exclude platform --context "$BAKERY_CONTEXT")
           echo "versions_matrix=$(echo "$result" | jq --compact-output .)" >> "$GITHUB_OUTPUT"
+
+      - name: Save dependency version cache
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: "${{ steps.setup-bakery.outputs.cache-artifact-name }}-matrix"
+          path: /tmp/bakery_cache
+          if-no-files-found: ignore
 
   readme-check:
     name: README Length Check
@@ -189,6 +199,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Setup bakery
+        id: setup-bakery
         uses: "posit-dev/images-shared/setup-bakery@main"
         with:
           version: ${{ inputs.version }}
@@ -288,6 +299,15 @@ jobs:
             --dev-versions "$DEV_VERSIONS" \
             --matrix-versions "$MATRIX_VERSIONS" \
             --context "$BAKERY_CONTEXT"
+
+      - name: Save dependency version cache
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: "${{ steps.setup-bakery.outputs.cache-artifact-name }}-build-test-${{ strategy.job-index }}"
+          path: /tmp/bakery_cache
+          if-no-files-found: ignore
 
   build-test-result:
     name: Build/Test result

--- a/.github/workflows/bakery-build.yml
+++ b/.github/workflows/bakery-build.yml
@@ -182,6 +182,7 @@ jobs:
           name: ${{ steps.setup-bakery.outputs.cache-artifact-name }}
           path: /tmp/bakery_cache
           if-no-files-found: ignore
+          retention-days: 1
 
   build:
     name: "${{ matrix.img.image }}:${{ matrix.img.version }}"
@@ -361,6 +362,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
+      # Restores the shared cache like every other job but never saves it:
+      # bakery ci readme has no --image-name filter and always resolves
+      # every image in bakery.yaml, so its results aren't a subset of what
+      # matrix already covered. It's also last in the job DAG, so nothing
+      # would ever restore a save from here anyway.
       - name: Setup bakery
         uses: "posit-dev/images-shared/setup-bakery@main"
         with:

--- a/.github/workflows/bakery-build.yml
+++ b/.github/workflows/bakery-build.yml
@@ -127,9 +127,11 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Install
+        id: setup-bakery
         uses: "posit-dev/images-shared/setup-bakery@main"
         with:
           version: ${{ inputs.version }}
+          cache-scope: ${{ toJSON(inputs) }}
 
       - name: Resolve dev-spec
         id: resolve-dev-spec
@@ -172,6 +174,15 @@ jobs:
           result=$(bakery ci matrix "${ARGS[@]}")
           echo "matrix=$(echo "$result" | jq --compact-output .)" >> "$GITHUB_OUTPUT"
 
+      - name: Save dependency version cache
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: ${{ steps.setup-bakery.outputs.cache-artifact-name }}
+          path: /tmp/bakery_cache
+          if-no-files-found: ignore
+
   build:
     name: "${{ matrix.img.image }}:${{ matrix.img.version }}"
     permissions:
@@ -192,6 +203,7 @@ jobs:
         uses: "posit-dev/images-shared/setup-bakery@main"
         with:
           version: ${{ inputs.version }}
+          cache-scope: ${{ toJSON(inputs) }}
 
       - name: Setup goss
         uses: "posit-dev/images-shared/setup-goss@main"
@@ -353,6 +365,7 @@ jobs:
         uses: "posit-dev/images-shared/setup-bakery@main"
         with:
           version: ${{ inputs.version }}
+          cache-scope: ${{ toJSON(inputs) }}
 
       - name: Push READMEs to Docker Hub
         env:

--- a/.github/workflows/bakery-build.yml
+++ b/.github/workflows/bakery-build.yml
@@ -132,6 +132,7 @@ jobs:
         with:
           version: ${{ inputs.version }}
           cache-scope: ${{ toJSON(inputs) }}
+          is-writer: "true"
 
       - name: Resolve dev-spec
         id: resolve-dev-spec

--- a/posit-bakery/posit_bakery/config/dependencies/positron.py
+++ b/posit-bakery/posit_bakery/config/dependencies/positron.py
@@ -81,9 +81,12 @@ class PositronDependency(BakeryYAMLModel, abc.ABC):
     def available_versions(self) -> list[DependencyVersion]:
         """Return a list of available Positron versions.
 
+        Returns a shallow copy since ``_fetch_versions`` is memoized; callers
+        must not mutate the cached list shared across all instances.
+
         :return: A sorted list of available Positron versions.
         """
-        return self._fetch_versions(self.prerelease)
+        return list(self._fetch_versions(self.prerelease))
 
 
 class PositronDependencyVersions(DependencyVersions, PositronDependency):

--- a/posit-bakery/posit_bakery/config/dependencies/positron.py
+++ b/posit-bakery/posit_bakery/config/dependencies/positron.py
@@ -1,4 +1,5 @@
 import abc
+import copy
 from functools import cache
 from typing import Annotated, Literal, ClassVar
 
@@ -81,12 +82,13 @@ class PositronDependency(BakeryYAMLModel, abc.ABC):
     def available_versions(self) -> list[DependencyVersion]:
         """Return a list of available Positron versions.
 
-        Returns a shallow copy since ``_fetch_versions`` is memoized; callers
-        must not mutate the cached list shared across all instances.
+        Returns a deep copy since ``_fetch_versions`` is memoized; callers
+        can freely mutate the returned list or its elements without
+        corrupting the shared cache.
 
         :return: A sorted list of available Positron versions.
         """
-        return list(self._fetch_versions(self.prerelease))
+        return copy.deepcopy(self._fetch_versions(self.prerelease))
 
 
 class PositronDependencyVersions(DependencyVersions, PositronDependency):

--- a/posit-bakery/posit_bakery/config/dependencies/positron.py
+++ b/posit-bakery/posit_bakery/config/dependencies/positron.py
@@ -1,4 +1,5 @@
 import abc
+from functools import cache
 from typing import Annotated, Literal, ClassVar
 
 from pydantic import ConfigDict, Field
@@ -49,25 +50,28 @@ class PositronDependency(BakeryYAMLModel, abc.ABC):
         arch = _ARCH_MAP[target_arch]
         return POSITRON_DAILY_URL_TEMPLATE.format(arch=arch)
 
-    def _fetch_versions(self) -> list[DependencyVersion]:
+    @staticmethod
+    @cache
+    def _fetch_versions(prerelease: bool = False) -> list[DependencyVersion]:
         """Fetch available Positron versions from Posit CDN.
 
         Uses the default architecture for version discovery since the version
         list is identical across architectures.
 
-        This method uses caching to avoid repeated network requests.
+        Memoized so the fetch+parse runs once per bakery invocation per
+        ``prerelease`` value (at most two entries).
 
         :return: A sorted list of available Positron versions.
         """
         session = cached_session()
-        response = session.get(self.releases_url())
+        response = session.get(PositronDependency.releases_url())
         response.raise_for_status()
 
         releases = response.json().get("releases", [])
         versions = [DependencyVersion(r["version"]) for r in releases]
 
-        if self.prerelease:
-            response = session.get(self.daily_url())
+        if prerelease:
+            response = session.get(PositronDependency.daily_url())
             response.raise_for_status()
             data = response.json()
             versions.append(DependencyVersion(data["version"]))
@@ -79,7 +83,7 @@ class PositronDependency(BakeryYAMLModel, abc.ABC):
 
         :return: A sorted list of available Positron versions.
         """
-        return self._fetch_versions()
+        return self._fetch_versions(self.prerelease)
 
 
 class PositronDependencyVersions(DependencyVersions, PositronDependency):

--- a/posit-bakery/posit_bakery/config/dependencies/python.py
+++ b/posit-bakery/posit_bakery/config/dependencies/python.py
@@ -51,9 +51,12 @@ class PythonDependency(BakeryYAMLModel, abc.ABC):
     def available_versions(self) -> list[DependencyVersion]:
         """Return a list of available Python versions.
 
+        Returns a shallow copy since ``_fetch_versions`` is memoized; callers
+        must not mutate the cached list shared across all instances.
+
         :return: A sorted list of available Python versions.
         """
-        return self._fetch_versions()
+        return list(self._fetch_versions())
 
 
 class PythonDependencyVersions(DependencyVersions, PythonDependency):

--- a/posit-bakery/posit_bakery/config/dependencies/python.py
+++ b/posit-bakery/posit_bakery/config/dependencies/python.py
@@ -1,4 +1,5 @@
 import abc
+import copy
 from functools import cache
 from typing import Literal, ClassVar
 
@@ -51,12 +52,13 @@ class PythonDependency(BakeryYAMLModel, abc.ABC):
     def available_versions(self) -> list[DependencyVersion]:
         """Return a list of available Python versions.
 
-        Returns a shallow copy since ``_fetch_versions`` is memoized; callers
-        must not mutate the cached list shared across all instances.
+        Returns a deep copy since ``_fetch_versions`` is memoized; callers
+        can freely mutate the returned list or its elements without
+        corrupting the shared cache.
 
         :return: A sorted list of available Python versions.
         """
-        return list(self._fetch_versions())
+        return copy.deepcopy(self._fetch_versions())
 
 
 class PythonDependencyVersions(DependencyVersions, PythonDependency):

--- a/posit-bakery/posit_bakery/config/dependencies/python.py
+++ b/posit-bakery/posit_bakery/config/dependencies/python.py
@@ -1,4 +1,5 @@
 import abc
+from functools import cache
 from typing import Literal, ClassVar
 
 from pydantic import ConfigDict
@@ -17,10 +18,13 @@ class PythonDependency(BakeryYAMLModel, abc.ABC):
 
     dependency: Literal[SupportedDependencies.PYTHON] = SupportedDependencies.PYTHON
 
-    def _fetch_versions(self) -> list[DependencyVersion]:
+    @staticmethod
+    @cache
+    def _fetch_versions() -> list[DependencyVersion]:
         """Fetch available Python versions from astral-sh/python-build-standalone.
 
-        This method uses caching to avoid repeated network requests.
+        Memoized so the fetch+parse runs once per bakery invocation regardless
+        of how many constraint instances ask for it.
 
         The results only include cpython builds for linux.
         Prerelease versions are excluded.

--- a/posit-bakery/posit_bakery/config/dependencies/quarto.py
+++ b/posit-bakery/posit_bakery/config/dependencies/quarto.py
@@ -66,9 +66,12 @@ class QuartoDependency(BakeryYAMLModel, abc.ABC):
         """Return a list of available Quarto version.
         Only the latest patch version for each minor version is included.
 
+        Returns a shallow copy since ``_fetch_versions`` is memoized; callers
+        must not mutate the cached list shared across all instances.
+
         :return: A sorted list of available Quarto versions.
         """
-        return self._fetch_versions(self.prerelease)
+        return list(self._fetch_versions(self.prerelease))
 
 
 class QuartoDependencyVersions(DependencyVersions, QuartoDependency):

--- a/posit-bakery/posit_bakery/config/dependencies/quarto.py
+++ b/posit-bakery/posit_bakery/config/dependencies/quarto.py
@@ -1,4 +1,5 @@
 import abc
+import copy
 from functools import cache
 from typing import Annotated, Literal, ClassVar
 
@@ -66,12 +67,13 @@ class QuartoDependency(BakeryYAMLModel, abc.ABC):
         """Return a list of available Quarto version.
         Only the latest patch version for each minor version is included.
 
-        Returns a shallow copy since ``_fetch_versions`` is memoized; callers
-        must not mutate the cached list shared across all instances.
+        Returns a deep copy since ``_fetch_versions`` is memoized; callers
+        can freely mutate the returned list or its elements without
+        corrupting the shared cache.
 
         :return: A sorted list of available Quarto versions.
         """
-        return list(self._fetch_versions(self.prerelease))
+        return copy.deepcopy(self._fetch_versions(self.prerelease))
 
 
 class QuartoDependencyVersions(DependencyVersions, QuartoDependency):

--- a/posit-bakery/posit_bakery/config/dependencies/quarto.py
+++ b/posit-bakery/posit_bakery/config/dependencies/quarto.py
@@ -1,4 +1,5 @@
 import abc
+from functools import cache
 from typing import Annotated, Literal, ClassVar
 
 from pydantic import ConfigDict, Field, field_validator
@@ -28,11 +29,14 @@ class QuartoDependency(BakeryYAMLModel, abc.ABC):
         ),
     ]
 
-    def _fetch_versions(self) -> list[DependencyVersion]:
+    @staticmethod
+    @cache
+    def _fetch_versions(prerelease: bool = False) -> list[DependencyVersion]:
         """Fetch available Quarto versions.
         Only the latest patch version for each minor version is included.
 
-        This method uses caching to avoid repeated network requests.
+        Memoized so the fetch+parse runs once per bakery invocation per
+        ``prerelease`` value (at most two entries).
 
         :return: A sorted list of available Quarto versions.
         """
@@ -44,7 +48,7 @@ class QuartoDependency(BakeryYAMLModel, abc.ABC):
         response.raise_for_status()
         versions.append(DependencyVersion(response.json().get("version")))
 
-        if self.prerelease:
+        if prerelease:
             # Fetch prerelease version
             response = session.get(QUARTO_PRERELEASE_URL)
             response.raise_for_status()
@@ -64,7 +68,7 @@ class QuartoDependency(BakeryYAMLModel, abc.ABC):
 
         :return: A sorted list of available Quarto versions.
         """
-        return self._fetch_versions()
+        return self._fetch_versions(self.prerelease)
 
 
 class QuartoDependencyVersions(DependencyVersions, QuartoDependency):

--- a/posit-bakery/posit_bakery/config/dependencies/r.py
+++ b/posit-bakery/posit_bakery/config/dependencies/r.py
@@ -1,4 +1,5 @@
 import abc
+from functools import cache
 from typing import Literal, ClassVar
 
 from pydantic import ConfigDict
@@ -17,10 +18,13 @@ class RDependency(BakeryYAMLModel, abc.ABC):
 
     dependency: Literal[SupportedDependencies.R] = SupportedDependencies.R
 
-    def _fetch_versions(self) -> list[DependencyVersion]:
+    @staticmethod
+    @cache
+    def _fetch_versions() -> list[DependencyVersion]:
         """Fetch available R versions from Posit.
 
-        This method uses caching to avoid repeated network requests.
+        Memoized so the fetch+parse runs once per bakery invocation regardless
+        of how many constraint instances ask for it.
 
         The results exclude "devel" and "next" versions.
 

--- a/posit-bakery/posit_bakery/config/dependencies/r.py
+++ b/posit-bakery/posit_bakery/config/dependencies/r.py
@@ -1,4 +1,5 @@
 import abc
+import copy
 from functools import cache
 from typing import Literal, ClassVar
 
@@ -42,12 +43,13 @@ class RDependency(BakeryYAMLModel, abc.ABC):
     def available_versions(self) -> list[DependencyVersion]:
         """Return a list of available R versions.
 
-        Returns a shallow copy since ``_fetch_versions`` is memoized; callers
-        must not mutate the cached list shared across all instances.
+        Returns a deep copy since ``_fetch_versions`` is memoized; callers
+        can freely mutate the returned list or its elements without
+        corrupting the shared cache.
 
         :return: A sorted list of available R versions.
         """
-        return list(self._fetch_versions())
+        return copy.deepcopy(self._fetch_versions())
 
 
 class RDependencyVersions(DependencyVersions, RDependency):

--- a/posit-bakery/posit_bakery/config/dependencies/r.py
+++ b/posit-bakery/posit_bakery/config/dependencies/r.py
@@ -42,9 +42,12 @@ class RDependency(BakeryYAMLModel, abc.ABC):
     def available_versions(self) -> list[DependencyVersion]:
         """Return a list of available R versions.
 
+        Returns a shallow copy since ``_fetch_versions`` is memoized; callers
+        must not mutate the cached list shared across all instances.
+
         :return: A sorted list of available R versions.
         """
-        return self._fetch_versions()
+        return list(self._fetch_versions())
 
 
 class RDependencyVersions(DependencyVersions, RDependency):

--- a/posit-bakery/posit_bakery/util.py
+++ b/posit-bakery/posit_bakery/util.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from functools import cache
 from pathlib import Path
 from shutil import which
 from typing import Union
@@ -63,17 +64,19 @@ def auto_path() -> Path:
     return context
 
 
-def cached_session(**kwargs) -> CachedSession:
-    """Create a cached requests session with default settings."""
-    session_kwargs = {
-        "cache_name": "bakery_cache",
-        "expire_after": 3600,
-        "backend": "filesystem",
-        "use_temp": True,
-        "allowable_methods": ["GET"],
-        "allowable_codes": [200],
-        "stale_if_error": True,
-    }
-    session_kwargs.update(kwargs)
+@cache
+def cached_session() -> CachedSession:
+    """Return a process-wide cached requests session.
 
-    return CachedSession(**session_kwargs)
+    Memoized so backend initialization and the accompanying log chatter only
+    happen once per bakery invocation.
+    """
+    return CachedSession(
+        cache_name="bakery_cache",
+        expire_after=3600,
+        backend="filesystem",
+        use_temp=True,
+        allowable_methods=["GET"],
+        allowable_codes=[200],
+        stale_if_error=True,
+    )

--- a/posit-bakery/posit_bakery/util.py
+++ b/posit-bakery/posit_bakery/util.py
@@ -70,10 +70,23 @@ def cached_session() -> CachedSession:
 
     Memoized so backend initialization and the accompanying log chatter only
     happen once per bakery invocation.
+
+    ``expire_after`` defaults to one hour, long enough to dedupe requests
+    within a single invocation but short enough for local iteration to pick
+    up new upstream releases. CI restores the underlying cache directory
+    across all jobs in a workflow run (see ``setup-bakery``) so that a
+    version resolved in an early job stays consistent through later jobs;
+    ``BAKERY_CACHE_EXPIRE_AFTER`` lets that restored cache outlive the
+    default TTL for the life of the run instead of going stale mid-workflow.
     """
+    try:
+        expire_after = int(os.environ.get("BAKERY_CACHE_EXPIRE_AFTER", 3600))
+    except ValueError:
+        expire_after = 3600
+
     return CachedSession(
         cache_name="bakery_cache",
-        expire_after=3600,
+        expire_after=expire_after,
         backend="filesystem",
         use_temp=True,
         allowable_methods=["GET"],

--- a/posit-bakery/test/config/conftest.py
+++ b/posit-bakery/test/config/conftest.py
@@ -96,11 +96,13 @@ def patch_testdata_response(url: str):
     return mock_response
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="function", autouse=True)
 def disable_requests_caching(mocker):
     # The session factory and fetch helpers are decorated with @functools.cache,
     # so values returned by an earlier test would otherwise survive into the
     # next one. Clear the per-process caches so each test's patches take effect.
+    # Autouse so a test that forgets to request patch_requests_get still gets
+    # isolated caches instead of silently inheriting a prior test's state.
     from posit_bakery.config.dependencies.positron import PositronDependency
     from posit_bakery.config.dependencies.python import PythonDependency
     from posit_bakery.config.dependencies.quarto import QuartoDependency

--- a/posit-bakery/test/config/conftest.py
+++ b/posit-bakery/test/config/conftest.py
@@ -98,6 +98,21 @@ def patch_testdata_response(url: str):
 
 @pytest.fixture(scope="function")
 def disable_requests_caching(mocker):
+    # The session factory and fetch helpers are decorated with @functools.cache,
+    # so values returned by an earlier test would otherwise survive into the
+    # next one. Clear the per-process caches so each test's patches take effect.
+    from posit_bakery.config.dependencies.positron import PositronDependency
+    from posit_bakery.config.dependencies.python import PythonDependency
+    from posit_bakery.config.dependencies.quarto import QuartoDependency
+    from posit_bakery.config.dependencies.r import RDependency
+    from posit_bakery.util import cached_session
+
+    cached_session.cache_clear()
+    PythonDependency._fetch_versions.cache_clear()
+    RDependency._fetch_versions.cache_clear()
+    QuartoDependency._fetch_versions.cache_clear()
+    PositronDependency._fetch_versions.cache_clear()
+
     return mocker.patch("posit_bakery.util.CachedSession", spec=requests.Session)
 
 

--- a/posit-bakery/test/config/image/test_image.py
+++ b/posit-bakery/test/config/image/test_image.py
@@ -600,7 +600,7 @@ class TestImage:
         with pytest.raises(ValueError, match="Version '1.0.0' already exists in image 'test-image'."):
             i.patch_version("1.0.0", "1.0.0")
 
-    def test_create_matrix(self):
+    def test_create_matrix(self, patch_requests_get):
         """Test that create_version creates a new version and adds it to the image."""
         i = Image(name="my-image")
         matrix = i.create_matrix(
@@ -648,7 +648,7 @@ class TestImage:
                 ]
             )
 
-    def test_create_matrix_existing_matrix_update_existing(self):
+    def test_create_matrix_existing_matrix_update_existing(self, patch_requests_get):
         """Test that create_matrix updates a matrix the update_if_exists option."""
         i = Image(
             name="my-image",

--- a/posit-bakery/test/config/test_config.py
+++ b/posit-bakery/test/config/test_config.py
@@ -1950,7 +1950,7 @@ class TestBakeryConfig:
         assert not (version.path / "Containerfile.ubuntu2204.min").exists()
         assert not (version.path / "test").exists()
 
-    def test_target_generation_matrix(self, get_tmpcontext):
+    def test_target_generation_matrix(self, get_tmpcontext, patch_requests_get):
         config = BakeryConfig(
             get_tmpcontext("matrix") / "bakery.yaml",
             settings=BakerySettings(matrix_versions=MatrixVersionInclusionEnum.INCLUDE),

--- a/posit-bakery/test/test_util.py
+++ b/posit-bakery/test/test_util.py
@@ -64,3 +64,30 @@ def test_try_get_repo_url_no_remote(mocker):
     mock_repo = MagicMock(remotes=[])
     mocker.patch("posit_bakery.util.git.Repo", return_value=mock_repo)
     assert util.try_get_repo_url("/tmp") == "<REPLACE ME>"
+
+
+def test_cached_session_default_expire_after(mocker):
+    """Test that cached_session defaults to a one hour expiration"""
+    util.cached_session.cache_clear()
+    mocker.patch.dict("posit_bakery.util.os.environ", {}, clear=True)
+    mock_cached_session_cls = mocker.patch("posit_bakery.util.CachedSession")
+    util.cached_session()
+    assert mock_cached_session_cls.call_args.kwargs["expire_after"] == 3600
+
+
+def test_cached_session_respects_expire_after_env_var(mocker):
+    """Test that BAKERY_CACHE_EXPIRE_AFTER overrides the default expiration"""
+    util.cached_session.cache_clear()
+    mocker.patch.dict("posit_bakery.util.os.environ", {"BAKERY_CACHE_EXPIRE_AFTER": "86400"})
+    mock_cached_session_cls = mocker.patch("posit_bakery.util.CachedSession")
+    util.cached_session()
+    assert mock_cached_session_cls.call_args.kwargs["expire_after"] == 86400
+
+
+def test_cached_session_ignores_invalid_expire_after_env_var(mocker):
+    """Test that a non-integer BAKERY_CACHE_EXPIRE_AFTER falls back to the default"""
+    util.cached_session.cache_clear()
+    mocker.patch.dict("posit_bakery.util.os.environ", {"BAKERY_CACHE_EXPIRE_AFTER": "not-a-number"})
+    mock_cached_session_cls = mocker.patch("posit_bakery.util.CachedSession")
+    util.cached_session()
+    assert mock_cached_session_cls.call_args.kwargs["expire_after"] == 3600

--- a/setup-bakery/action.yml
+++ b/setup-bakery/action.yml
@@ -14,10 +14,22 @@ inputs:
     description: >-
       Opaque string distinguishing concurrent invocations of a shared workflow
       within one run (e.g. toJSON(inputs) of the calling reusable workflow).
-      Hashed into the dependency version cache key. Leave empty to share one
-      cache across the whole run.
+      Hashed into the dependency version cache artifact name. Leave empty to
+      share one cache across the whole run.
     required: false
     default: ""
+
+outputs:
+  cache-artifact-name:
+    description: >-
+      Base name for this invocation's dependency-version cache artifacts.
+      Upload to "<cache-artifact-name>-<unique-suffix>" (path
+      /tmp/bakery_cache) as the last step of each job so later jobs, and
+      other parallel instances of the same job, can restore it. The suffix
+      must be unique per job (e.g. a static string for a single-instance job,
+      or "${{ strategy.job-index }}" for a matrix job) since artifact names
+      must be unique within a run.
+    value: ${{ steps.artifact-name.outputs.name }}
 
 runs:
   using: "composite"
@@ -40,31 +52,36 @@ runs:
     - name: Configure dependency version cache TTL
       shell: bash
       # Long enough that the restored cache below stays valid for the life of
-      # a workflow run; the run-scoped cache key (not this TTL) is what keeps
-      # results from leaking staleness into the next run.
+      # a workflow run; the run-scoped artifact name (not this TTL) is what
+      # keeps results from leaking staleness into the next run.
       run: echo "BAKERY_CACHE_EXPIRE_AFTER=86400" >> "$GITHUB_ENV"
 
-    - name: Compute cache key
-      id: cache-key
+    - name: Compute cache artifact name
+      id: artifact-name
       shell: bash
       # A bare run_id is not enough: a single run can invoke a shared workflow
       # more than once concurrently with different inputs (e.g. a PR workflow
       # building production/development/content in parallel), and those
-      # invocations would otherwise race to populate the exact same cache
-      # entry. Folding a hash of cache-scope in gives each invocation its own
-      # entry without any cross-job plumbing, since every job within one
+      # invocations would otherwise race to share the exact same artifact
+      # name. Folding a hash of cache-scope in gives each invocation its own
+      # name without any cross-job plumbing, since every job within one
       # invocation sees the same inputs context.
       env:
         CACHE_SCOPE: ${{ inputs.cache-scope }}
       run: |
-        KEY="bakery-deps-${GITHUB_RUN_ID}"
+        NAME="bakery-deps-${GITHUB_RUN_ID}"
         if [[ -n "$CACHE_SCOPE" ]]; then
-          KEY="${KEY}-$(printf '%s' "$CACHE_SCOPE" | sha256sum | cut -c1-16)"
+          NAME="${NAME}-$(printf '%s' "$CACHE_SCOPE" | sha256sum | cut -c1-16)"
         fi
-        echo "key=$KEY" >> "$GITHUB_OUTPUT"
+        echo "name=$NAME" >> "$GITHUB_OUTPUT"
 
-    - name: Cache dependency version lookups
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+    - name: Restore dependency version cache
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+      # No artifact yet (first job to run this invocation) is expected, not
+      # fatal: continue with an empty /tmp/bakery_cache and let it populate
+      # from upstream as normal.
+      continue-on-error: true
       with:
         path: /tmp/bakery_cache
-        key: ${{ steps.cache-key.outputs.key }}
+        pattern: "${{ steps.artifact-name.outputs.name }}-*"
+        merge-multiple: true

--- a/setup-bakery/action.yml
+++ b/setup-bakery/action.yml
@@ -10,6 +10,14 @@ inputs:
     description: "The version of Python to use"
     required: false
     default: "3.x"
+  cache-scope:
+    description: >-
+      Opaque string distinguishing concurrent invocations of a shared workflow
+      within one run (e.g. toJSON(inputs) of the calling reusable workflow).
+      Hashed into the dependency version cache key. Leave empty to share one
+      cache across the whole run.
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -28,3 +36,35 @@ runs:
       shell: bash
       run: |
         uv tool install "git+https://github.com/posit-dev/images-shared.git@${{ inputs.version }}#subdirectory=posit-bakery&egg=posit-bakery"
+
+    - name: Configure dependency version cache TTL
+      shell: bash
+      # Long enough that the restored cache below stays valid for the life of
+      # a workflow run; the run-scoped cache key (not this TTL) is what keeps
+      # results from leaking staleness into the next run.
+      run: echo "BAKERY_CACHE_EXPIRE_AFTER=86400" >> "$GITHUB_ENV"
+
+    - name: Compute cache key
+      id: cache-key
+      shell: bash
+      # A bare run_id is not enough: a single run can invoke a shared workflow
+      # more than once concurrently with different inputs (e.g. a PR workflow
+      # building production/development/content in parallel), and those
+      # invocations would otherwise race to populate the exact same cache
+      # entry. Folding a hash of cache-scope in gives each invocation its own
+      # entry without any cross-job plumbing, since every job within one
+      # invocation sees the same inputs context.
+      env:
+        CACHE_SCOPE: ${{ inputs.cache-scope }}
+      run: |
+        KEY="bakery-deps-${GITHUB_RUN_ID}"
+        if [[ -n "$CACHE_SCOPE" ]]; then
+          KEY="${KEY}-$(printf '%s' "$CACHE_SCOPE" | sha256sum | cut -c1-16)"
+        fi
+        echo "key=$KEY" >> "$GITHUB_OUTPUT"
+
+    - name: Cache dependency version lookups
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      with:
+        path: /tmp/bakery_cache
+        key: ${{ steps.cache-key.outputs.key }}

--- a/setup-bakery/action.yml
+++ b/setup-bakery/action.yml
@@ -18,6 +18,13 @@ inputs:
       share one cache across the whole run.
     required: false
     default: ""
+  is-writer:
+    description: >-
+      "true" if this job resolves the full dependency-version set and uploads
+      the cache artifact itself (see the cache-artifact-name output), making a
+      prior restore pointless. Leave "false" for every other job.
+    required: false
+    default: "false"
 
 outputs:
   cache-artifact-name:
@@ -75,6 +82,7 @@ runs:
         echo "name=$NAME" >> "$GITHUB_OUTPUT"
 
     - name: Restore dependency version cache
+      if: inputs.is-writer != 'true'
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
       # No artifact yet (first job to run this invocation) is expected, not
       # fatal: continue with an empty /tmp/bakery_cache and let it populate

--- a/setup-bakery/action.yml
+++ b/setup-bakery/action.yml
@@ -78,7 +78,10 @@ runs:
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
       # No artifact yet (first job to run this invocation) is expected, not
       # fatal: continue with an empty /tmp/bakery_cache and let it populate
-      # from upstream as normal.
+      # from upstream as normal. Tradeoff: this also swallows a real failure
+      # (bad name, permissions) identically to a cold cache, and the job
+      # that saves the cache will always show this step as failed-but
+      # -continued on its own restore attempt, since nothing exists yet.
       continue-on-error: true
       with:
         path: /tmp/bakery_cache

--- a/setup-bakery/action.yml
+++ b/setup-bakery/action.yml
@@ -22,13 +22,12 @@ inputs:
 outputs:
   cache-artifact-name:
     description: >-
-      Base name for this invocation's dependency-version cache artifacts.
-      Upload to "<cache-artifact-name>-<unique-suffix>" (path
-      /tmp/bakery_cache) as the last step of each job so later jobs, and
-      other parallel instances of the same job, can restore it. The suffix
-      must be unique per job (e.g. a static string for a single-instance job,
-      or "${{ strategy.job-index }}" for a matrix job) since artifact names
-      must be unique within a run.
+      Name for this invocation's dependency-version cache artifact. Exactly
+      one job — whichever one first resolves the full set of dependency
+      versions needed for the run (typically the job calling `bakery ci
+      matrix`) — should upload /tmp/bakery_cache under this name as its last
+      step. Other jobs only need to restore it: they resolve a subset of the
+      same versions and gain nothing by re-uploading.
     value: ${{ steps.artifact-name.outputs.name }}
 
 runs:
@@ -83,5 +82,4 @@ runs:
       continue-on-error: true
       with:
         path: /tmp/bakery_cache
-        pattern: "${{ steps.artifact-name.outputs.name }}-*"
-        merge-multiple: true
+        name: ${{ steps.artifact-name.outputs.name }}


### PR DESCRIPTION
Closes https://github.com/posit-dev/images-shared/issues/330
Closes https://github.com/posit-dev/images-shared/issues/304

Memoize the requests-cache session factory and each dependency's `_fetch_versions` helper so backend init and JSON fetch+parse run exactly once per `bakery` invocation, instead of once per `DependencyConstraint` instance.

- `available_versions()` returns a copy of the memoized list in all four dependency files, so callers can't corrupt the shared cache.
- `setup-bakery` restores the dependency-version HTTP cache from a run-scoped GitHub Actions cache and raises its TTL for the life of a run, so every job in a workflow (matrix, build-test, merge) resolves the same versions instead of racing against upstream between build time and merge time.