### PR TITLE
feat(bakery): add UBI as an alias for RHEL in OS name resolution

### DIFF
--- a/posit-bakery/posit_bakery/config/image/build_os.py
+++ b/posit-bakery/posit_bakery/config/image/build_os.py
@@ -49,6 +49,7 @@ ALTERNATE_NAMES = {
     "red hat": "rhel",
     "rh": "rhel",
     "el": "rhel",
+    "ubi": "rhel",
     "almalinux": "alma",
     "alma linux": "alma",
     "rockylinux": "rocky",

--- a/posit-bakery/test/config/image/test_version_os.py
+++ b/posit-bakery/test/config/image/test_version_os.py
@@ -140,6 +140,8 @@ class TestImageVersionOS:
             ("RHEL", SUPPORTED_OS["rhel"]["10"]),
             ("RH 9", SUPPORTED_OS["rhel"]["9"]),
             ("EL8", SUPPORTED_OS["rhel"]["8"]),
+            ("UBI 10", SUPPORTED_OS["rhel"]["10"]),
+            ("UBI", SUPPORTED_OS["rhel"]["10"]),
             ("Alma 9", SUPPORTED_OS["alma"]["9"]),
             ("AlmaLinux 8", SUPPORTED_OS["alma"]["8"]),
             ("Alma Linux", SUPPORTED_OS["alma"]["10"]),


### PR DESCRIPTION
Adds `"ubi": "rhel"` to `ALTERNATE_NAMES` in `build_os.py` so product `bakery.yaml` files can use `"UBI 10"` as an OS name interchangeably with `"RHEL 10"`. Prerequisite for the UBI 10 product image initiative.