### PR TITLE
fix: drop invalid version-file arg from setup-uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
-          python-version-file: "posit-bakery/pyproject.toml"
+          version-file: "posit-bakery/pyproject.toml"
           enable-cache: false
 
       - name: Install dependencies
@@ -248,7 +248,7 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
-          python-version-file: "posit-bakery/pyproject.toml"
+          version-file: "posit-bakery/pyproject.toml"
           enable-cache: false
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,6 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
-          version-file: "posit-bakery/pyproject.toml"
           enable-cache: false
 
       - name: Install dependencies
@@ -248,7 +247,6 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
-          version-file: "posit-bakery/pyproject.toml"
           enable-cache: false
 
       - name: Install dependencies

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
-          python-version-file: posit-bakery/pyproject.toml
+          version-file: posit-bakery/pyproject.toml
           enable-cache: false
 
       - name: Install docs dependencies

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,6 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
-          version-file: posit-bakery/pyproject.toml
           enable-cache: false
 
       - name: Install docs dependencies


### PR DESCRIPTION
## Summary

The `astral-sh/setup-uv` steps passed `python-version-file`, which is not a valid input for that action and produced "Unexpected input(s)" warnings in `ci.yml` and `docs.yml`.

The action's real `version-file` input only pins the **uv** version itself (read from `[tool.uv] required-version` or a `.uv-version` file). We don't pin uv — `posit-bakery/pyproject.toml` has no `[tool.uv]` section — so the argument serves no purpose. This drops it entirely and lets `setup-uv` install the default uv, resolving the warnings.

The `actions/setup-python` call (which legitimately uses `python-version-file`) is left unchanged.

## Changes

- `.github/workflows/ci.yml` — two `setup-uv` steps
- `.github/workflows/docs.yml` — one `setup-uv` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)