### PR TITLE
Add --dev-spec for dispatch-pinned dev builds

### DIFF
--- a/.github/workflows/bakery-build-native.yml
+++ b/.github/workflows/bakery-build-native.yml
@@ -42,6 +42,16 @@ on:
         default: ""
         required: false
         type: string
+      dev-version:
+        description: "Pinned dev version string for a dispatched build. Used with dev-channel to construct dev-spec."
+        default: ""
+        required: false
+        type: string
+      dev-spec:
+        description: "JSON spec for a dispatched dev build. If set, takes precedence over dev-version/dev-channel for spec construction."
+        default: ""
+        required: false
+        type: string
       push:
         description: "Whether to push images to registries [default: false]"
         default: false
@@ -127,12 +137,21 @@ jobs:
           MATRIX_VERSIONS: ${{ inputs.matrix-versions }}
           IMAGE_VERSION: ${{ inputs.image-version }}
           DEV_CHANNEL: ${{ inputs.dev-channel || inputs.dev-stream }}
+          DEV_VERSION: ${{ inputs.dev-version }}
+          DEV_SPEC: ${{ inputs.dev-spec }}
           CONTEXT: ${{ inputs.context }}
         run: |
           IMAGE_VERSION="${IMAGE_VERSION#v}"
           ARGS=(--quiet --dev-versions "$DEV_VERSIONS" --matrix-versions "$MATRIX_VERSIONS" --context "$CONTEXT")
           [[ -n "$IMAGE_VERSION" ]] && ARGS+=(--image-version "$IMAGE_VERSION")
           [[ -n "$DEV_CHANNEL" ]] && ARGS+=(--dev-channel "$DEV_CHANNEL")
+          if [[ -n "$DEV_SPEC" ]]; then
+            ARGS+=(--dev-spec "$DEV_SPEC")
+          elif [[ -n "$DEV_VERSION" ]]; then
+            DEV_SPEC_JSON=$(jq -cn --arg v "$DEV_VERSION" --arg c "$DEV_CHANNEL" \
+              '{version: $v} + if $c != "" then {channel: $c} else {} end')
+            ARGS+=(--dev-spec "$DEV_SPEC_JSON")
+          fi
           result=$(bakery ci matrix "${ARGS[@]}")
           echo "platform_matrix=$(echo "$result" | jq --compact-output .)" >> "$GITHUB_OUTPUT"
           echo "image_matrix=$(echo "$result" | jq --compact-output '[.[].image] | unique')" >> "$GITHUB_OUTPUT"
@@ -229,6 +248,9 @@ jobs:
           IMAGE_PLATFORM: ${{ matrix.img.platform }}
           DEV_VERSIONS: ${{ inputs.dev-versions }}
           MATRIX_VERSIONS: ${{ inputs.matrix-versions }}
+          DEV_CHANNEL: ${{ inputs.dev-channel || inputs.dev-stream }}
+          DEV_VERSION: ${{ inputs.dev-version }}
+          DEV_SPEC: ${{ inputs.dev-spec }}
           REGISTRY: ghcr.io/${{ github.repository_owner }}
           NORMALIZED_PLATFORM: ${{ steps.normalize-platform.outputs.platform }}
           CONTEXT: ${{ inputs.context }}
@@ -240,6 +262,14 @@ jobs:
           if [ "$CACHE" = "true" ]; then
             CACHE_FLAGS=(--cache-registry "$REGISTRY")
           fi
+          DEV_SPEC_FLAGS=()
+          if [[ -n "$DEV_SPEC" ]]; then
+            DEV_SPEC_FLAGS+=(--dev-spec "$DEV_SPEC")
+          elif [[ -n "$DEV_VERSION" ]]; then
+            DEV_SPEC_JSON=$(jq -cn --arg v "$DEV_VERSION" --arg c "$DEV_CHANNEL" \
+              '{version: $v} + if $c != "" then {channel: $c} else {} end')
+            DEV_SPEC_FLAGS+=(--dev-spec "$DEV_SPEC_JSON")
+          fi
           bakery build \
             --strategy build --pull \
             --retry "$RETRY" \
@@ -249,6 +279,7 @@ jobs:
             --dev-versions "$DEV_VERSIONS" \
             --matrix-versions "$MATRIX_VERSIONS" \
             "${CACHE_FLAGS[@]}" \
+            "${DEV_SPEC_FLAGS[@]}" \
             --temp-registry "$REGISTRY" \
             --metadata-file "./${IMAGE_NAME}-${IMAGE_VERSION}-${NORMALIZED_PLATFORM}-metadata.json" \
             --context "$CONTEXT" \

--- a/.github/workflows/bakery-build-native.yml
+++ b/.github/workflows/bakery-build-native.yml
@@ -144,13 +144,14 @@ jobs:
           IMAGE_VERSION="${IMAGE_VERSION#v}"
           ARGS=(--quiet --dev-versions "$DEV_VERSIONS" --matrix-versions "$MATRIX_VERSIONS" --context "$CONTEXT")
           [[ -n "$IMAGE_VERSION" ]] && ARGS+=(--image-version "$IMAGE_VERSION")
-          [[ -n "$DEV_CHANNEL" ]] && ARGS+=(--dev-channel "$DEV_CHANNEL")
           if [[ -n "$DEV_SPEC" ]]; then
             ARGS+=(--dev-spec "$DEV_SPEC")
           elif [[ -n "$DEV_VERSION" ]]; then
             DEV_SPEC_JSON=$(jq -cn --arg v "$DEV_VERSION" --arg c "$DEV_CHANNEL" \
               '{version: $v} + if $c != "" then {channel: $c} else {} end')
             ARGS+=(--dev-spec "$DEV_SPEC_JSON")
+          elif [[ -n "$DEV_CHANNEL" ]]; then
+            ARGS+=(--dev-channel "$DEV_CHANNEL")
           fi
           result=$(bakery ci matrix "${ARGS[@]}")
           echo "platform_matrix=$(echo "$result" | jq --compact-output .)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/bakery-build.yml
+++ b/.github/workflows/bakery-build.yml
@@ -43,6 +43,16 @@ on:
         default: ""
         required: false
         type: string
+      dev-version:
+        description: "Pinned dev version string for a dispatched build. Used with dev-channel to construct dev-spec."
+        default: ""
+        required: false
+        type: string
+      dev-spec:
+        description: "JSON spec for a dispatched dev build. If set, takes precedence over dev-version/dev-channel for spec construction."
+        default: ""
+        required: false
+        type: string
       push:
         description: "Whether to push images to registries [default: false]"
         default: false
@@ -117,12 +127,21 @@ jobs:
           MATRIX_VERSIONS: ${{ inputs.matrix-versions }}
           IMAGE_VERSION: ${{ inputs.image-version }}
           DEV_CHANNEL: ${{ inputs.dev-channel || inputs.dev-stream }}
+          DEV_VERSION: ${{ inputs.dev-version }}
+          DEV_SPEC: ${{ inputs.dev-spec }}
           CONTEXT: ${{ inputs.context }}
         run: |
           IMAGE_VERSION="${IMAGE_VERSION#v}"
           ARGS=(--quiet --dev-versions "$DEV_VERSIONS" --matrix-versions "$MATRIX_VERSIONS" --context "$CONTEXT")
           [[ -n "$IMAGE_VERSION" ]] && ARGS+=(--image-version "$IMAGE_VERSION")
           [[ -n "$DEV_CHANNEL" ]] && ARGS+=(--dev-channel "$DEV_CHANNEL")
+          if [[ -n "$DEV_SPEC" ]]; then
+            ARGS+=(--dev-spec "$DEV_SPEC")
+          elif [[ -n "$DEV_VERSION" ]]; then
+            DEV_SPEC_JSON=$(jq -cn --arg v "$DEV_VERSION" --arg c "$DEV_CHANNEL" \
+              '{version: $v} + if $c != "" then {channel: $c} else {} end')
+            ARGS+=(--dev-spec "$DEV_SPEC_JSON")
+          fi
           result=$(bakery ci matrix "${ARGS[@]}")
           echo "matrix=$(echo "$result" | jq --compact-output .)" >> "$GITHUB_OUTPUT"
 
@@ -201,6 +220,9 @@ jobs:
           IMAGE_VERSION: ${{ matrix.img.version }}
           DEV_VERSIONS: ${{ inputs.dev-versions }}
           MATRIX_VERSIONS: ${{ inputs.matrix-versions }}
+          DEV_CHANNEL: ${{ inputs.dev-channel || inputs.dev-stream }}
+          DEV_VERSION: ${{ inputs.dev-version }}
+          DEV_SPEC: ${{ inputs.dev-spec }}
           REGISTRY: ghcr.io/${{ github.repository_owner }}
           CONTEXT: ${{ inputs.context }}
           CACHE: ${{ inputs.cache }}
@@ -210,6 +232,14 @@ jobs:
           if [ "$CACHE" = "true" ]; then
             CACHE_FLAGS=(--cache-registry "$REGISTRY")
           fi
+          DEV_SPEC_FLAGS=()
+          if [[ -n "$DEV_SPEC" ]]; then
+            DEV_SPEC_FLAGS+=(--dev-spec "$DEV_SPEC")
+          elif [[ -n "$DEV_VERSION" ]]; then
+            DEV_SPEC_JSON=$(jq -cn --arg v "$DEV_VERSION" --arg c "$DEV_CHANNEL" \
+              '{version: $v} + if $c != "" then {channel: $c} else {} end')
+            DEV_SPEC_FLAGS+=(--dev-spec "$DEV_SPEC_JSON")
+          fi
           bakery build --load --pull \
             --retry "$RETRY" \
             --image-name "^${IMAGE_NAME}$" \
@@ -217,6 +247,7 @@ jobs:
             --dev-versions "$DEV_VERSIONS" \
             --matrix-versions "$MATRIX_VERSIONS" \
             "${CACHE_FLAGS[@]}" \
+            "${DEV_SPEC_FLAGS[@]}" \
             --context "$CONTEXT"
 
       - name: Test
@@ -249,15 +280,27 @@ jobs:
           IMAGE_VERSION: ${{ matrix.img.version }}
           DEV_VERSIONS: ${{ inputs.dev-versions }}
           MATRIX_VERSIONS: ${{ inputs.matrix-versions }}
+          DEV_CHANNEL: ${{ inputs.dev-channel || inputs.dev-stream }}
+          DEV_VERSION: ${{ inputs.dev-version }}
+          DEV_SPEC: ${{ inputs.dev-spec }}
           CONTEXT: ${{ inputs.context }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          DEV_SPEC_FLAGS=()
+          if [[ -n "$DEV_SPEC" ]]; then
+            DEV_SPEC_FLAGS+=(--dev-spec "$DEV_SPEC")
+          elif [[ -n "$DEV_VERSION" ]]; then
+            DEV_SPEC_JSON=$(jq -cn --arg v "$DEV_VERSION" --arg c "$DEV_CHANNEL" \
+              '{version: $v} + if $c != "" then {channel: $c} else {} end')
+            DEV_SPEC_FLAGS+=(--dev-spec "$DEV_SPEC_JSON")
+          fi
           bakery build --push --pull \
             --retry "$RETRY" \
             --image-name "^${IMAGE_NAME}$" \
             --image-version "$IMAGE_VERSION" \
             --dev-versions "$DEV_VERSIONS" \
             --matrix-versions "$MATRIX_VERSIONS" \
+            "${DEV_SPEC_FLAGS[@]}" \
             --context "$CONTEXT"
 
   readme:

--- a/.github/workflows/bakery-build.yml
+++ b/.github/workflows/bakery-build.yml
@@ -134,13 +134,14 @@ jobs:
           IMAGE_VERSION="${IMAGE_VERSION#v}"
           ARGS=(--quiet --dev-versions "$DEV_VERSIONS" --matrix-versions "$MATRIX_VERSIONS" --context "$CONTEXT")
           [[ -n "$IMAGE_VERSION" ]] && ARGS+=(--image-version "$IMAGE_VERSION")
-          [[ -n "$DEV_CHANNEL" ]] && ARGS+=(--dev-channel "$DEV_CHANNEL")
           if [[ -n "$DEV_SPEC" ]]; then
             ARGS+=(--dev-spec "$DEV_SPEC")
           elif [[ -n "$DEV_VERSION" ]]; then
             DEV_SPEC_JSON=$(jq -cn --arg v "$DEV_VERSION" --arg c "$DEV_CHANNEL" \
               '{version: $v} + if $c != "" then {channel: $c} else {} end')
             ARGS+=(--dev-spec "$DEV_SPEC_JSON")
+          elif [[ -n "$DEV_CHANNEL" ]]; then
+            ARGS+=(--dev-channel "$DEV_CHANNEL")
           fi
           result=$(bakery ci matrix "${ARGS[@]}")
           echo "matrix=$(echo "$result" | jq --compact-output .)" >> "$GITHUB_OUTPUT"

--- a/posit-bakery/posit_bakery/cli/build.py
+++ b/posit-bakery/posit_bakery/cli/build.py
@@ -9,7 +9,6 @@ import typer
 from posit_bakery.cli.common import with_verbosity_flags, with_temporary_storage, parse_dev_spec
 from posit_bakery.config import BakeryConfig
 from posit_bakery.config.config import BakeryConfigFilter, BakerySettings
-from posit_bakery.config.image.dev_version.spec import DevBuildSpec
 from posit_bakery.config.image.posit_product.const import ReleaseChannelEnum
 from posit_bakery.const import DevVersionInclusionEnum, MatrixVersionInclusionEnum
 from posit_bakery.error import BakeryBuildErrorGroup, BakeryToolRuntimeError

--- a/posit-bakery/posit_bakery/cli/build.py
+++ b/posit-bakery/posit_bakery/cli/build.py
@@ -10,6 +10,7 @@ from posit_bakery.cli.common import with_verbosity_flags, with_temporary_storage
 from posit_bakery.config import BakeryConfig
 from posit_bakery.config.config import BakeryConfigFilter, BakerySettings
 from posit_bakery.config.image.posit_product.const import ReleaseChannelEnum
+from posit_bakery.config.image.posit_product.errors import DispatchVersionMismatchError
 from posit_bakery.const import DevVersionInclusionEnum, MatrixVersionInclusionEnum
 from posit_bakery.error import BakeryBuildErrorGroup, BakeryToolRuntimeError
 from posit_bakery.image import ImageBuildStrategy
@@ -253,7 +254,11 @@ def build(
         dev_spec=dev_spec,  # type: ignore[arg-type]  # typer requires str annotation; parse_dev_spec callback delivers DevBuildSpec at runtime
     )
 
-    config: BakeryConfig = BakeryConfig.from_context(context, settings)
+    try:
+        config: BakeryConfig = BakeryConfig.from_context(context, settings)
+    except DispatchVersionMismatchError as e:
+        stderr_console.print(f"❌ {e}", style="error")
+        raise typer.Exit(code=1)
 
     if plan:
         if strategy == ImageBuildStrategy.BUILD:

--- a/posit-bakery/posit_bakery/cli/build.py
+++ b/posit-bakery/posit_bakery/cli/build.py
@@ -20,6 +20,17 @@ from posit_bakery.util import auto_path
 log = logging.getLogger(__name__)
 
 
+def _parse_dev_spec(ctx: typer.Context, param: typer.CallbackParam, value: str | None) -> DevBuildSpec | None:
+    if value is None:
+        return None
+    from pydantic import ValidationError
+
+    try:
+        return DevBuildSpec.model_validate_json(value)
+    except ValidationError as e:
+        raise typer.BadParameter(str(e), ctx=ctx, param=param) from e
+
+
 class RichHelpPanelEnum(str, Enum):
     """Enum for categorizing options into rich help panels."""
 
@@ -213,12 +224,13 @@ def build(
         ),
     ] = False,
     dev_spec: Annotated[
-        str | None,
+        Optional[str],
         typer.Option(
             "--dev-spec",
             envvar="BAKERY_DEV_SPEC",
             help='JSON spec for a dispatched dev build. Ex: \'{"version": "2026.05.0-dev+185-gSHA", "channel": "daily"}\'',
             rich_help_panel=RichHelpPanelEnum.FILTERS,
+            callback=_parse_dev_spec,
         ),
     ] = None,
 ) -> None:
@@ -235,12 +247,6 @@ def build(
         log.warning("--dev-stream is deprecated, use --dev-channel instead.")
         if dev_channel is None:
             dev_channel = dev_stream
-    parsed_dev_spec: DevBuildSpec | None = None
-    if dev_spec:
-        try:
-            parsed_dev_spec = DevBuildSpec.model_validate_json(dev_spec)
-        except Exception as e:
-            raise typer.BadParameter(f"--dev-spec is not valid JSON: {e}", param_hint="--dev-spec") from e
     settings = BakerySettings(
         filter=BakeryConfigFilter(
             image_name=image_name,
@@ -256,7 +262,7 @@ def build(
         clean_temporary=clean,
         cache_registry=cache_registry,
         temp_registry=temp_registry,
-        dev_spec=parsed_dev_spec,
+        dev_spec=dev_spec,  # type: ignore[arg-type]
     )
 
     config: BakeryConfig = BakeryConfig.from_context(context, settings)

--- a/posit-bakery/posit_bakery/cli/build.py
+++ b/posit-bakery/posit_bakery/cli/build.py
@@ -1,3 +1,4 @@
+import logging
 from enum import Enum
 from pathlib import Path
 from typing import Annotated, Optional
@@ -8,12 +9,15 @@ import typer
 from posit_bakery.cli.common import with_verbosity_flags, with_temporary_storage
 from posit_bakery.config import BakeryConfig
 from posit_bakery.config.config import BakeryConfigFilter, BakerySettings
+from posit_bakery.config.image.dev_version.spec import DevBuildSpec
 from posit_bakery.config.image.posit_product.const import ReleaseChannelEnum
 from posit_bakery.const import DevVersionInclusionEnum, MatrixVersionInclusionEnum
 from posit_bakery.error import BakeryBuildErrorGroup, BakeryToolRuntimeError
 from posit_bakery.image import ImageBuildStrategy
 from posit_bakery.log import stderr_console, stdout_console
 from posit_bakery.util import auto_path
+
+log = logging.getLogger(__name__)
 
 
 class RichHelpPanelEnum(str, Enum):
@@ -208,6 +212,15 @@ def build(
             rich_help_panel=RichHelpPanelEnum.FILTERS,
         ),
     ] = False,
+    dev_spec: Annotated[
+        str | None,
+        typer.Option(
+            "--dev-spec",
+            envvar="BAKERY_DEV_SPEC",
+            help='JSON spec for a dispatched dev build. Ex: \'{"version": "2026.05.0-dev+185-gSHA", "channel": "daily"}\'',
+            rich_help_panel=RichHelpPanelEnum.FILTERS,
+        ),
+    ] = None,
 ) -> None:
     """Builds images in the context path
 
@@ -222,6 +235,12 @@ def build(
         log.warning("--dev-stream is deprecated, use --dev-channel instead.")
         if dev_channel is None:
             dev_channel = dev_stream
+    parsed_dev_spec: DevBuildSpec | None = None
+    if dev_spec:
+        try:
+            parsed_dev_spec = DevBuildSpec.model_validate_json(dev_spec)
+        except Exception as e:
+            raise typer.BadParameter(f"--dev-spec is not valid JSON: {e}", param_hint="--dev-spec") from e
     settings = BakerySettings(
         filter=BakeryConfigFilter(
             image_name=image_name,
@@ -237,6 +256,7 @@ def build(
         clean_temporary=clean,
         cache_registry=cache_registry,
         temp_registry=temp_registry,
+        dev_spec=parsed_dev_spec,
     )
 
     config: BakeryConfig = BakeryConfig.from_context(context, settings)

--- a/posit-bakery/posit_bakery/cli/build.py
+++ b/posit-bakery/posit_bakery/cli/build.py
@@ -6,7 +6,7 @@ from typing import Annotated, Optional
 import python_on_whales
 import typer
 
-from posit_bakery.cli.common import with_verbosity_flags, with_temporary_storage
+from posit_bakery.cli.common import with_verbosity_flags, with_temporary_storage, parse_dev_spec
 from posit_bakery.config import BakeryConfig
 from posit_bakery.config.config import BakeryConfigFilter, BakerySettings
 from posit_bakery.config.image.dev_version.spec import DevBuildSpec
@@ -18,17 +18,6 @@ from posit_bakery.log import stderr_console, stdout_console
 from posit_bakery.util import auto_path
 
 log = logging.getLogger(__name__)
-
-
-def _parse_dev_spec(ctx: typer.Context, param: typer.CallbackParam, value: str | None) -> DevBuildSpec | None:
-    if value is None:
-        return None
-    from pydantic import ValidationError
-
-    try:
-        return DevBuildSpec.model_validate_json(value)
-    except ValidationError as e:
-        raise typer.BadParameter(str(e), ctx=ctx, param=param) from e
 
 
 class RichHelpPanelEnum(str, Enum):
@@ -224,13 +213,13 @@ def build(
         ),
     ] = False,
     dev_spec: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(
             "--dev-spec",
             envvar="BAKERY_DEV_SPEC",
             help='JSON spec for a dispatched dev build. Ex: \'{"version": "2026.05.0-dev+185-gSHA", "channel": "daily"}\'',
             rich_help_panel=RichHelpPanelEnum.FILTERS,
-            callback=_parse_dev_spec,
+            callback=parse_dev_spec,
         ),
     ] = None,
 ) -> None:
@@ -262,7 +251,7 @@ def build(
         clean_temporary=clean,
         cache_registry=cache_registry,
         temp_registry=temp_registry,
-        dev_spec=dev_spec,  # type: ignore[arg-type]
+        dev_spec=dev_spec,  # type: ignore[arg-type]  # typer requires str annotation; parse_dev_spec callback delivers DevBuildSpec at runtime
     )
 
     config: BakeryConfig = BakeryConfig.from_context(context, settings)

--- a/posit-bakery/posit_bakery/cli/ci.py
+++ b/posit-bakery/posit_bakery/cli/ci.py
@@ -22,6 +22,17 @@ app = typer.Typer(no_args_is_help=True)
 log = logging.getLogger(__name__)
 
 
+def _parse_dev_spec(ctx: typer.Context, param: typer.CallbackParam, value: str | None) -> DevBuildSpec | None:
+    if value is None:
+        return None
+    from pydantic import ValidationError
+
+    try:
+        return DevBuildSpec.model_validate_json(value)
+    except ValidationError as e:
+        raise typer.BadParameter(str(e), ctx=ctx, param=param) from e
+
+
 class RichHelpPanelEnum(str, Enum):
     """Enum for categorizing options into rich help panels."""
 
@@ -92,12 +103,13 @@ def matrix(
         ),
     ] = auto_path(),
     dev_spec: Annotated[
-        str | None,
+        Optional[str],
         typer.Option(
             "--dev-spec",
             envvar="BAKERY_DEV_SPEC",
             help='JSON spec for a dispatched dev build. Ex: \'{"version": "2026.05.0-dev+185-gSHA", "channel": "daily"}\'',
             rich_help_panel=RichHelpPanelEnum.FILTERS,
+            callback=_parse_dev_spec,
         ),
     ] = None,
 ) -> None:
@@ -124,18 +136,12 @@ def matrix(
         log.warning("--dev-stream is deprecated, use --dev-channel instead.")
         if dev_channel is None:
             dev_channel = dev_stream
-    parsed_dev_spec: DevBuildSpec | None = None
-    if dev_spec:
-        try:
-            parsed_dev_spec = DevBuildSpec.model_validate_json(dev_spec)
-        except Exception as e:
-            raise typer.BadParameter(f"--dev-spec is not valid JSON: {e}", param_hint="--dev-spec") from e
     try:
         settings = BakerySettings(
             filter=BakeryConfigFilter(image_name=image_name),
             dev_versions=dev_versions,
             dev_channel=dev_channel,
-            dev_spec=parsed_dev_spec,
+            dev_spec=dev_spec,  # type: ignore[arg-type]
         )
         c = BakeryConfig.from_context(context=context, settings=settings)
         images = [i for i in c.model.images]

--- a/posit-bakery/posit_bakery/cli/ci.py
+++ b/posit-bakery/posit_bakery/cli/ci.py
@@ -8,7 +8,7 @@ from typing import Annotated, Optional
 
 import typer
 
-from posit_bakery.cli.common import with_verbosity_flags
+from posit_bakery.cli.common import with_verbosity_flags, parse_dev_spec
 from posit_bakery.config import BakeryConfig
 from posit_bakery.config.config import BakerySettings, BakeryConfigFilter, version_matches
 from posit_bakery.config.image.dev_version.spec import DevBuildSpec
@@ -20,17 +20,6 @@ from posit_bakery.util import auto_path
 
 app = typer.Typer(no_args_is_help=True)
 log = logging.getLogger(__name__)
-
-
-def _parse_dev_spec(ctx: typer.Context, param: typer.CallbackParam, value: str | None) -> DevBuildSpec | None:
-    if value is None:
-        return None
-    from pydantic import ValidationError
-
-    try:
-        return DevBuildSpec.model_validate_json(value)
-    except ValidationError as e:
-        raise typer.BadParameter(str(e), ctx=ctx, param=param) from e
 
 
 class RichHelpPanelEnum(str, Enum):
@@ -103,13 +92,13 @@ def matrix(
         ),
     ] = auto_path(),
     dev_spec: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(
             "--dev-spec",
             envvar="BAKERY_DEV_SPEC",
             help='JSON spec for a dispatched dev build. Ex: \'{"version": "2026.05.0-dev+185-gSHA", "channel": "daily"}\'',
             rich_help_panel=RichHelpPanelEnum.FILTERS,
-            callback=_parse_dev_spec,
+            callback=parse_dev_spec,
         ),
     ] = None,
 ) -> None:
@@ -141,7 +130,7 @@ def matrix(
             filter=BakeryConfigFilter(image_name=image_name),
             dev_versions=dev_versions,
             dev_channel=dev_channel,
-            dev_spec=dev_spec,  # type: ignore[arg-type]
+            dev_spec=dev_spec,  # type: ignore[arg-type]  # typer requires str annotation; parse_dev_spec callback delivers DevBuildSpec at runtime
         )
         c = BakeryConfig.from_context(context=context, settings=settings)
         images = [i for i in c.model.images]

--- a/posit-bakery/posit_bakery/cli/ci.py
+++ b/posit-bakery/posit_bakery/cli/ci.py
@@ -11,6 +11,7 @@ import typer
 from posit_bakery.cli.common import with_verbosity_flags
 from posit_bakery.config import BakeryConfig
 from posit_bakery.config.config import BakerySettings, BakeryConfigFilter, version_matches
+from posit_bakery.config.image.dev_version.spec import DevBuildSpec
 from posit_bakery.config.image.posit_product.const import ReleaseChannelEnum
 from posit_bakery.const import DevVersionInclusionEnum, MatrixVersionInclusionEnum
 from posit_bakery.log import stderr_console, stdout_console
@@ -90,6 +91,15 @@ def matrix(
             help="The root path to use. Defaults to the current working directory where invoked.",
         ),
     ] = auto_path(),
+    dev_spec: Annotated[
+        str | None,
+        typer.Option(
+            "--dev-spec",
+            envvar="BAKERY_DEV_SPEC",
+            help='JSON spec for a dispatched dev build. Ex: \'{"version": "2026.05.0-dev+185-gSHA", "channel": "daily"}\'',
+            rich_help_panel=RichHelpPanelEnum.FILTERS,
+        ),
+    ] = None,
 ) -> None:
     """Generates a JSON matrix of image versions for CI workflows to consume
 
@@ -114,11 +124,18 @@ def matrix(
         log.warning("--dev-stream is deprecated, use --dev-channel instead.")
         if dev_channel is None:
             dev_channel = dev_stream
+    parsed_dev_spec: DevBuildSpec | None = None
+    if dev_spec:
+        try:
+            parsed_dev_spec = DevBuildSpec.model_validate_json(dev_spec)
+        except Exception as e:
+            raise typer.BadParameter(f"--dev-spec is not valid JSON: {e}", param_hint="--dev-spec") from e
     try:
         settings = BakerySettings(
             filter=BakeryConfigFilter(image_name=image_name),
             dev_versions=dev_versions,
             dev_channel=dev_channel,
+            dev_spec=parsed_dev_spec,
         )
         c = BakeryConfig.from_context(context=context, settings=settings)
         images = [i for i in c.model.images]

--- a/posit-bakery/posit_bakery/cli/ci.py
+++ b/posit-bakery/posit_bakery/cli/ci.py
@@ -11,7 +11,6 @@ import typer
 from posit_bakery.cli.common import with_verbosity_flags, parse_dev_spec
 from posit_bakery.config import BakeryConfig
 from posit_bakery.config.config import BakerySettings, BakeryConfigFilter, version_matches
-from posit_bakery.config.image.dev_version.spec import DevBuildSpec
 from posit_bakery.config.image.posit_product.const import ReleaseChannelEnum
 from posit_bakery.const import DevVersionInclusionEnum, MatrixVersionInclusionEnum
 from posit_bakery.log import stderr_console, stdout_console

--- a/posit-bakery/posit_bakery/cli/common.py
+++ b/posit-bakery/posit_bakery/cli/common.py
@@ -26,11 +26,7 @@ def parse_dev_spec(ctx: typer.Context, param: typer.CallbackParam, value: str | 
     if value is None:
         return None
     try:
-        data = json.loads(value)
-    except json.JSONDecodeError as e:
-        raise typer.BadParameter(f"not valid JSON: {e}", ctx=ctx, param=param) from e
-    try:
-        return DevBuildSpec.model_validate(data)
+        return DevBuildSpec.model_validate_json(value)
     except ValidationError as e:
         raise typer.BadParameter(str(e), ctx=ctx, param=param) from e
 

--- a/posit-bakery/posit_bakery/cli/common.py
+++ b/posit-bakery/posit_bakery/cli/common.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Annotated, Optional, Any
 
 import typer
+from pydantic import ValidationError
 
 from posit_bakery.config.dependencies import (
     get_dependency_versions_class,
@@ -14,10 +15,24 @@ from posit_bakery.config.dependencies import (
     DependencyConstraint,
     DependencyVersions,
 )
+from posit_bakery.config.image.dev_version.spec import DevBuildSpec
 from posit_bakery.log import init_logging
 from posit_bakery.settings import SETTINGS
 
 log = logging.getLogger(__name__)
+
+
+def parse_dev_spec(ctx: typer.Context, param: typer.CallbackParam, value: str | None) -> DevBuildSpec | None:
+    if value is None:
+        return None
+    try:
+        data = json.loads(value)
+    except json.JSONDecodeError as e:
+        raise typer.BadParameter(f"not valid JSON: {e}", ctx=ctx, param=param) from e
+    try:
+        return DevBuildSpec.model_validate(data)
+    except ValidationError as e:
+        raise typer.BadParameter(str(e), ctx=ctx, param=param) from e
 
 
 def with_verbosity_flags(fn):

--- a/posit-bakery/posit_bakery/config/config.py
+++ b/posit-bakery/posit_bakery/config/config.py
@@ -384,7 +384,21 @@ def _apply_dev_spec(image: Image, settings: "BakerySettings") -> None:
     Called before load_dev_versions() so the pinned version is set
     when resolution runs.
     """
+    # Local import to avoid circular import.
     from posit_bakery.config.image.dev_version.stream import ImageDevelopmentVersionFromProductStream
+
+    # Validate channel consistency: if both are set and differ, the pinned version
+    # would be filtered out by --dev-channel. Fail loudly instead of silently skipping.
+    if (
+        settings.dev_spec.channel is not None
+        and settings.dev_channel is not None
+        and settings.dev_spec.channel != settings.dev_channel
+    ):
+        raise ValueError(
+            f"Conflicting channels: --dev-spec has channel '{settings.dev_spec.channel.value}' "
+            f"but --dev-channel is '{settings.dev_channel.value}'. "
+            f"Either omit 'channel' from --dev-spec or ensure they match."
+        )
 
     target_channel = settings.dev_spec.channel or settings.dev_channel
     candidates = [

--- a/posit-bakery/posit_bakery/config/config.py
+++ b/posit-bakery/posit_bakery/config/config.py
@@ -385,7 +385,7 @@ def _apply_dev_spec(image: Image, settings: BakerySettings) -> None:
     when resolution runs.
     """
     # Local import to avoid circular import.
-    from posit_bakery.config.image.dev_version.channel import ImageDevelopmentVersionFromProductStream
+    from posit_bakery.config.image.dev_version.channel import ImageDevelopmentVersionFromProductChannel
 
     # Validate channel consistency: if both are set and differ, the pinned version
     # would be filtered out by --dev-channel. Fail loudly instead of silently skipping.
@@ -404,7 +404,7 @@ def _apply_dev_spec(image: Image, settings: BakerySettings) -> None:
     candidates = [
         dv
         for dv in image.devVersions
-        if isinstance(dv, ImageDevelopmentVersionFromProductStream)
+        if isinstance(dv, ImageDevelopmentVersionFromProductChannel)
         and (target_channel is None or dv.channel == target_channel)
     ]
     if not candidates:
@@ -415,7 +415,7 @@ def _apply_dev_spec(image: Image, settings: BakerySettings) -> None:
             f"channel '{target_channel}'. Specify 'channel' in --dev-spec or pass "
             f"--dev-channel to disambiguate."
         )
-    candidates[0].pinned_version = settings.dev_spec.version
+    candidates[0].version_override = settings.dev_spec.version
 
 
 class BakeryConfig:

--- a/posit-bakery/posit_bakery/config/config.py
+++ b/posit-bakery/posit_bakery/config/config.py
@@ -26,6 +26,7 @@ from posit_bakery.config.repository import Repository
 from posit_bakery.config.shared import BakeryPathMixin, BakeryYAMLModel
 from posit_bakery.config.templating import TPL_CONTAINERFILE, TPL_BAKERY_CONFIG_YAML
 from posit_bakery.config.templating.render import jinja2_env, normalize_rendered_output
+from posit_bakery.config.image.dev_version.spec import DevBuildSpec
 from posit_bakery.config.image.parsed_version import ParsedVersion
 from posit_bakery.config.image.posit_product.const import ReleaseChannelEnum
 from posit_bakery.const import DEFAULT_BASE_IMAGE, DevVersionInclusionEnum, MatrixVersionInclusionEnum
@@ -314,6 +315,14 @@ class BakerySettings(BaseModel):
             description="Filter development versions to a specific release channel.",
         ),
     ] = None
+    dev_spec: Annotated[
+        DevBuildSpec | None,
+        Field(
+            default=None,
+            description="Pinned dev build spec from a workflow dispatch. When set, overrides "
+            "CDN discovery for the matching channel dev version.",
+        ),
+    ] = None
 
     @model_validator(mode="before")
     @classmethod
@@ -369,6 +378,32 @@ class BakerySettings(BaseModel):
     temp_registry: Annotated[str | None, Field(description="Registry to use for image build temp cache.", default=None)]
 
 
+def _apply_dev_spec(image: Image, settings: "BakerySettings") -> None:
+    """Pin the dispatched version onto the matching stream dev version.
+
+    Called before load_dev_versions() so the pinned version is set
+    when resolution runs.
+    """
+    from posit_bakery.config.image.dev_version.stream import ImageDevelopmentVersionFromProductStream
+
+    target_channel = settings.dev_spec.channel or settings.dev_channel
+    candidates = [
+        dv
+        for dv in image.devVersions
+        if isinstance(dv, ImageDevelopmentVersionFromProductStream)
+        and (target_channel is None or dv.channel == target_channel)
+    ]
+    if not candidates:
+        return
+    if len(candidates) > 1:
+        raise ValueError(
+            f"Image '{image.name}' has {len(candidates)} dev versions matching "
+            f"channel '{target_channel}'. Specify 'channel' in --dev-spec or pass "
+            f"--dev-channel to disambiguate."
+        )
+    candidates[0].pinned_version = settings.dev_spec.version
+
+
 class BakeryConfig:
     """Manager for the bakery.yaml configuration file and operations against the configuration.
 
@@ -421,6 +456,9 @@ class BakeryConfig:
             )
 
         if self.settings.dev_versions in [DevVersionInclusionEnum.ONLY, DevVersionInclusionEnum.INCLUDE]:
+            if self.settings.dev_spec is not None:
+                for image in self.model.images:
+                    _apply_dev_spec(image, self.settings)
             for image in self.model.images:
                 image.load_dev_versions()
                 image.render_ephemeral_version_files()

--- a/posit-bakery/posit_bakery/config/config.py
+++ b/posit-bakery/posit_bakery/config/config.py
@@ -385,7 +385,7 @@ def _apply_dev_spec(image: Image, settings: "BakerySettings") -> None:
     when resolution runs.
     """
     # Local import to avoid circular import.
-    from posit_bakery.config.image.dev_version.stream import ImageDevelopmentVersionFromProductStream
+    from posit_bakery.config.image.dev_version.channel import ImageDevelopmentVersionFromProductStream
 
     # Validate channel consistency: if both are set and differ, the pinned version
     # would be filtered out by --dev-channel. Fail loudly instead of silently skipping.

--- a/posit-bakery/posit_bakery/config/config.py
+++ b/posit-bakery/posit_bakery/config/config.py
@@ -378,7 +378,7 @@ class BakerySettings(BaseModel):
     temp_registry: Annotated[str | None, Field(description="Registry to use for image build temp cache.", default=None)]
 
 
-def _apply_dev_spec(image: Image, settings: "BakerySettings") -> None:
+def _apply_dev_spec(image: Image, settings: BakerySettings) -> None:
     """Pin the dispatched version onto the matching channel dev version.
 
     Called before load_dev_versions() so the pinned version is set

--- a/posit-bakery/posit_bakery/config/config.py
+++ b/posit-bakery/posit_bakery/config/config.py
@@ -329,7 +329,7 @@ class BakerySettings(BaseModel):
     def migrate_dev_stream_to_dev_channel(cls, data: Any) -> Any:
         if not isinstance(data, dict):
             return data
-        if "dev_stream" in data and "dev_channel" not in data:
+        if "dev_stream" in data and data.get("dev_channel") is None:
             import warnings
 
             warnings.warn(

--- a/posit-bakery/posit_bakery/config/config.py
+++ b/posit-bakery/posit_bakery/config/config.py
@@ -379,7 +379,7 @@ class BakerySettings(BaseModel):
 
 
 def _apply_dev_spec(image: Image, settings: "BakerySettings") -> None:
-    """Pin the dispatched version onto the matching stream dev version.
+    """Pin the dispatched version onto the matching channel dev version.
 
     Called before load_dev_versions() so the pinned version is set
     when resolution runs.

--- a/posit-bakery/posit_bakery/config/image/dev_version/channel.py
+++ b/posit-bakery/posit_bakery/config/image/dev_version/channel.py
@@ -31,7 +31,7 @@ class ImageDevelopmentVersionFromProductChannel(BaseImageDevelopmentVersion):
             "get_version().",
         ),
     ]
-    pinned_version: Annotated[
+    version_override: Annotated[
         str | None,
         Field(
             exclude=True,
@@ -65,14 +65,14 @@ class ImageDevelopmentVersionFromProductChannel(BaseImageDevelopmentVersion):
     def get_version(self) -> str:
         """Retrieve the version from the specified product channel.
 
-        If pinned_version is set, returns it immediately without a network call.
+        If version_override is set, returns it immediately without a network call.
         If _resolve_os_urls() has already been called, returns the cached
         version. Otherwise fetches it from the primary OS channel.
 
         :return: The version string from the product channel.
         """
-        if self.pinned_version is not None:
-            return self.pinned_version
+        if self.version_override is not None:
+            return self.version_override
         if self.resolved_version is not None:
             return self.resolved_version
         _os = self.get_primary_os()
@@ -113,7 +113,7 @@ class ImageDevelopmentVersionFromProductChannel(BaseImageDevelopmentVersion):
                     self.product,
                     self.channel,
                     os_version.buildOS,
-                    version_override=self.pinned_version,
+                    version_override=self.version_override,
                 )
                 if generalize:
                     os_version.artifactDownloadURL = str(result.architecture_generalized_download_url)

--- a/posit-bakery/posit_bakery/config/image/dev_version/channel.py
+++ b/posit-bakery/posit_bakery/config/image/dev_version/channel.py
@@ -102,7 +102,7 @@ class ImageDevelopmentVersionFromProductChannel(BaseImageDevelopmentVersion):
         that get_version() can return it without a redundant fetch.
         """
         # Local import avoids a circular import between channel.py and main.py.
-        from posit_bakery.config.image.posit_product.main import DispatchVersionMismatchError
+        from posit_bakery.config.image.posit_product.errors import DispatchVersionMismatchError
 
         self.resolved_version = None
         resolved = []

--- a/posit-bakery/posit_bakery/config/image/dev_version/channel.py
+++ b/posit-bakery/posit_bakery/config/image/dev_version/channel.py
@@ -31,6 +31,16 @@ class ImageDevelopmentVersionFromProductChannel(BaseImageDevelopmentVersion):
             "get_version().",
         ),
     ]
+    pinned_version: Annotated[
+        str | None,
+        Field(
+            exclude=True,
+            default=None,
+            description="Version pinned by a workflow dispatch spec. When set, bypasses CDN "
+            "discovery and is forwarded to the stream resolver for offline template rendering "
+            "(PPM) or manifest assertion (Connect, Workbench).",
+        ),
+    ]
 
     @model_validator(mode="before")
     @classmethod
@@ -55,11 +65,14 @@ class ImageDevelopmentVersionFromProductChannel(BaseImageDevelopmentVersion):
     def get_version(self) -> str:
         """Retrieve the version from the specified product channel.
 
+        If pinned_version is set, returns it immediately without a network call.
         If _resolve_os_urls() has already been called, returns the cached
         version. Otherwise fetches it from the primary OS channel.
 
         :return: The version string from the product channel.
         """
+        if self.pinned_version is not None:
+            return self.pinned_version
         if self.resolved_version is not None:
             return self.resolved_version
         _os = self.get_primary_os()
@@ -88,12 +101,20 @@ class ImageDevelopmentVersionFromProductChannel(BaseImageDevelopmentVersion):
         Caches the version from the first successfully resolved OS so
         that get_version() can return it without a redundant fetch.
         """
+        # Local import avoids a circular import between channel.py and main.py.
+        from posit_bakery.config.image.posit_product.main import DispatchVersionMismatchError
+
         self.resolved_version = None
         resolved = []
         for os_version in self.os:
             try:
                 generalize = os_version.platforms != DEFAULT_PLATFORMS
-                result = get_product_artifact_by_channel(self.product, self.channel, os_version.buildOS)
+                result = get_product_artifact_by_channel(
+                    self.product,
+                    self.channel,
+                    os_version.buildOS,
+                    version_override=self.pinned_version,
+                )
                 if generalize:
                     os_version.artifactDownloadURL = str(result.architecture_generalized_download_url)
                 else:
@@ -101,6 +122,8 @@ class ImageDevelopmentVersionFromProductChannel(BaseImageDevelopmentVersion):
                 if self.resolved_version is None:
                     self.resolved_version = result.version
                 resolved.append(os_version)
+            except DispatchVersionMismatchError:
+                raise
             except (ValueError, ValidationError, requests.RequestException) as e:
                 log.warning(f"Excluding OS '{os_version.name}' from {repr(self)}: {e}")
         return resolved

--- a/posit-bakery/posit_bakery/config/image/dev_version/channel.py
+++ b/posit-bakery/posit_bakery/config/image/dev_version/channel.py
@@ -37,7 +37,7 @@ class ImageDevelopmentVersionFromProductChannel(BaseImageDevelopmentVersion):
             exclude=True,
             default=None,
             description="Version pinned by a workflow dispatch spec. When set, bypasses CDN "
-            "discovery and is forwarded to the stream resolver for offline template rendering "
+            "discovery and is forwarded to the channel resolver for offline template rendering "
             "(PPM) or manifest assertion (Connect, Workbench).",
         ),
     ]

--- a/posit-bakery/posit_bakery/config/image/dev_version/spec.py
+++ b/posit-bakery/posit_bakery/config/image/dev_version/spec.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, ConfigDict, field_validator
 
 from posit_bakery.config.image.posit_product.const import ReleaseChannelEnum
 
@@ -6,12 +6,15 @@ from posit_bakery.config.image.posit_product.const import ReleaseChannelEnum
 class DevBuildSpec(BaseModel):
     """Typed payload for a workflow-dispatched dev build."""
 
+    model_config = ConfigDict(extra="forbid")
+
     version: str
     channel: ReleaseChannelEnum | None = None
 
     @field_validator("version")
     @classmethod
     def version_not_empty(cls, v: str) -> str:
-        if not v.strip():
+        v = v.strip()
+        if not v:
             raise ValueError("version must not be empty")
         return v

--- a/posit-bakery/posit_bakery/config/image/dev_version/spec.py
+++ b/posit-bakery/posit_bakery/config/image/dev_version/spec.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel, field_validator
+
+from posit_bakery.config.image.posit_product.const import ReleaseChannelEnum
+
+
+class DevBuildSpec(BaseModel):
+    """Typed payload for a workflow-dispatched dev build."""
+
+    version: str
+    channel: ReleaseChannelEnum | None = None
+
+    @field_validator("version")
+    @classmethod
+    def version_not_empty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("version must not be empty")
+        return v

--- a/posit-bakery/posit_bakery/config/image/posit_product/errors.py
+++ b/posit-bakery/posit_bakery/config/image/posit_product/errors.py
@@ -1,0 +1,6 @@
+class DispatchVersionMismatchError(Exception):
+    """Raised when a dispatched version override does not match the upstream manifest.
+
+    Must NOT subclass ValueError or RequestException so it escapes the per-OS
+    catch in _resolve_os_urls and the skip-on-error catch in load_dev_versions.
+    """

--- a/posit-bakery/posit_bakery/config/image/posit_product/main.py
+++ b/posit-bakery/posit_bakery/config/image/posit_product/main.py
@@ -17,16 +17,9 @@ from posit_bakery.config.image.posit_product.const import (
     CONNECT_DAILY_URL,
     DOWNLOADS_JSON_URL,
 )
+from posit_bakery.config.image.posit_product.errors import DispatchVersionMismatchError
 from posit_bakery.config.shared import OSFamilyEnum
 from posit_bakery.util import cached_session
-
-
-class DispatchVersionMismatchError(Exception):
-    """Raised when a dispatched version override does not match the upstream manifest.
-
-    Must NOT subclass ValueError or RequestException so it escapes the per-OS
-    catch in _resolve_os_urls and the skip-on-error catch in load_dev_versions.
-    """
 
 
 class ReleaseChannelResult(BaseModel):

--- a/posit-bakery/posit_bakery/config/image/posit_product/main.py
+++ b/posit-bakery/posit_bakery/config/image/posit_product/main.py
@@ -67,7 +67,6 @@ class ReleaseChannelPath:
                     result[key] = resolver.format(**metadata, **result, **url_safe_result)
             return ReleaseChannelResult(**result)
 
-
         session = cached_session()
         response = session.get(self.channel_url)
         response.raise_for_status()

--- a/posit-bakery/posit_bakery/config/image/posit_product/main.py
+++ b/posit-bakery/posit_bakery/config/image/posit_product/main.py
@@ -293,7 +293,6 @@ def get_product_artifact_by_channel(
     product: ProductEnum,
     channel: ReleaseChannelEnum,
     os: BuildOS,
-    generalize_arch: bool = True,
     version_override: str | None = None,
 ) -> ReleaseChannelResult:
     """Fetches the version and download URL for a given product, release channel, and OS."""

--- a/posit-bakery/posit_bakery/config/image/posit_product/main.py
+++ b/posit-bakery/posit_bakery/config/image/posit_product/main.py
@@ -21,6 +21,14 @@ from posit_bakery.config.shared import OSFamilyEnum
 from posit_bakery.util import cached_session
 
 
+class DispatchVersionMismatchError(Exception):
+    """Raised when a dispatched version override does not match the upstream manifest.
+
+    Must NOT subclass ValueError or RequestException so it escapes the per-OS
+    catch in _resolve_os_urls and the skip-on-error catch in load_dev_versions.
+    """
+
+
 class ReleaseChannelResult(BaseModel):
     """Represents a resulting artifact found in a release channel. This provides an easy validation for data we get."""
 
@@ -37,12 +45,29 @@ class ReleaseChannelResult(BaseModel):
 class ReleaseChannelPath:
     """Represents a path to a release channel and a map of resolvers to extract data from the fetched data."""
 
-    def __init__(self, channel_url: str, resolver_map: dict[str, resolvers.AbstractResolver | str]):
+    def __init__(
+        self,
+        channel_url: str,
+        resolver_map: dict[str, resolvers.AbstractResolver | str],
+        version_templatable: bool = False,
+    ):
         self.channel_url = channel_url
         self.resolver_map = resolver_map
+        self.version_templatable = version_templatable
 
-    def get(self, metadata: dict) -> ReleaseChannelResult:
+    def get(self, metadata: dict, version_override: str | None = None) -> ReleaseChannelResult:
         """Fetches data from the channel URL and resolves the data using the given resolvers."""
+        if version_override is not None and self.version_templatable:
+            result: dict = {"version": version_override}
+            url_safe_result = {f"url_safe_{k}": quote(str(v), safe="") for k, v in result.items()}
+            for key, resolver in self.resolver_map.items():
+                if key == "version":
+                    continue
+                if isinstance(resolver, str):
+                    result[key] = resolver.format(**metadata, **result, **url_safe_result)
+            return ReleaseChannelResult(**result)
+
+
         session = cached_session()
         response = session.get(self.channel_url)
         response.raise_for_status()
@@ -60,6 +85,13 @@ class ReleaseChannelPath:
             elif isinstance(resolver, resolvers.AbstractResolver):
                 resolver.set_metadata(metadata)
                 result[key] = resolver.resolve(data)
+
+        if version_override is not None and result.get("version") != version_override:
+            raise DispatchVersionMismatchError(
+                f"Dispatched version {version_override!r} does not match manifest version "
+                f"{result.get('version')!r} at {self.channel_url!r}. "
+                f"The upstream manifest has not propagated the dispatched build yet."
+            )
 
         return ReleaseChannelResult(**result)
 
@@ -119,6 +151,7 @@ product_release_channel_url_map = {
                     ),
                 ]
             ),
+            version_templatable=True,
         ),
         ReleaseChannelEnum.DAILY: ReleaseChannelPath(
             PACKAGE_MANAGER_DAILY_URL,
@@ -133,6 +166,7 @@ product_release_channel_url_map = {
                     ),
                 ]
             ),
+            version_templatable=True,
         ),
     },
     ProductEnum.WORKBENCH: {
@@ -257,7 +291,11 @@ def _make_resolver_metadata(_os: BuildOS, product: ProductEnum):
 
 
 def get_product_artifact_by_channel(
-    product: ProductEnum, channel: ReleaseChannelEnum, os: BuildOS, generalize_arch: bool = True
+    product: ProductEnum,
+    channel: ReleaseChannelEnum,
+    os: BuildOS,
+    generalize_arch: bool = True,
+    version_override: str | None = None,
 ) -> ReleaseChannelResult:
     """Fetches the version and download URL for a given product, release channel, and OS."""
     if product not in product_release_channel_url_map:
@@ -267,4 +305,4 @@ def get_product_artifact_by_channel(
 
     metadata = _make_resolver_metadata(os, product)
 
-    return product_release_channel_url_map[product][channel].get(metadata)
+    return product_release_channel_url_map[product][channel].get(metadata, version_override)

--- a/posit-bakery/posit_bakery/config/image/version.py
+++ b/posit-bakery/posit_bakery/config/image/version.py
@@ -148,8 +148,9 @@ class ImageVersion(BakeryPathMixin, BakeryYAMLModel):
             return False, "not a development version (excluded by --dev-versions only)"
         if dev_channel is not None and self.isDevelopmentVersion:
             version_channel = self.metadata.get("release_channel")
+            vc_str = version_channel.value if version_channel is not None else None
             if version_channel != dev_channel:
-                return False, (f"dev channel '{version_channel}' does not match --dev-channel '{dev_channel.value}'")
+                return False, f"dev channel '{vc_str}' does not match --dev-channel '{dev_channel.value}'"
         return True, None
 
     @field_validator("extraRegistries", "overrideRegistries", mode="after")

--- a/posit-bakery/test/cli/test_build.py
+++ b/posit-bakery/test/cli/test_build.py
@@ -11,6 +11,7 @@ from pytest_bdd import scenarios, then, parsers
 from typer.testing import CliRunner
 
 from posit_bakery.cli.main import app
+from posit_bakery.config.image.posit_product.errors import DispatchVersionMismatchError
 
 scenarios(
     "cli/build.feature",
@@ -29,6 +30,19 @@ def mock_build_config():
         instance.build_targets.return_value = None
         mock.from_context.return_value = instance
         yield mock
+
+
+class TestDispatchVersionMismatch:
+    def test_mismatch_exits_with_clean_message(self):
+        """DispatchVersionMismatchError should print a plain message, not a traceback."""
+        msg = "Dispatched version '9999.99.0' does not match manifest version '2026.04.0'"
+        with patch("posit_bakery.cli.build.BakeryConfig") as mock:
+            mock.from_context.side_effect = DispatchVersionMismatchError(msg)
+            result = runner.invoke(app, ["build", "--context", BASIC_CONTEXT], catch_exceptions=False)
+
+        assert result.exit_code == 1
+        assert msg in result.output
+        assert "Traceback" not in result.output
 
 
 class TestBuildLatestFlag:

--- a/posit-bakery/test/cli/test_dev_spec.py
+++ b/posit-bakery/test/cli/test_dev_spec.py
@@ -24,12 +24,6 @@ def _settings_from_call(mock):
 
 
 class TestBuildDevSpec:
-    def _mock(self):
-        with patch("posit_bakery.cli.build.BakeryConfig") as mock:
-            instance = MagicMock()
-            mock.from_context.return_value = instance
-            yield mock
-
     def test_dev_spec_via_flag(self):
         """--dev-spec JSON is parsed and forwarded to BakerySettings."""
         with patch("posit_bakery.cli.build.BakeryConfig") as mock:

--- a/posit-bakery/test/cli/test_dev_spec.py
+++ b/posit-bakery/test/cli/test_dev_spec.py
@@ -1,0 +1,200 @@
+"""Tests for --dev-spec / BAKERY_DEV_SPEC flag in build and ci matrix commands."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from posit_bakery.cli.main import app
+from posit_bakery.config.image.dev_version.spec import DevBuildSpec
+from posit_bakery.config.image.posit_product.const import ReleaseChannelEnum
+
+runner = CliRunner()
+BASIC_CONTEXT = str(Path(__file__).parent.parent / "resources" / "basic")
+
+
+def _settings_from_call(mock):
+    """Extract the BakerySettings passed to BakeryConfig.from_context.
+
+    Handles both positional (build.py: from_context(context, settings))
+    and keyword (ci.py: from_context(context=context, settings=settings)) calls.
+    """
+    args, kwargs = mock.from_context.call_args
+    return kwargs.get("settings", args[1] if len(args) > 1 else None)
+
+
+class TestBuildDevSpec:
+    def _mock(self):
+        with patch("posit_bakery.cli.build.BakeryConfig") as mock:
+            instance = MagicMock()
+            mock.from_context.return_value = instance
+            yield mock
+
+    def test_dev_spec_via_flag(self):
+        """--dev-spec JSON is parsed and forwarded to BakerySettings."""
+        with patch("posit_bakery.cli.build.BakeryConfig") as mock:
+            instance = MagicMock()
+            mock.from_context.return_value = instance
+            result = runner.invoke(
+                app,
+                [
+                    "build",
+                    "--context",
+                    BASIC_CONTEXT,
+                    "--dev-versions",
+                    "only",
+                    "--dev-spec",
+                    '{"version": "2026.05.0-dev+185-gSHA", "channel": "daily"}',
+                ],
+                catch_exceptions=False,
+            )
+        assert result.exit_code == 0, result.output
+        settings = _settings_from_call(mock)
+        assert isinstance(settings.dev_spec, DevBuildSpec)
+        assert settings.dev_spec.version == "2026.05.0-dev+185-gSHA"
+        assert settings.dev_spec.channel == ReleaseChannelEnum.DAILY
+
+    def test_dev_spec_via_env_var(self):
+        """BAKERY_DEV_SPEC env var is equivalent to --dev-spec flag."""
+        with patch("posit_bakery.cli.build.BakeryConfig") as mock:
+            instance = MagicMock()
+            mock.from_context.return_value = instance
+            result = runner.invoke(
+                app,
+                ["build", "--context", BASIC_CONTEXT, "--dev-versions", "only"],
+                env={"BAKERY_DEV_SPEC": '{"version": "2026.05.0-dev+185-gSHA"}'},
+                catch_exceptions=False,
+            )
+        assert result.exit_code == 0, result.output
+        settings = _settings_from_call(mock)
+        assert isinstance(settings.dev_spec, DevBuildSpec)
+        assert settings.dev_spec.version == "2026.05.0-dev+185-gSHA"
+        assert settings.dev_spec.channel is None
+
+    def test_dev_spec_invalid_json_rejected(self):
+        """Invalid JSON in --dev-spec causes a non-zero exit."""
+        with patch("posit_bakery.cli.build.BakeryConfig") as mock:
+            mock.from_context.return_value = MagicMock()
+            result = runner.invoke(
+                app,
+                ["build", "--context", BASIC_CONTEXT, "--dev-spec", "not-json"],
+            )
+        assert result.exit_code != 0
+
+    def test_dev_spec_invalid_schema_rejected(self):
+        """JSON with unknown fields is rejected (extra='forbid' on DevBuildSpec)."""
+        with patch("posit_bakery.cli.build.BakeryConfig") as mock:
+            mock.from_context.return_value = MagicMock()
+            result = runner.invoke(
+                app,
+                [
+                    "build",
+                    "--context",
+                    BASIC_CONTEXT,
+                    "--dev-spec",
+                    '{"version": "1.0.0", "chanenl": "daily"}',
+                ],
+            )
+        assert result.exit_code != 0
+
+    def test_dev_spec_absent_is_none(self):
+        """When --dev-spec is not passed, BakerySettings.dev_spec is None."""
+        with patch("posit_bakery.cli.build.BakeryConfig") as mock:
+            instance = MagicMock()
+            mock.from_context.return_value = instance
+            result = runner.invoke(
+                app,
+                ["build", "--context", BASIC_CONTEXT],
+                catch_exceptions=False,
+            )
+        assert result.exit_code == 0, result.output
+        settings = _settings_from_call(mock)
+        assert settings.dev_spec is None
+
+
+class TestCiMatrixDevSpec:
+    def test_dev_spec_via_flag(self):
+        """--dev-spec JSON is parsed and forwarded to BakerySettings in ci matrix."""
+        with patch("posit_bakery.cli.ci.BakeryConfig") as mock:
+            instance = MagicMock()
+            instance.model.images = []
+            mock.from_context.return_value = instance
+            result = runner.invoke(
+                app,
+                [
+                    "ci",
+                    "matrix",
+                    "--context",
+                    BASIC_CONTEXT,
+                    "--dev-versions",
+                    "only",
+                    "--dev-spec",
+                    '{"version": "2026.05.0-dev+185-gSHA", "channel": "daily"}',
+                ],
+                catch_exceptions=False,
+            )
+        assert result.exit_code == 0, result.output
+        settings = _settings_from_call(mock)
+        assert isinstance(settings.dev_spec, DevBuildSpec)
+        assert settings.dev_spec.version == "2026.05.0-dev+185-gSHA"
+        assert settings.dev_spec.channel == ReleaseChannelEnum.DAILY
+
+    def test_dev_spec_via_env_var(self):
+        """BAKERY_DEV_SPEC env var works in ci matrix."""
+        with patch("posit_bakery.cli.ci.BakeryConfig") as mock:
+            instance = MagicMock()
+            instance.model.images = []
+            mock.from_context.return_value = instance
+            result = runner.invoke(
+                app,
+                ["ci", "matrix", "--context", BASIC_CONTEXT, "--dev-versions", "only"],
+                env={"BAKERY_DEV_SPEC": '{"version": "2026.05.0-dev+185-gSHA"}'},
+                catch_exceptions=False,
+            )
+        assert result.exit_code == 0, result.output
+        settings = _settings_from_call(mock)
+        assert isinstance(settings.dev_spec, DevBuildSpec)
+        assert settings.dev_spec.version == "2026.05.0-dev+185-gSHA"
+        assert settings.dev_spec.channel is None
+
+    def test_dev_spec_invalid_json_rejected(self):
+        """Invalid JSON in --dev-spec causes a non-zero exit in ci matrix."""
+        with patch("posit_bakery.cli.ci.BakeryConfig") as mock:
+            mock.from_context.return_value = MagicMock()
+            result = runner.invoke(
+                app,
+                ["ci", "matrix", "--context", BASIC_CONTEXT, "--dev-spec", "not-json"],
+            )
+        assert result.exit_code != 0
+
+    def test_dev_spec_invalid_schema_rejected(self):
+        """JSON with unknown fields is rejected (extra='forbid' on DevBuildSpec)."""
+        with patch("posit_bakery.cli.ci.BakeryConfig") as mock:
+            mock.from_context.return_value = MagicMock()
+            result = runner.invoke(
+                app,
+                [
+                    "ci",
+                    "matrix",
+                    "--context",
+                    BASIC_CONTEXT,
+                    "--dev-spec",
+                    '{"version": "1.0.0", "chanenl": "daily"}',
+                ],
+            )
+        assert result.exit_code != 0
+
+    def test_dev_spec_absent_is_none(self):
+        """When --dev-spec is not passed, BakerySettings.dev_spec is None."""
+        with patch("posit_bakery.cli.ci.BakeryConfig") as mock:
+            instance = MagicMock()
+            instance.model.images = []
+            mock.from_context.return_value = instance
+            result = runner.invoke(
+                app,
+                ["ci", "matrix", "--context", BASIC_CONTEXT],
+                catch_exceptions=False,
+            )
+        assert result.exit_code == 0, result.output
+        settings = _settings_from_call(mock)
+        assert settings.dev_spec is None

--- a/posit-bakery/test/config/image/dev_version/test_channel.py
+++ b/posit-bakery/test/config/image/dev_version/test_channel.py
@@ -413,7 +413,7 @@ class TestImageDevelopmentVersionFromProductChannel:
         )
         dv.pinned_version = "9999.99.0-daily+1.pro1"
         with patch(
-            "posit_bakery.config.image.dev_version.stream.get_product_artifact_by_stream",
+            "posit_bakery.config.image.dev_version.channel.get_product_artifact_by_channel",
             side_effect=DispatchVersionMismatchError("mismatch"),
         ):
             with pytest.raises(DispatchVersionMismatchError):

--- a/posit-bakery/test/config/image/dev_version/test_channel.py
+++ b/posit-bakery/test/config/image/dev_version/test_channel.py
@@ -388,15 +388,15 @@ class TestImageDevelopmentVersionFromProductChannel:
             url_by_os = dev_version.get_url_by_os(generalize_architecture=generalize_architecture)
             assert url_by_os[mock_os.name] == expected_url
 
-    def test_pinned_version_returned_by_get_version(self, patch_requests_get):
-        """When pinned_version is set, get_version() returns it without a network call."""
-        dv = ImageDevelopmentVersionFromProductStream(
+    def test_version_override_returned_by_get_version(self, patch_requests_get):
+        """When version_override is set, get_version() returns it without a network call."""
+        dv = ImageDevelopmentVersionFromProductChannel(
             sourceType="stream",
             product="package-manager",
             channel="daily",
             os=[{"name": "Ubuntu 24.04", "primary": True}],
         )
-        dv.pinned_version = "2026.05.0-dev+185-gSHA"
+        dv.version_override = "2026.05.0-dev+185-gSHA"
         assert dv.get_version() == "2026.05.0-dev+185-gSHA"
         patch_requests_get.assert_not_called()
 
@@ -405,13 +405,13 @@ class TestImageDevelopmentVersionFromProductChannel:
         from posit_bakery.config.image.posit_product.main import DispatchVersionMismatchError
         from unittest.mock import patch
 
-        dv = ImageDevelopmentVersionFromProductStream(
+        dv = ImageDevelopmentVersionFromProductChannel(
             sourceType="stream",
             product="workbench",
             channel="daily",
             os=[{"name": "Ubuntu 24.04", "primary": True}],
         )
-        dv.pinned_version = "9999.99.0-daily+1.pro1"
+        dv.version_override = "9999.99.0-daily+1.pro1"
         with patch(
             "posit_bakery.config.image.dev_version.channel.get_product_artifact_by_channel",
             side_effect=DispatchVersionMismatchError("mismatch"),

--- a/posit-bakery/test/config/image/dev_version/test_channel.py
+++ b/posit-bakery/test/config/image/dev_version/test_channel.py
@@ -388,6 +388,37 @@ class TestImageDevelopmentVersionFromProductChannel:
             url_by_os = dev_version.get_url_by_os(generalize_architecture=generalize_architecture)
             assert url_by_os[mock_os.name] == expected_url
 
+    def test_pinned_version_returned_by_get_version(self, patch_requests_get):
+        """When pinned_version is set, get_version() returns it without a network call."""
+        dv = ImageDevelopmentVersionFromProductStream(
+            sourceType="stream",
+            product="package-manager",
+            channel="daily",
+            os=[{"name": "Ubuntu 24.04", "primary": True}],
+        )
+        dv.pinned_version = "2026.05.0-dev+185-gSHA"
+        assert dv.get_version() == "2026.05.0-dev+185-gSHA"
+        patch_requests_get.assert_not_called()
+
+    def test_mismatch_error_propagates_through_resolve_os_urls(self):
+        """DispatchVersionMismatchError must NOT be swallowed by _resolve_os_urls."""
+        from posit_bakery.config.image.posit_product.main import DispatchVersionMismatchError
+        from unittest.mock import patch
+
+        dv = ImageDevelopmentVersionFromProductStream(
+            sourceType="stream",
+            product="workbench",
+            channel="daily",
+            os=[{"name": "Ubuntu 24.04", "primary": True}],
+        )
+        dv.pinned_version = "9999.99.0-daily+1.pro1"
+        with patch(
+            "posit_bakery.config.image.dev_version.stream.get_product_artifact_by_stream",
+            side_effect=DispatchVersionMismatchError("mismatch"),
+        ):
+            with pytest.raises(DispatchVersionMismatchError):
+                dv._resolve_os_urls()
+
 
 class TestByChannel:
     @pytest.mark.parametrize(
@@ -1002,7 +1033,7 @@ class TestResolveOsUrls:
     def test_excludes_os_on_resolution_failure(self):
         good = ReleaseChannelResult(version="1.0.0", download_url="https://example.com/good.deb")
 
-        def side_effect(product, channel, build_os):
+        def side_effect(product, channel, build_os, **kwargs):
             if build_os.version == "26.04":
                 raise ValueError("no packages for ubuntu26")
             return good
@@ -1071,7 +1102,7 @@ class TestResolveOsUrls:
     def test_primary_os_excluded_falls_back_to_secondary(self):
         good = ReleaseChannelResult(version="1.0.0", download_url="https://example.com/good.deb")
 
-        def side_effect(product, channel, build_os):
+        def side_effect(product, channel, build_os, **kwargs):
             if build_os.version == "26.04":
                 raise ValueError("no packages for ubuntu26")
             return good

--- a/posit-bakery/test/config/image/dev_version/test_spec.py
+++ b/posit-bakery/test/config/image/dev_version/test_spec.py
@@ -28,3 +28,13 @@ class TestDevBuildSpec:
     def test_empty_version_raises(self):
         with pytest.raises(ValidationError):
             DevBuildSpec(version="")
+        with pytest.raises(ValidationError):
+            DevBuildSpec(version="   ")
+
+    def test_whitespace_version_is_stripped(self):
+        spec = DevBuildSpec.model_validate_json('{"version": "  2026.05.0-dev+185-gSHA  "}')
+        assert spec.version == "2026.05.0-dev+185-gSHA"
+
+    def test_unknown_fields_raise(self):
+        with pytest.raises(ValidationError):
+            DevBuildSpec.model_validate_json('{"version": "2026.05.0-dev+1-gSHA", "chanenl": "daily"}')

--- a/posit-bakery/test/config/image/dev_version/test_spec.py
+++ b/posit-bakery/test/config/image/dev_version/test_spec.py
@@ -1,0 +1,30 @@
+import pytest
+from pydantic import ValidationError
+
+from posit_bakery.config.image.dev_version.spec import DevBuildSpec
+from posit_bakery.config.image.posit_product.const import ReleaseChannelEnum
+
+pytestmark = [pytest.mark.unit, pytest.mark.config]
+
+
+class TestDevBuildSpec:
+    def test_version_required(self):
+        with pytest.raises(ValidationError):
+            DevBuildSpec.model_validate_json("{}")
+
+    def test_minimal_valid(self):
+        spec = DevBuildSpec.model_validate_json('{"version": "2026.05.0-dev+185-gSHA"}')
+        assert spec.version == "2026.05.0-dev+185-gSHA"
+        assert spec.channel is None
+
+    def test_with_channel(self):
+        spec = DevBuildSpec.model_validate_json('{"version": "2026.05.0-dev+185-gSHA", "channel": "daily"}')
+        assert spec.channel == ReleaseChannelEnum.DAILY
+
+    def test_invalid_channel_raises(self):
+        with pytest.raises(ValidationError):
+            DevBuildSpec.model_validate_json('{"version": "2026.05.0-dev+185-gSHA", "channel": "nightly"}')
+
+    def test_empty_version_raises(self):
+        with pytest.raises(ValidationError):
+            DevBuildSpec(version="")

--- a/posit-bakery/test/config/image/posit_products/test_main.py
+++ b/posit-bakery/test/config/image/posit_products/test_main.py
@@ -783,3 +783,66 @@ class TestGetProductArtifactByChannel:
         output = get_product_artifact_by_channel(ProductEnum.WORKBENCH_SESSION, ReleaseStreamEnum.DAILY, _os)
         assert output.version == expected_version
         assert str(output.download_url) == expected_session_url
+
+
+class TestDispatchOverride:
+    def test_ppm_daily_override_renders_offline(self, mocker):
+        """Template streams must NOT hit the network when version_override is supplied."""
+        spy = mocker.patch("posit_bakery.config.image.posit_product.main.cached_session")
+        override = "2026.05.0-dev+185-g8a23833f57"
+        result = get_product_artifact_by_stream(
+            ProductEnum.PACKAGE_MANAGER,
+            ReleaseChannelEnum.DAILY,
+            SUPPORTED_OS["ubuntu"]["24"],
+            version_override=override,
+        )
+        spy.assert_not_called()
+        assert result.version == override
+        assert "2026.05.0-dev%2B185-g8a23833f57" in str(result.download_url)
+
+    def test_ppm_preview_override_renders_offline(self, mocker):
+        """Preview stream is also templatable — no network on override."""
+        spy = mocker.patch("posit_bakery.config.image.posit_product.main.cached_session")
+        override = "2026.05.0-dev+185-g8a23833f57"
+        result = get_product_artifact_by_stream(
+            ProductEnum.PACKAGE_MANAGER,
+            ReleaseChannelEnum.PREVIEW,
+            SUPPORTED_OS["ubuntu"]["24"],
+            version_override=override,
+        )
+        spy.assert_not_called()
+        assert result.version == override
+
+    def test_connect_daily_override_mismatch_raises(self, patch_requests_get):
+        """Manifest streams must raise DispatchVersionMismatchError when versions differ."""
+        from posit_bakery.config.image.posit_product.main import DispatchVersionMismatchError
+
+        with pytest.raises(DispatchVersionMismatchError):
+            get_product_artifact_by_stream(
+                ProductEnum.CONNECT,
+                ReleaseChannelEnum.DAILY,
+                SUPPORTED_OS["ubuntu"]["24"],
+                version_override="9999.99.0-dev+1-gdeadbeef",
+            )
+
+    def test_workbench_daily_override_mismatch_raises(self, patch_requests_get):
+        """Workbench daily is a manifest stream — mismatch raises."""
+        from posit_bakery.config.image.posit_product.main import DispatchVersionMismatchError
+
+        with pytest.raises(DispatchVersionMismatchError):
+            get_product_artifact_by_stream(
+                ProductEnum.WORKBENCH,
+                ReleaseChannelEnum.DAILY,
+                SUPPORTED_OS["ubuntu"]["24"],
+                version_override="9999.99.0-daily+1.pro1",
+            )
+
+    def test_no_override_scheduled_path_unchanged(self, patch_requests_get):
+        """With version_override=None, behavior is identical to before this task."""
+        result = get_product_artifact_by_stream(
+            ProductEnum.PACKAGE_MANAGER,
+            ReleaseChannelEnum.DAILY,
+            SUPPORTED_OS["ubuntu"]["24"],
+        )
+        assert result.version is not None
+        assert result.download_url is not None

--- a/posit-bakery/test/config/image/posit_products/test_main.py
+++ b/posit-bakery/test/config/image/posit_products/test_main.py
@@ -790,7 +790,7 @@ class TestDispatchOverride:
         """Template streams must NOT hit the network when version_override is supplied."""
         spy = mocker.patch("posit_bakery.config.image.posit_product.main.cached_session")
         override = "2026.05.0-dev+185-g8a23833f57"
-        result = get_product_artifact_by_stream(
+        result = get_product_artifact_by_channel(
             ProductEnum.PACKAGE_MANAGER,
             ReleaseChannelEnum.DAILY,
             SUPPORTED_OS["ubuntu"]["24"],
@@ -804,7 +804,7 @@ class TestDispatchOverride:
         """Preview stream is also templatable — no network on override."""
         spy = mocker.patch("posit_bakery.config.image.posit_product.main.cached_session")
         override = "2026.05.0-dev+185-g8a23833f57"
-        result = get_product_artifact_by_stream(
+        result = get_product_artifact_by_channel(
             ProductEnum.PACKAGE_MANAGER,
             ReleaseChannelEnum.PREVIEW,
             SUPPORTED_OS["ubuntu"]["24"],
@@ -818,7 +818,7 @@ class TestDispatchOverride:
         from posit_bakery.config.image.posit_product.main import DispatchVersionMismatchError
 
         with pytest.raises(DispatchVersionMismatchError):
-            get_product_artifact_by_stream(
+            get_product_artifact_by_channel(
                 ProductEnum.CONNECT,
                 ReleaseChannelEnum.DAILY,
                 SUPPORTED_OS["ubuntu"]["24"],
@@ -830,7 +830,7 @@ class TestDispatchOverride:
         from posit_bakery.config.image.posit_product.main import DispatchVersionMismatchError
 
         with pytest.raises(DispatchVersionMismatchError):
-            get_product_artifact_by_stream(
+            get_product_artifact_by_channel(
                 ProductEnum.WORKBENCH,
                 ReleaseChannelEnum.DAILY,
                 SUPPORTED_OS["ubuntu"]["24"],
@@ -839,7 +839,7 @@ class TestDispatchOverride:
 
     def test_no_override_scheduled_path_unchanged(self, patch_requests_get):
         """With version_override=None, behavior is identical to before this task."""
-        result = get_product_artifact_by_stream(
+        result = get_product_artifact_by_channel(
             ProductEnum.PACKAGE_MANAGER,
             ReleaseChannelEnum.DAILY,
             SUPPORTED_OS["ubuntu"]["24"],

--- a/posit-bakery/test/config/test_config.py
+++ b/posit-bakery/test/config/test_config.py
@@ -388,6 +388,16 @@ class TestBakeryConfig:
         )
         assert settings.dev_channel == ReleaseChannelEnum.PREVIEW
 
+    def test_dev_stream_migrates_when_dev_channel_is_explicit_none(self):
+        """dev_stream must migrate even when dev_channel=None is passed explicitly."""
+        import warnings
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            settings = BakerySettings(dev_stream=ReleaseChannelEnum.DAILY, dev_channel=None)
+        assert settings.dev_channel == ReleaseChannelEnum.DAILY
+        assert any(issubclass(warning.category, DeprecationWarning) for warning in w)
+
     class TestDevBuildSpecApplication:
         def test_inert_when_no_spec(self, testdata_path, patch_requests_get):
             """No dev_spec: config loads normally, no pinned_version set."""

--- a/posit-bakery/test/config/test_config.py
+++ b/posit-bakery/test/config/test_config.py
@@ -350,7 +350,6 @@ class TestBakeryConfig:
         BakeryConfig(yaml_file, BakerySettings(latest=True))
         assert "--latest ignores development versions" not in caplog.text
 
-
     def test_dev_channel_warning_when_dev_versions_excluded(
         self,
         caplog,

--- a/posit-bakery/test/config/test_config.py
+++ b/posit-bakery/test/config/test_config.py
@@ -388,6 +388,66 @@ class TestBakeryConfig:
         )
         assert settings.dev_channel == ReleaseChannelEnum.PREVIEW
 
+    class TestDevBuildSpecApplication:
+        def test_inert_when_no_spec(self, testdata_path, patch_requests_get):
+            """No dev_spec: config loads normally, no pinned_version set."""
+            yaml_file = testdata_path / "valid" / "complex.yaml"
+            with patch.object(posit_bakery.config.image.Image, "render_ephemeral_version_files"):
+                with patch.object(posit_bakery.config.image.Image, "remove_ephemeral_version_files"):
+                    config = BakeryConfig(
+                        yaml_file,
+                        settings=BakerySettings(dev_versions=DevVersionInclusionEnum.ONLY),
+                    )
+            for image in config.model.images:
+                for dv in image.devVersions:
+                    assert dv.pinned_version is None
+
+        def test_pins_version_on_matching_channel(self, testdata_path, patch_requests_get):
+            """dev_spec pins the matching stream dev version before resolution."""
+            from posit_bakery.config.image.dev_version.spec import DevBuildSpec
+
+            yaml_file = testdata_path / "valid" / "complex.yaml"
+            spec = DevBuildSpec(version="2026.05.0-dev+999-gSHA", channel=ReleaseChannelEnum.DAILY)
+            settings = BakerySettings(
+                dev_versions=DevVersionInclusionEnum.ONLY,
+                dev_spec=spec,
+            )
+            with patch.object(posit_bakery.config.image.Image, "render_ephemeral_version_files"):
+                with patch.object(posit_bakery.config.image.Image, "remove_ephemeral_version_files"):
+                    config = BakeryConfig(yaml_file, settings=settings)
+            pinned = [dv for image in config.model.images for dv in image.devVersions if dv.pinned_version is not None]
+            assert len(pinned) == 1
+            assert pinned[0].pinned_version == "2026.05.0-dev+999-gSHA"
+
+        def test_ambiguity_raises_when_no_channel(self, tmp_path, patch_requests_get):
+            """dev_spec without channel raises when image has two stream dev versions."""
+            from posit_bakery.config.image.dev_version.spec import DevBuildSpec
+
+            bakery_yaml = tmp_path / "bakery.yaml"
+            bakery_yaml.write_text(
+                "repository:\n"
+                "  url: https://github.com/posit-dev/test\n"
+                "images:\n"
+                "  - name: test-image\n"
+                "    devVersions:\n"
+                "      - sourceType: stream\n"
+                "        product: package-manager\n"
+                "        channel: daily\n"
+                "        os:\n"
+                "          - name: Ubuntu 24.04\n"
+                "            primary: true\n"
+                "      - sourceType: stream\n"
+                "        product: package-manager\n"
+                "        channel: preview\n"
+                "        os:\n"
+                "          - name: Ubuntu 24.04\n"
+                "            primary: true\n"
+            )
+            spec = DevBuildSpec(version="2026.05.0-dev+999-gSHA")
+            settings = BakerySettings(dev_versions=DevVersionInclusionEnum.ONLY, dev_spec=spec)
+            with pytest.raises(ValueError, match="[Aa]mbig"):
+                BakeryConfig(bakery_yaml, settings=settings)
+
     @pytest.mark.parametrize(
         "include_matrix_versions,expected_uids",
         [

--- a/posit-bakery/test/config/test_config.py
+++ b/posit-bakery/test/config/test_config.py
@@ -448,6 +448,33 @@ class TestBakeryConfig:
             with pytest.raises(ValueError, match="[Aa]mbig"):
                 BakeryConfig(bakery_yaml, settings=settings)
 
+        def test_conflicting_channels_raise(self, tmp_path, patch_requests_get):
+            """dev_spec.channel and --dev-channel must not conflict."""
+            from posit_bakery.config.image.dev_version.spec import DevBuildSpec
+
+            bakery_yaml = tmp_path / "bakery.yaml"
+            bakery_yaml.write_text(
+                "repository:\n"
+                "  url: https://github.com/posit-dev/test\n"
+                "images:\n"
+                "  - name: test-image\n"
+                "    devVersions:\n"
+                "      - sourceType: stream\n"
+                "        product: package-manager\n"
+                "        channel: daily\n"
+                "        os:\n"
+                "          - name: Ubuntu 24.04\n"
+                "            primary: true\n"
+            )
+            spec = DevBuildSpec(version="2026.05.0-dev+999-gSHA", channel=ReleaseChannelEnum.DAILY)
+            settings = BakerySettings(
+                dev_versions=DevVersionInclusionEnum.ONLY,
+                dev_spec=spec,
+                dev_channel=ReleaseChannelEnum.PREVIEW,  # conflicts with spec.channel
+            )
+            with pytest.raises(ValueError, match="[Cc]onfli"):
+                BakeryConfig(bakery_yaml, settings=settings)
+
     @pytest.mark.parametrize(
         "include_matrix_versions,expected_uids",
         [

--- a/posit-bakery/test/config/test_config.py
+++ b/posit-bakery/test/config/test_config.py
@@ -350,6 +350,7 @@ class TestBakeryConfig:
         BakeryConfig(yaml_file, BakerySettings(latest=True))
         assert "--latest ignores development versions" not in caplog.text
 
+
     def test_dev_channel_warning_when_dev_versions_excluded(
         self,
         caplog,

--- a/posit-bakery/test/config/test_config.py
+++ b/posit-bakery/test/config/test_config.py
@@ -400,7 +400,7 @@ class TestBakeryConfig:
 
     class TestDevBuildSpecApplication:
         def test_inert_when_no_spec(self, testdata_path, patch_requests_get):
-            """No dev_spec: config loads normally, no pinned_version set."""
+            """No dev_spec: config loads normally, no version_override set."""
             yaml_file = testdata_path / "valid" / "complex.yaml"
             with patch.object(posit_bakery.config.image.Image, "render_ephemeral_version_files"):
                 with patch.object(posit_bakery.config.image.Image, "remove_ephemeral_version_files"):
@@ -410,7 +410,7 @@ class TestBakeryConfig:
                     )
             for image in config.model.images:
                 for dv in image.devVersions:
-                    assert dv.pinned_version is None
+                    assert dv.version_override is None
 
         def test_pins_version_on_matching_channel(self, testdata_path, patch_requests_get):
             """dev_spec pins the matching stream dev version before resolution."""
@@ -425,9 +425,11 @@ class TestBakeryConfig:
             with patch.object(posit_bakery.config.image.Image, "render_ephemeral_version_files"):
                 with patch.object(posit_bakery.config.image.Image, "remove_ephemeral_version_files"):
                     config = BakeryConfig(yaml_file, settings=settings)
-            pinned = [dv for image in config.model.images for dv in image.devVersions if dv.pinned_version is not None]
+            pinned = [
+                dv for image in config.model.images for dv in image.devVersions if dv.version_override is not None
+            ]
             assert len(pinned) == 1
-            assert pinned[0].pinned_version == "2026.05.0-dev+999-gSHA"
+            assert pinned[0].version_override == "2026.05.0-dev+999-gSHA"
 
         def test_ambiguity_raises_when_no_channel(self, tmp_path, patch_requests_get):
             """dev_spec without channel raises when image has two stream dev versions."""


### PR DESCRIPTION
Upstream CI can now pin an exact dev version on workflow dispatch,
eliminating the CDN-propagation window where a re-triggered build picks
up a stale artifact instead of the one just built.

`--dev-spec` (or `BAKERY_DEV_SPEC`) accepts a JSON payload on `bakery
build` and `bakery ci matrix`. Template-URL products (PPM) render the
download URL offline from the pinned version. Manifest products (Connect,
Workbench) fetch and assert the manifest matches, raising loudly rather
than silently building stale.

Preparatory work: removes the dormant `env` dev-version source type, and
renames `stream` to `channel` throughout. `--dev-stream` and `stream:` in
bakery.yaml are retained as deprecated aliases.