### PR TITLE
Remove ORAS manifest delete from merge workflow

### DIFF
--- a/posit-bakery/posit_bakery/plugins/builtin/oras/oras.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/oras/oras.py
@@ -142,24 +142,6 @@ class OrasCopy(OrasCommand):
         return cmd
 
 
-class OrasManifestDelete(OrasCommand):
-    """Delete a manifest from a registry.
-
-    This command deletes a manifest (image or index) from a registry.
-    """
-
-    reference: Annotated[str, Field(description="The manifest reference to delete.")]
-
-    @property
-    def command(self) -> list[str]:
-        """Build the oras manifest delete command."""
-        cmd = [self.oras_bin, "manifest", "delete", "--force"]
-        if self.plain_http:
-            cmd.append("--plain-http")
-        cmd.append(self.reference)
-        return cmd
-
-
 class OrasMergeWorkflowResult(BaseModel):
     """Result of an ORAS merge workflow execution."""
 
@@ -175,7 +157,9 @@ class OrasMergeWorkflow(BaseModel):
     This workflow:
     1. Creates a temporary manifest index from platform-specific source images
     2. Copies the index to all target registries/tags
-    3. Deletes the temporary index
+
+    The temporary index is left in place and is cleaned up out-of-band by the
+    ``clean.yml`` workflow (``bakery clean temp-registry``) rather than deleted here.
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -241,18 +225,8 @@ class OrasMergeWorkflow(BaseModel):
                 )
                 copy_cmd.run(dry_run=dry_run)
 
-            # Step 3: Delete the temporary index (non-fatal)
-            log.info(f"Cleaning up temporary index {self.temp_index_tag}")
-            delete_cmd = OrasManifestDelete(
-                oras_bin=self.oras_bin,
-                reference=self.temp_index_tag,
-                plain_http=self.plain_http,
-            )
-            try:
-                delete_cmd.run(dry_run=dry_run)
-            except BakeryToolRuntimeError as e:
-                log.warning(f"Failed to clean up temporary index {self.temp_index_tag}: {e}")
-
+            # The temporary index is intentionally left in place; it is cleaned up
+            # out-of-band by the clean.yml workflow (bakery clean temp-registry).
             log.info(f"ORAS merge workflow completed successfully")
             return OrasMergeWorkflowResult(
                 success=True,

--- a/posit-bakery/test/plugins/builtin/oras/test_oras.py
+++ b/posit-bakery/test/plugins/builtin/oras/test_oras.py
@@ -13,7 +13,6 @@ from posit_bakery.plugins.builtin.oras.oras import (
     find_oras_bin,
     get_repository_from_ref,
     OrasCopy,
-    OrasManifestDelete,
     OrasManifestIndexCreate,
     OrasMergeWorkflow,
     OrasMergeWorkflowResult,
@@ -188,34 +187,6 @@ class TestOrasCopy:
         assert result.returncode == 0
 
 
-class TestOrasManifestDelete:
-    """Tests for the OrasManifestDelete command."""
-
-    def test_command_construction(self):
-        """Test that the command is constructed correctly."""
-        cmd = OrasManifestDelete(
-            oras_bin="oras",
-            reference="ghcr.io/posit-dev/test/tmp:tag",
-        )
-
-        expected = ["oras", "manifest", "delete", "--force", "ghcr.io/posit-dev/test/tmp:tag"]
-        assert cmd.command == expected
-
-    def test_run_success(self):
-        """Test successful delete execution."""
-        cmd = OrasManifestDelete(
-            oras_bin="oras",
-            reference="ghcr.io/posit-dev/test/tmp:tag",
-        )
-
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = subprocess.CompletedProcess(args=cmd.command, returncode=0, stdout=b"", stderr=b"")
-            result = cmd.run()
-
-        mock_run.assert_called_once_with(cmd.command, capture_output=True)
-        assert result.returncode == 0
-
-
 class TestOrasMergeWorkflow:
     """Tests for the OrasMergeWorkflow orchestrator."""
 
@@ -295,8 +266,9 @@ class TestOrasMergeWorkflow:
         assert result.temp_index_ref is not None
 
         # Should have called:
-        # 1 create + 2 copy (grouped by destination) + 1 delete = 4 calls
-        assert mock_run.call_count == 4
+        # 1 create + 2 copy (grouped by destination) = 3 calls.
+        # The temporary index is no longer deleted here; clean.yml handles it.
+        assert mock_run.call_count == 3
 
     def test_execute_dry_run(self, basic_workflow):
         """Test dry run mode."""
@@ -517,17 +489,6 @@ class TestOrasCommandsPlainHttp:
         )
 
         expected = ["oras", "cp", "--plain-http", "localhost:5000/test:source", "localhost:5000/test:dest"]
-        assert cmd.command == expected
-
-    def test_manifest_delete_with_plain_http(self):
-        """Test that --plain-http flag is included when plain_http=True."""
-        cmd = OrasManifestDelete(
-            oras_bin="oras",
-            reference="localhost:5000/test:tag",
-            plain_http=True,
-        )
-
-        expected = ["oras", "manifest", "delete", "--force", "--plain-http", "localhost:5000/test:tag"]
         assert cmd.command == expected
 
 


### PR DESCRIPTION
## Summary

The `OrasManifestDelete` command frequently failed when cleaning up the temporary manifest index after a merge. This removes the command and the in-line cleanup step from `OrasMergeWorkflow`.

The temporary index is now left in place and cleaned up out-of-band by the `clean.yml` workflow (`bakery clean temp-registry`), which each product repo already runs on a schedule.

## Changes

- Removed the `OrasManifestDelete` class from `oras.py`.
- Removed "Step 3" (delete temporary index) from `OrasMergeWorkflow.run()`; the workflow now only creates the temporary index and copies it to destinations.
- Updated the workflow docstring/comments to note the temp index is cleaned up by `clean.yml`.
- Updated tests: dropped the `OrasManifestDelete` import, removed `TestOrasManifestDelete` and `test_manifest_delete_with_plain_http`, and adjusted `test_execute_success`'s call-count assertion from 4 → 3.

## Testing

- `uv run pytest test/plugins/builtin/oras/` → 43 passed
- `uv run ruff check` on both modified files → all checks passed

## Notes

With the in-line delete gone, temporary indexes now persist until the cleanup job runs (default: removes those older than 3 days) rather than being deleted immediately after each merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)