### PR TITLE
feat(ci): per-image merge jobs in native build workflow

### DIFF
--- a/.github/workflows/bakery-build-native.yml
+++ b/.github/workflows/bakery-build-native.yml
@@ -104,6 +104,7 @@ jobs:
       contents: read
     outputs:
       platform-matrix: ${{ steps.images-by-platform.outputs.platform_matrix }}
+      image-matrix: ${{ steps.images-by-platform.outputs.image_matrix }}
 
     steps:
       - name: Checkout
@@ -129,6 +130,7 @@ jobs:
           [[ -n "$DEV_STREAM" ]] && ARGS+=(--dev-stream "$DEV_STREAM")
           result=$(bakery ci matrix "${ARGS[@]}")
           echo "platform_matrix=$(echo "$result" | jq --compact-output .)" >> "$GITHUB_OUTPUT"
+          echo "image_matrix=$(echo "$result" | jq --compact-output '[.[].image] | unique')" >> "$GITHUB_OUTPUT"
 
   build-test:
     name: "Build/Test ${{ matrix.img.image }}:${{ matrix.img.version }} (${{ matrix.img.platform }})"
@@ -275,11 +277,15 @@ jobs:
           overwrite: 'true'
 
   merge:
-    name: "Merge/Push"
+    name: "Merge/Push ${{ matrix.image }}"
     permissions:
       contents: read
       packages: write
-    needs: [build-test]
+    needs: [matrix, build-test]
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJson(needs.matrix.outputs.image-matrix) }}
     runs-on: ${{ inputs.merge-builder }}
 
     steps:
@@ -360,10 +366,12 @@ jobs:
           CONTEXT: ${{ inputs.context }}
           REGISTRY: ghcr.io/${{ github.repository_owner }}
           PUSH: ${{ inputs.push }}
+          IMAGE_NAME: ${{ matrix.image }}
         run: |
           if [ "$PUSH" = "true" ]; then PUSH_FLAG=""; else PUSH_FLAG="--dry-run"; fi
           bakery ci merge \
             --context "$CONTEXT" \
+            --image-name "^${IMAGE_NAME}$" \
             --temp-registry "$REGISTRY" \
             $PUSH_FLAG \
             ./*-metadata.json

--- a/posit-bakery/posit_bakery/cli/ci.py
+++ b/posit-bakery/posit_bakery/cli/ci.py
@@ -159,6 +159,13 @@ def merge(
     context: Annotated[
         Path, typer.Option(help="The root path to use. Defaults to the current working directory where invoked.")
     ] = auto_path(),
+    image_name: Annotated[
+        Optional[str],
+        typer.Option(
+            help="Filter merge to a specific image name (regex, e.g. '^workbench$').",
+            rich_help_panel=RichHelpPanelEnum.FILTERS,
+        ),
+    ] = None,
     temp_registry: Annotated[
         Optional[str],
         typer.Option(
@@ -194,6 +201,7 @@ def merge(
     ```
     """
     settings = BakerySettings(
+        filter=BakeryConfigFilter(image_name=image_name),
         dev_versions=DevVersionInclusionEnum.INCLUDE,
         dev_stream=dev_stream,
         matrix_versions=MatrixVersionInclusionEnum.INCLUDE,

--- a/posit-bakery/test/cli/testdata/ci/merge/multi-image/images-metadata.json
+++ b/posit-bakery/test/cli/testdata/ci/merge/multi-image/images-metadata.json
@@ -1,0 +1,4 @@
+{
+  "test-alpha-1-0-0-scratch": {},
+  "test-alpha-extra-1-0-0-scratch": {}
+}

--- a/posit-bakery/test/features/cli/ci/merge.feature
+++ b/posit-bakery/test/features/cli/ci/merge.feature
@@ -52,3 +52,17 @@ Feature: merge
         When I execute the command
         Then The command succeeds
         * 0 targets are found in the metadata
+
+    Scenario: Merging filtered to one image excludes a prefix-colliding image
+        Given I call bakery ci merge
+        * in a temp merge-multi-image context
+        * with the arguments:
+            | --image-name    |
+            | ^test-alpha$    |
+            | *-metadata.json |
+        * with testdata ci/merge/multi-image copied to context
+        * with the context as the working directory
+        * with image target merge method patched
+        When I execute the command
+        Then The command succeeds
+        * 1 targets are found in the metadata

--- a/posit-bakery/test/features/cli/ci/merge.feature
+++ b/posit-bakery/test/features/cli/ci/merge.feature
@@ -20,3 +20,35 @@ Feature: merge
             | cripittwood.azurecr.io/posit/test-multi/tmp:latest@sha256:b0f70c272157281f3e70fcd1d890d6927a9268f4bd315e6d7cba677182bd6098 | cripittwood.azurecr.io/posit/test-multi/tmp:latest@sha256:22adb0b3d07e78916da03c81b899d5ded4aaff8098d40a9b8cb071c8c0f3a4a2 |
             | cripittwood.azurecr.io/posit/test-multi/tmp:latest@sha256:f31fb59b841be3502be62d4e85696b002204a94821839ce2e8e2fa7c26eb232a |                                                                                                                            |
             | cripittwood.azurecr.io/posit/test-multi/tmp:latest@sha256:415b48b2fcc903f194b20e48cdbd2c76e2f8127c2453f8b18e5512973186dde0 | cripittwood.azurecr.io/posit/test-multi/tmp:latest@sha256:e0ee4e80f5d1b04dd103d19a7db1198c0b8bd214ed040b87d74521f2dcd6ea8e |
+
+    Scenario: Merging filtered to a matching image name
+        Given I call bakery ci merge
+        * in a temp multiplatform context
+        * with the arguments:
+            | --image-name    |
+            | ^test-multi$    |
+            | *-metadata.json |
+        * with testdata ci/merge/multiplatform copied to context
+        * with the context as the working directory
+        * with image target merge method patched
+        When I execute the command
+        Then The command succeeds
+        * 4 targets are found in the metadata
+        * the merge calls include:
+            | cripittwood.azurecr.io/posit/test-multi/tmp:latest@sha256:f5d7d95a3801d05f91db1fa7b5bba9fdb3d5babc0332c56f0cca25407c93a2f1 |                                                                                                                            |
+            | cripittwood.azurecr.io/posit/test-multi/tmp:latest@sha256:b0f70c272157281f3e70fcd1d890d6927a9268f4bd315e6d7cba677182bd6098 | cripittwood.azurecr.io/posit/test-multi/tmp:latest@sha256:22adb0b3d07e78916da03c81b899d5ded4aaff8098d40a9b8cb071c8c0f3a4a2 |
+            | cripittwood.azurecr.io/posit/test-multi/tmp:latest@sha256:f31fb59b841be3502be62d4e85696b002204a94821839ce2e8e2fa7c26eb232a |                                                                                                                            |
+            | cripittwood.azurecr.io/posit/test-multi/tmp:latest@sha256:415b48b2fcc903f194b20e48cdbd2c76e2f8127c2453f8b18e5512973186dde0 | cripittwood.azurecr.io/posit/test-multi/tmp:latest@sha256:e0ee4e80f5d1b04dd103d19a7db1198c0b8bd214ed040b87d74521f2dcd6ea8e |
+
+    Scenario: Merging filtered to a non-matching image name skips all targets
+        Given I call bakery ci merge
+        * in a temp multiplatform context
+        * with the arguments:
+            | --image-name    |
+            | ^test-mult$     |
+            | *-metadata.json |
+        * with testdata ci/merge/multiplatform copied to context
+        * with the context as the working directory
+        When I execute the command
+        Then The command succeeds
+        * 0 targets are found in the metadata

--- a/posit-bakery/test/resources/merge-multi-image/bakery.yaml
+++ b/posit-bakery/test/resources/merge-multi-image/bakery.yaml
@@ -1,0 +1,24 @@
+repository:
+  url: "github.com/posit-images-shared/posit-images-shared"
+  vendor: "Posit Software, PBC"
+  maintainer:
+    name: "Posit Docker Team"
+    email: "docker@posit.co"
+
+registries:
+  - host: "ghcr.io"
+    namespace: "posit-dev"
+
+images:
+  - name: "test-alpha"
+    versions:
+      - name: "1.0.0"
+        latest: true
+        os:
+          - name: "Scratch"
+  - name: "test-alpha-extra"
+    versions:
+      - name: "1.0.0"
+        latest: true
+        os:
+          - name: "Scratch"


### PR DESCRIPTION
## Summary

- The `merge` job in `bakery-build-native.yml` previously ran as a single job for all images built by the workflow. It now fans out as a **matrix keyed by image name** — one merge job per distinct image (e.g. separate `workbench` and `workbench-session-init` merges).
- Added an `--image-name` regex filter to `bakery ci merge` (mirroring `bakery ci matrix` / `bakery build`), so each per-image merge job scopes itself with `--image-name "^${IMAGE_NAME}$"`. The anchored regex keeps prefix-colliding names isolated (`workbench` won't match `workbench-session-init`).
- The `matrix` job now also emits an `image-matrix` output (`jq '[.[].image] | unique'`) that the merge matrix iterates over.

This is about parallelism, isolation, and clearer per-image logs — `bakery ci merge` already only acted on targets whose metadata was present, so correctness is unchanged.

## Why it's safe for caller repos

No `workflow_call` inputs changed. The additions are internal to the shared workflow (a new `matrix` output, a `strategy.matrix` on `merge`, and a `needs` addition). Callers pinning `@main` get the matching `bakery` via `setup-bakery@main`, so the CLI flag and workflow stay in sync. No changes required in `images-connect`, `images-workbench`, or `images-package-manager`.

## Test Plan

- [x] `uv run pytest test/cli/test_ci.py` — 27 passed, including three new merge scenarios:
  - matching image name → full merge
  - non-matching anchored name → 0 targets (no-op-filter guard)
  - **prefix-colliding** fixture (`test-alpha` vs `test-alpha-extra`) → only `test-alpha` merged (selectivity / anchoring guard)
- [x] `actionlint` passes on `bakery-build-native.yml` (via pre-commit)
- [ ] Confirm a real native build run produces one merge job per image and pushes correct multi-platform manifests

🤖 Generated with [Claude Code](https://claude.com/claude-code)