### PR TITLE
feat(oras): dump command stdout/stderr on merge failure

### DIFF
--- a/posit-bakery/posit_bakery/plugins/builtin/oras/__init__.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/oras/__init__.py
@@ -148,7 +148,10 @@ class OrasPlugin(BakeryToolPlugin):
 
     def results(self, results: list[ToolCallResult]) -> None:
         """Display ORAS merge results and exit non-zero on failures."""
+        import textwrap
+
         from posit_bakery.log import stderr_console
+        from posit_bakery.settings import SETTINGS
 
         has_errors = False
         for result in results:
@@ -159,6 +162,20 @@ class OrasPlugin(BakeryToolPlugin):
                     f"Error merging '{result.target}': {result.stderr}",
                     style="error",
                 )
+                # Surface the captured oras stdout/stderr so the failure is
+                # actionable. Skip when quiet logging is enabled (--quiet raises
+                # log_level to ERROR).
+                if workflow_result and SETTINGS.log_level < logging.ERROR:
+                    if workflow_result.stdout:
+                        stderr_console.print(
+                            f"oras stdout:\n{textwrap.indent(workflow_result.stdout, '  ')}",
+                            style="error",
+                        )
+                    if workflow_result.stderr:
+                        stderr_console.print(
+                            f"oras stderr:\n{textwrap.indent(workflow_result.stderr, '  ')}",
+                            style="error",
+                        )
             elif workflow_result:
                 log.info(f"Merged '{result.target}' -> {', '.join(workflow_result.destinations)}")
 

--- a/posit-bakery/posit_bakery/plugins/builtin/oras/oras.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/oras/oras.py
@@ -149,6 +149,8 @@ class OrasMergeWorkflowResult(BaseModel):
     temp_index_ref: Annotated[str | None, Field(default=None, description="Reference to the temporary index created.")]
     destinations: Annotated[list[str], Field(default_factory=list, description="List of destination references.")]
     error: Annotated[str | None, Field(default=None, description="Error message if the workflow failed.")]
+    stdout: Annotated[str, Field(default="", description="Captured stdout of the failed oras command, if any.")]
+    stderr: Annotated[str, Field(default="", description="Captured stderr of the failed oras command, if any.")]
 
 
 class OrasMergeWorkflow(BaseModel):
@@ -236,11 +238,16 @@ class OrasMergeWorkflow(BaseModel):
 
         except BakeryToolRuntimeError as e:
             log.error(f"ORAS merge workflow failed: {e}")
+            # The base error's __str__ only reports the exit code and command. Carry
+            # the captured oras stdout/stderr up so results() can surface the
+            # underlying failure to the user (unless quiet logging is enabled).
             return OrasMergeWorkflowResult(
                 success=False,
                 temp_index_ref=self.temp_index_tag,
                 destinations=self.image_target.tags.as_strings(),
                 error=str(e),
+                stdout=e.dump_stdout(),
+                stderr=e.dump_stderr(),
             )
 
     @classmethod

--- a/posit-bakery/test/plugins/builtin/oras/test_oras.py
+++ b/posit-bakery/test/plugins/builtin/oras/test_oras.py
@@ -310,6 +310,31 @@ class TestOrasMergeWorkflow:
         assert result.success is False
         assert result.error is not None
 
+    def test_failure_captures_command_output(self, basic_workflow):
+        """A failed workflow result carries the failed command's stdout/stderr."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[],
+                returncode=1,
+                stdout=b"oras stdout details",
+                stderr=b"oras stderr details",
+            )
+            result = basic_workflow.run()
+
+        assert result.success is False
+        assert result.stdout == "oras stdout details"
+        assert result.stderr == "oras stderr details"
+
+    def test_success_has_no_captured_output(self, basic_workflow):
+        """A successful workflow result has empty stdout/stderr."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout=b"", stderr=b"")
+            result = basic_workflow.run()
+
+        assert result.success is True
+        assert result.stdout == ""
+        assert result.stderr == ""
+
     def test_validates_sources_required(self):
         """Test that validation fails when no sources are provided."""
         mock_target = MagicMock(spec=ImageTarget)

--- a/posit-bakery/test/plugins/builtin/oras/test_oras_plugin.py
+++ b/posit-bakery/test/plugins/builtin/oras/test_oras_plugin.py
@@ -213,6 +213,61 @@ class TestOrasPluginExecute:
         assert msg.endswith("a-first, c-second, b-third, d-last"), msg
 
 
+class TestOrasPluginResults:
+    """Tests for OrasPlugin.results() output behavior."""
+
+    @staticmethod
+    def _failed_result() -> "ToolCallResult":
+        from posit_bakery.plugins.protocol import ToolCallResult
+
+        workflow_result = OrasMergeWorkflowResult(
+            success=False,
+            error="oras command failed",
+            stdout="oras stdout details",
+            stderr="oras stderr details",
+        )
+        return ToolCallResult(
+            exit_code=1,
+            tool_name="oras",
+            target="test-image:1.0.0",
+            stdout="",
+            stderr=workflow_result.error,
+            artifacts={"workflow_result": workflow_result},
+        )
+
+    def test_results_dumps_command_output_when_not_quiet(self, plugin, monkeypatch):
+        """Failed merges dump the captured oras stdout/stderr when not quiet."""
+        from posit_bakery.log import stderr_console
+        from posit_bakery.settings import SETTINGS
+
+        monkeypatch.setattr(SETTINGS, "log_level", logging.INFO)
+
+        with stderr_console.capture() as capture:
+            with pytest.raises(typer.Exit):
+                plugin.results([self._failed_result()])
+
+        output = capture.get()
+        assert "oras stdout details" in output
+        assert "oras stderr details" in output
+
+    def test_results_suppresses_command_output_when_quiet(self, plugin, monkeypatch):
+        """Failed merges suppress the captured oras stdout/stderr when quiet."""
+        from posit_bakery.log import stderr_console
+        from posit_bakery.settings import SETTINGS
+
+        monkeypatch.setattr(SETTINGS, "log_level", logging.ERROR)
+
+        with stderr_console.capture() as capture:
+            with pytest.raises(typer.Exit):
+                plugin.results([self._failed_result()])
+
+        output = capture.get()
+        # The error summary is still shown, but the verbose dumps are not.
+        assert "Error merging" in output
+        assert "oras stdout details" not in output
+        assert "oras stderr details" not in output
+
+
 class TestOrasPluginCLI:
     def test_register_cli_adds_oras_command(self, plugin):
         app = typer.Typer()


### PR DESCRIPTION
## Summary

Improves ORAS error logging. Previously, when an ORAS merge or copy command failed, Bakery reported only the exit code and the executed command — the actual error output from `oras` was discarded (the base `BakeryToolRuntimeError.__str__` omits captured stdout/stderr). This made CI merge failures hard to diagnose.

Now the captured stdout/stderr from the failed command are surfaced to the user, unless quiet logging is enabled.

## Changes

- **`oras.py`** — `OrasMergeWorkflowResult` gains `stdout`/`stderr` fields. The `run()` exception handler captures the failed command's output (`e.dump_stdout()` / `e.dump_stderr()`) onto the result instead of discarding it. The workflow stays pure — no presentation logic.
- **`__init__.py`** — `OrasPlugin.results()` (the plugin's display layer, matching the hadolint pattern) prints the captured stdout/stderr via `stderr_console`, gated on `SETTINGS.log_level < logging.ERROR` so it is suppressed under `--quiet`.

## Testing

- Run-level tests verify the result carries the captured output on failure and is empty on success.
- `results()`-level tests verify the dumps appear when not quiet and are suppressed (while the error summary is still shown) under `--quiet`.
- Full fast suite: 1569 passed. `ruff check` / `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)