### PR TITLE
Finish stream→channel rename and add deprecation tests

### DIFF
--- a/posit-bakery/test/cli/conftest.py
+++ b/posit-bakery/test/cli/conftest.py
@@ -11,6 +11,16 @@ from test.cli.bakery_command import BakeryCommand
 from test.helpers import remove_images
 
 
+def settings_from_call(mock):
+    """Extract BakerySettings from a mocked BakeryConfig.from_context call.
+
+    Handles both positional (from_context(context, settings)) and keyword
+    (from_context(context=context, settings=settings)) calling conventions.
+    """
+    args, kwargs = mock.from_context.call_args
+    return kwargs.get("settings", args[1] if len(args) > 1 else None)
+
+
 @pytest.fixture(scope="session")
 def ci_testdata():
     """Return the path to the CI test data directory"""

--- a/posit-bakery/test/cli/test_dev_spec.py
+++ b/posit-bakery/test/cli/test_dev_spec.py
@@ -8,19 +8,10 @@ from typer.testing import CliRunner
 from posit_bakery.cli.main import app
 from posit_bakery.config.image.dev_version.spec import DevBuildSpec
 from posit_bakery.config.image.posit_product.const import ReleaseChannelEnum
+from test.cli.conftest import settings_from_call
 
 runner = CliRunner()
 BASIC_CONTEXT = str(Path(__file__).parent.parent / "resources" / "basic")
-
-
-def _settings_from_call(mock):
-    """Extract the BakerySettings passed to BakeryConfig.from_context.
-
-    Handles both positional (build.py: from_context(context, settings))
-    and keyword (ci.py: from_context(context=context, settings=settings)) calls.
-    """
-    args, kwargs = mock.from_context.call_args
-    return kwargs.get("settings", args[1] if len(args) > 1 else None)
 
 
 class TestBuildDevSpec:
@@ -43,7 +34,7 @@ class TestBuildDevSpec:
                 catch_exceptions=False,
             )
         assert result.exit_code == 0, result.output
-        settings = _settings_from_call(mock)
+        settings = settings_from_call(mock)
         assert isinstance(settings.dev_spec, DevBuildSpec)
         assert settings.dev_spec.version == "2026.05.0-dev+185-gSHA"
         assert settings.dev_spec.channel == ReleaseChannelEnum.DAILY
@@ -60,7 +51,7 @@ class TestBuildDevSpec:
                 catch_exceptions=False,
             )
         assert result.exit_code == 0, result.output
-        settings = _settings_from_call(mock)
+        settings = settings_from_call(mock)
         assert isinstance(settings.dev_spec, DevBuildSpec)
         assert settings.dev_spec.version == "2026.05.0-dev+185-gSHA"
         assert settings.dev_spec.channel is None
@@ -102,7 +93,7 @@ class TestBuildDevSpec:
                 catch_exceptions=False,
             )
         assert result.exit_code == 0, result.output
-        settings = _settings_from_call(mock)
+        settings = settings_from_call(mock)
         assert settings.dev_spec is None
 
 
@@ -128,7 +119,7 @@ class TestCiMatrixDevSpec:
                 catch_exceptions=False,
             )
         assert result.exit_code == 0, result.output
-        settings = _settings_from_call(mock)
+        settings = settings_from_call(mock)
         assert isinstance(settings.dev_spec, DevBuildSpec)
         assert settings.dev_spec.version == "2026.05.0-dev+185-gSHA"
         assert settings.dev_spec.channel == ReleaseChannelEnum.DAILY
@@ -146,7 +137,7 @@ class TestCiMatrixDevSpec:
                 catch_exceptions=False,
             )
         assert result.exit_code == 0, result.output
-        settings = _settings_from_call(mock)
+        settings = settings_from_call(mock)
         assert isinstance(settings.dev_spec, DevBuildSpec)
         assert settings.dev_spec.version == "2026.05.0-dev+185-gSHA"
         assert settings.dev_spec.channel is None
@@ -190,5 +181,5 @@ class TestCiMatrixDevSpec:
                 catch_exceptions=False,
             )
         assert result.exit_code == 0, result.output
-        settings = _settings_from_call(mock)
+        settings = settings_from_call(mock)
         assert settings.dev_spec is None

--- a/posit-bakery/test/cli/test_dev_stream_deprecated.py
+++ b/posit-bakery/test/cli/test_dev_stream_deprecated.py
@@ -1,0 +1,228 @@
+"""Tests for --dev-stream deprecation coalesce on commands not covered by test_dev_spec.py.
+
+Verifies that --dev-stream is accepted as a hidden deprecated alias for --dev-channel
+on ci merge, ci readme, clean cache-registry, clean temp-registry, get tags, and
+run dgoss, and that --dev-channel takes precedence when both flags are provided.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from posit_bakery.cli.main import app
+from posit_bakery.config.image.posit_product.const import ReleaseChannelEnum
+
+runner = CliRunner()
+BASIC_CONTEXT = str(Path(__file__).parent.parent / "resources" / "basic")
+
+
+def _channel_from_settings(mock):
+    """Extract dev_channel from the BakerySettings passed to from_context."""
+    args, kwargs = mock.from_context.call_args
+    settings = kwargs.get("settings", args[1] if len(args) > 1 else None)
+    return settings.dev_channel
+
+
+class TestCiMergeDevStreamDeprecation:
+    @pytest.fixture
+    def mock_merge(self, tmp_path):
+        metadata_file = tmp_path / "meta.json"
+        metadata_file.write_text("{}")
+        with patch("posit_bakery.cli.ci.BakeryConfig") as mock_config:
+            instance = MagicMock()
+            instance.load_build_metadata_from_file.return_value = []
+            instance.targets = []
+            mock_config.from_context.return_value = instance
+            with patch("posit_bakery.plugins.registry.get_plugin") as mock_plugin:
+                mock_oras = MagicMock()
+                mock_oras.execute.return_value = []
+                mock_plugin.return_value = mock_oras
+                yield mock_config, str(metadata_file)
+
+    def test_dev_stream_coalesces(self, mock_merge):
+        mock, meta = mock_merge
+        result = runner.invoke(
+            app,
+            ["ci", "merge", meta, "--context", BASIC_CONTEXT, "--dev-stream", "daily"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert _channel_from_settings(mock) == ReleaseChannelEnum.DAILY
+
+    def test_dev_channel_wins(self, mock_merge):
+        mock, meta = mock_merge
+        result = runner.invoke(
+            app,
+            ["ci", "merge", meta, "--context", BASIC_CONTEXT, "--dev-stream", "daily", "--dev-channel", "preview"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert _channel_from_settings(mock) == ReleaseChannelEnum.PREVIEW
+
+
+class TestCiReadmeDevStreamDeprecation:
+    @pytest.fixture
+    def mock_readme(self):
+        with patch("posit_bakery.cli.ci.BakeryConfig") as mock_config:
+            instance = MagicMock()
+            instance.targets = []
+            mock_config.from_context.return_value = instance
+            with patch("posit_bakery.cli.ci.push_readmes", return_value=0):
+                yield mock_config
+
+    def test_dev_stream_coalesces(self, mock_readme):
+        result = runner.invoke(
+            app,
+            ["ci", "readme", "--context", BASIC_CONTEXT, "--dev-stream", "daily"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert _channel_from_settings(mock_readme) == ReleaseChannelEnum.DAILY
+
+    def test_dev_channel_wins(self, mock_readme):
+        result = runner.invoke(
+            app,
+            ["ci", "readme", "--context", BASIC_CONTEXT, "--dev-stream", "daily", "--dev-channel", "preview"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert _channel_from_settings(mock_readme) == ReleaseChannelEnum.PREVIEW
+
+
+class TestCleanCacheRegistryDevStreamDeprecation:
+    @pytest.fixture
+    def mock_clean(self):
+        with patch("posit_bakery.cli.clean.BakeryConfig") as mock_config:
+            instance = MagicMock()
+            instance.clean_caches.return_value = []
+            mock_config.from_context.return_value = instance
+            yield mock_config
+
+    def test_dev_stream_coalesces(self, mock_clean):
+        result = runner.invoke(
+            app,
+            ["clean", "cache-registry", "ghcr.io/test", "--context", BASIC_CONTEXT, "--dev-stream", "daily"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert _channel_from_settings(mock_clean) == ReleaseChannelEnum.DAILY
+
+    def test_dev_channel_wins(self, mock_clean):
+        result = runner.invoke(
+            app,
+            [
+                "clean",
+                "cache-registry",
+                "ghcr.io/test",
+                "--context",
+                BASIC_CONTEXT,
+                "--dev-stream",
+                "daily",
+                "--dev-channel",
+                "preview",
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert _channel_from_settings(mock_clean) == ReleaseChannelEnum.PREVIEW
+
+
+class TestCleanTempRegistryDevStreamDeprecation:
+    @pytest.fixture
+    def mock_clean(self):
+        with patch("posit_bakery.cli.clean.BakeryConfig") as mock_config:
+            instance = MagicMock()
+            instance.clean_temporary.return_value = []
+            mock_config.from_context.return_value = instance
+            yield mock_config
+
+    def test_dev_stream_coalesces(self, mock_clean):
+        result = runner.invoke(
+            app,
+            ["clean", "temp-registry", "ghcr.io/test", "--context", BASIC_CONTEXT, "--dev-stream", "daily"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert _channel_from_settings(mock_clean) == ReleaseChannelEnum.DAILY
+
+    def test_dev_channel_wins(self, mock_clean):
+        result = runner.invoke(
+            app,
+            [
+                "clean",
+                "temp-registry",
+                "ghcr.io/test",
+                "--context",
+                BASIC_CONTEXT,
+                "--dev-stream",
+                "daily",
+                "--dev-channel",
+                "preview",
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert _channel_from_settings(mock_clean) == ReleaseChannelEnum.PREVIEW
+
+
+class TestGetTagsDevStreamDeprecation:
+    @pytest.fixture
+    def mock_get(self):
+        with patch("posit_bakery.cli.get.BakeryConfig") as mock_config:
+            instance = MagicMock()
+            instance.targets = []
+            mock_config.from_context.return_value = instance
+            yield mock_config
+
+    def test_dev_stream_coalesces(self, mock_get):
+        result = runner.invoke(
+            app,
+            ["get", "tags", "--context", BASIC_CONTEXT, "--dev-stream", "daily"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert _channel_from_settings(mock_get) == ReleaseChannelEnum.DAILY
+
+    def test_dev_channel_wins(self, mock_get):
+        result = runner.invoke(
+            app,
+            ["get", "tags", "--context", BASIC_CONTEXT, "--dev-stream", "daily", "--dev-channel", "preview"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert _channel_from_settings(mock_get) == ReleaseChannelEnum.PREVIEW
+
+
+class TestRunDgossDevStreamDeprecation:
+    @pytest.fixture
+    def mock_run(self):
+        with patch("posit_bakery.cli.run.BakeryConfig") as mock_config:
+            instance = MagicMock()
+            instance.base_path = Path(BASIC_CONTEXT)
+            instance.targets = []
+            mock_config.from_context.return_value = instance
+            with patch("posit_bakery.cli.run.get_plugin") as mock_plugin:
+                mock_dgoss = MagicMock()
+                mock_dgoss.execute.return_value = []
+                mock_plugin.return_value = mock_dgoss
+                yield mock_config
+
+    def test_dev_stream_coalesces(self, mock_run):
+        result = runner.invoke(
+            app,
+            ["run", "dgoss", "--context", BASIC_CONTEXT, "--dev-stream", "daily"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert _channel_from_settings(mock_run) == ReleaseChannelEnum.DAILY
+
+    def test_dev_channel_wins(self, mock_run):
+        result = runner.invoke(
+            app,
+            ["run", "dgoss", "--context", BASIC_CONTEXT, "--dev-stream", "daily", "--dev-channel", "preview"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert _channel_from_settings(mock_run) == ReleaseChannelEnum.PREVIEW

--- a/posit-bakery/test/cli/test_dev_stream_deprecated.py
+++ b/posit-bakery/test/cli/test_dev_stream_deprecated.py
@@ -13,16 +13,10 @@ from typer.testing import CliRunner
 
 from posit_bakery.cli.main import app
 from posit_bakery.config.image.posit_product.const import ReleaseChannelEnum
+from test.cli.conftest import settings_from_call
 
 runner = CliRunner()
 BASIC_CONTEXT = str(Path(__file__).parent.parent / "resources" / "basic")
-
-
-def _channel_from_settings(mock):
-    """Extract dev_channel from the BakerySettings passed to from_context."""
-    args, kwargs = mock.from_context.call_args
-    settings = kwargs.get("settings", args[1] if len(args) > 1 else None)
-    return settings.dev_channel
 
 
 class TestCiMergeDevStreamDeprecation:
@@ -49,7 +43,7 @@ class TestCiMergeDevStreamDeprecation:
             catch_exceptions=False,
         )
         assert result.exit_code == 0
-        assert _channel_from_settings(mock) == ReleaseChannelEnum.DAILY
+        assert settings_from_call(mock).dev_channel == ReleaseChannelEnum.DAILY
 
     def test_dev_channel_wins(self, mock_merge):
         mock, meta = mock_merge
@@ -59,7 +53,7 @@ class TestCiMergeDevStreamDeprecation:
             catch_exceptions=False,
         )
         assert result.exit_code == 0
-        assert _channel_from_settings(mock) == ReleaseChannelEnum.PREVIEW
+        assert settings_from_call(mock).dev_channel == ReleaseChannelEnum.PREVIEW
 
 
 class TestCiReadmeDevStreamDeprecation:
@@ -79,7 +73,7 @@ class TestCiReadmeDevStreamDeprecation:
             catch_exceptions=False,
         )
         assert result.exit_code == 0
-        assert _channel_from_settings(mock_readme) == ReleaseChannelEnum.DAILY
+        assert settings_from_call(mock_readme).dev_channel == ReleaseChannelEnum.DAILY
 
     def test_dev_channel_wins(self, mock_readme):
         result = runner.invoke(
@@ -88,7 +82,7 @@ class TestCiReadmeDevStreamDeprecation:
             catch_exceptions=False,
         )
         assert result.exit_code == 0
-        assert _channel_from_settings(mock_readme) == ReleaseChannelEnum.PREVIEW
+        assert settings_from_call(mock_readme).dev_channel == ReleaseChannelEnum.PREVIEW
 
 
 class TestCleanCacheRegistryDevStreamDeprecation:
@@ -107,7 +101,7 @@ class TestCleanCacheRegistryDevStreamDeprecation:
             catch_exceptions=False,
         )
         assert result.exit_code == 0
-        assert _channel_from_settings(mock_clean) == ReleaseChannelEnum.DAILY
+        assert settings_from_call(mock_clean).dev_channel == ReleaseChannelEnum.DAILY
 
     def test_dev_channel_wins(self, mock_clean):
         result = runner.invoke(
@@ -126,7 +120,7 @@ class TestCleanCacheRegistryDevStreamDeprecation:
             catch_exceptions=False,
         )
         assert result.exit_code == 0
-        assert _channel_from_settings(mock_clean) == ReleaseChannelEnum.PREVIEW
+        assert settings_from_call(mock_clean).dev_channel == ReleaseChannelEnum.PREVIEW
 
 
 class TestCleanTempRegistryDevStreamDeprecation:
@@ -145,7 +139,7 @@ class TestCleanTempRegistryDevStreamDeprecation:
             catch_exceptions=False,
         )
         assert result.exit_code == 0
-        assert _channel_from_settings(mock_clean) == ReleaseChannelEnum.DAILY
+        assert settings_from_call(mock_clean).dev_channel == ReleaseChannelEnum.DAILY
 
     def test_dev_channel_wins(self, mock_clean):
         result = runner.invoke(
@@ -164,7 +158,7 @@ class TestCleanTempRegistryDevStreamDeprecation:
             catch_exceptions=False,
         )
         assert result.exit_code == 0
-        assert _channel_from_settings(mock_clean) == ReleaseChannelEnum.PREVIEW
+        assert settings_from_call(mock_clean).dev_channel == ReleaseChannelEnum.PREVIEW
 
 
 class TestGetTagsDevStreamDeprecation:
@@ -183,7 +177,7 @@ class TestGetTagsDevStreamDeprecation:
             catch_exceptions=False,
         )
         assert result.exit_code == 0
-        assert _channel_from_settings(mock_get) == ReleaseChannelEnum.DAILY
+        assert settings_from_call(mock_get).dev_channel == ReleaseChannelEnum.DAILY
 
     def test_dev_channel_wins(self, mock_get):
         result = runner.invoke(
@@ -192,7 +186,7 @@ class TestGetTagsDevStreamDeprecation:
             catch_exceptions=False,
         )
         assert result.exit_code == 0
-        assert _channel_from_settings(mock_get) == ReleaseChannelEnum.PREVIEW
+        assert settings_from_call(mock_get).dev_channel == ReleaseChannelEnum.PREVIEW
 
 
 class TestRunDgossDevStreamDeprecation:
@@ -216,7 +210,7 @@ class TestRunDgossDevStreamDeprecation:
             catch_exceptions=False,
         )
         assert result.exit_code == 0
-        assert _channel_from_settings(mock_run) == ReleaseChannelEnum.DAILY
+        assert settings_from_call(mock_run).dev_channel == ReleaseChannelEnum.DAILY
 
     def test_dev_channel_wins(self, mock_run):
         result = runner.invoke(
@@ -225,4 +219,4 @@ class TestRunDgossDevStreamDeprecation:
             catch_exceptions=False,
         )
         assert result.exit_code == 0
-        assert _channel_from_settings(mock_run) == ReleaseChannelEnum.PREVIEW
+        assert settings_from_call(mock_run).dev_channel == ReleaseChannelEnum.PREVIEW


### PR DESCRIPTION
Completes the `stream`→`channel` terminology migration started in the parent PR and adds `--dev-stream` deprecation tests for the remaining CLI commands.

Stacked on:
- https://github.com/posit-dev/images-shared/pull/565