### PR TITLE
feat(r.j2): add manylinux R tarball install macros for self-contained R

### DIFF
--- a/posit-bakery/posit_bakery/config/templating/macros/r.j2
+++ b/posit-bakery/posit_bakery/config/templating/macros/r.j2
@@ -26,31 +26,35 @@ RUN_UNATTENDED=1 R_VERSION={{ version | trim }} bash -c "$(curl -fsSL https://rs
 find . -type f -name '[rR]-{{ version | trim }}.*\.(deb|rpm)' -delete
 {%- endmacro %}
 
-{# Downloads and extracts a manylinux_2_34 R tarball from cdn.posit.co/r directly to
-/opt/R/{version}/. Requires glibc >= 2.34 (RHEL 10, Ubuntu 22.04+, Debian 12+).
-Use in place of run_install when the platform cannot satisfy the RPM/deb dependencies.
+{# Downloads and extracts a manylinux R tarball from cdn.posit.co/r directly to
+/opt/R/{version}/. Use in place of run_install when the platform cannot satisfy
+the RPM/deb dependencies.
 
 :param version: The R version to install, e.g. "4.4.3"
+:param glibc_version: The manylinux glibc version string, e.g. "2_34" (default).
+    Requires the host glibc to be >= the chosen version.
 #}
-{% macro install_manylinux(version) -%}
+{% macro install_manylinux(version, glibc_version="2_34") -%}
 {%- set v = version | trim -%}
 ARCH=$(uname -m) && \
 ARCH_SUFFIX=$([ "$ARCH" = "aarch64" ] && echo "-arm64" || echo "") && \
-curl -fsSL "https://cdn.posit.co/r/manylinux_2_34/R-{{ v }}-manylinux_2_34${ARCH_SUFFIX}.tar.gz" \
+curl -fsSL "https://cdn.posit.co/r/manylinux_{{ glibc_version }}/R-{{ v }}-manylinux_{{ glibc_version }}${ARCH_SUFFIX}.tar.gz" \
     | tar -xz -C /opt/R/
 {%- endmacro %}
 
-{# Installs one or more versions of R from manylinux_2_34 tarballs as separate RUN statements
+{# Installs one or more versions of R from manylinux tarballs as separate RUN statements
 
 :param versions: A list of R versions or a comma separated string of R versions to install
+:param glibc_version: The manylinux glibc version string, e.g. "2_34" (default).
+    Passed through to install_manylinux.
 #}
-{% macro run_install_manylinux(versions) -%}
+{% macro run_install_manylinux(versions, glibc_version="2_34") -%}
 {%- if versions is string -%}
 {%- set versions = versions | split(",") | map('trim') -%}
 {%- endif -%}
 RUN mkdir -p /opt/R
 {% for version in versions -%}
-RUN {{ install_manylinux(version) | indent(4) }}
+RUN {{ install_manylinux(version, glibc_version) | indent(4) }}
 {%- if not loop.last %}
 {% endif %}
 {%- endfor %}

--- a/posit-bakery/posit_bakery/config/templating/macros/r.j2
+++ b/posit-bakery/posit_bakery/config/templating/macros/r.j2
@@ -26,6 +26,36 @@ RUN_UNATTENDED=1 R_VERSION={{ version | trim }} bash -c "$(curl -fsSL https://rs
 find . -type f -name '[rR]-{{ version | trim }}.*\.(deb|rpm)' -delete
 {%- endmacro %}
 
+{# Downloads and extracts a manylinux_2_34 R tarball from cdn.posit.co/r directly to
+/opt/R/{version}/. Requires glibc >= 2.34 (RHEL 10, Ubuntu 22.04+, Debian 12+).
+Use in place of run_install when the platform cannot satisfy the RPM/deb dependencies.
+
+:param version: The R version to install, e.g. "4.4.3"
+#}
+{% macro install_manylinux(version) -%}
+{%- set v = version | trim -%}
+ARCH=$(uname -m) && \
+ARCH_SUFFIX=$([ "$ARCH" = "aarch64" ] && echo "-arm64" || echo "") && \
+curl -fsSL "https://cdn.posit.co/r/manylinux_2_34/R-{{ v }}-manylinux_2_34${ARCH_SUFFIX}.tar.gz" \
+    | tar -xz -C /opt/R/
+{%- endmacro %}
+
+{# Installs one or more versions of R from manylinux_2_34 tarballs as separate RUN statements
+
+:param versions: A list of R versions or a comma separated string of R versions to install
+#}
+{% macro run_install_manylinux(versions) -%}
+{%- if versions is string -%}
+{%- set versions = versions | split(",") | map('trim') -%}
+{%- endif -%}
+RUN mkdir -p /opt/R
+{% for version in versions -%}
+RUN {{ install_manylinux(version) | indent(4) }}
+{%- if not loop.last %}
+{% endif %}
+{%- endfor %}
+{%- endmacro %}
+
 {# Installs one or more versions of R as separate RUN statements
 
 :param versions: A list of R versions or a comma separated string of R versions to install

--- a/posit-bakery/test/config/templating/test_macros.py
+++ b/posit-bakery/test/config/templating/test_macros.py
@@ -2456,6 +2456,81 @@ class TestRMacros:
         rendered = environment_with_macros.from_string(template).render()
         assert rendered == expected
 
+    def test_install_manylinux_default(self, environment_with_macros):
+        template = '{%- import "r.j2" as r -%}\n{{ r.install_manylinux("4.6.0") }}'
+        expected = textwrap.dedent(
+            """\
+            ARCH=$(uname -m) && \\
+            ARCH_SUFFIX=$([ "$ARCH" = "aarch64" ] && echo "-arm64" || echo "") && \\
+            curl -fsSL "https://cdn.posit.co/r/manylinux_2_34/R-4.6.0-manylinux_2_34${ARCH_SUFFIX}.tar.gz" \\
+                | tar -xz -C /opt/R/"""
+        )
+        rendered = environment_with_macros.from_string(template).render()
+        assert rendered == expected
+
+    def test_install_manylinux_explicit_version(self, environment_with_macros):
+        template = '{%- import "r.j2" as r -%}\n{{ r.install_manylinux("4.6.0", glibc_version="2_28") }}'
+        expected = textwrap.dedent(
+            """\
+            ARCH=$(uname -m) && \\
+            ARCH_SUFFIX=$([ "$ARCH" = "aarch64" ] && echo "-arm64" || echo "") && \\
+            curl -fsSL "https://cdn.posit.co/r/manylinux_2_28/R-4.6.0-manylinux_2_28${ARCH_SUFFIX}.tar.gz" \\
+                | tar -xz -C /opt/R/"""
+        )
+        rendered = environment_with_macros.from_string(template).render()
+        assert rendered == expected
+
+    @pytest.mark.parametrize(
+        "input,expected",
+        [
+            pytest.param(
+                (["4.6.0"],),
+                textwrap.dedent(
+                    """\
+                    RUN mkdir -p /opt/R
+                    RUN ARCH=$(uname -m) && \\
+                        ARCH_SUFFIX=$([ "$ARCH" = "aarch64" ] && echo "-arm64" || echo "") && \\
+                        curl -fsSL "https://cdn.posit.co/r/manylinux_2_34/R-4.6.0-manylinux_2_34${ARCH_SUFFIX}.tar.gz" \\
+                            | tar -xz -C /opt/R/"""
+                ),
+                id="single-version-default-glibc",
+            ),
+            pytest.param(
+                (["4.6.0", "4.4.3"],),
+                textwrap.dedent(
+                    """\
+                    RUN mkdir -p /opt/R
+                    RUN ARCH=$(uname -m) && \\
+                        ARCH_SUFFIX=$([ "$ARCH" = "aarch64" ] && echo "-arm64" || echo "") && \\
+                        curl -fsSL "https://cdn.posit.co/r/manylinux_2_34/R-4.6.0-manylinux_2_34${ARCH_SUFFIX}.tar.gz" \\
+                            | tar -xz -C /opt/R/
+                    RUN ARCH=$(uname -m) && \\
+                        ARCH_SUFFIX=$([ "$ARCH" = "aarch64" ] && echo "-arm64" || echo "") && \\
+                        curl -fsSL "https://cdn.posit.co/r/manylinux_2_34/R-4.4.3-manylinux_2_34${ARCH_SUFFIX}.tar.gz" \\
+                            | tar -xz -C /opt/R/"""
+                ),
+                id="multiple-versions-default-glibc",
+            ),
+            pytest.param(
+                (["4.6.0"], "2_28"),
+                textwrap.dedent(
+                    """\
+                    RUN mkdir -p /opt/R
+                    RUN ARCH=$(uname -m) && \\
+                        ARCH_SUFFIX=$([ "$ARCH" = "aarch64" ] && echo "-arm64" || echo "") && \\
+                        curl -fsSL "https://cdn.posit.co/r/manylinux_2_28/R-4.6.0-manylinux_2_28${ARCH_SUFFIX}.tar.gz" \\
+                            | tar -xz -C /opt/R/"""
+                ),
+                id="explicit-glibc-version",
+            ),
+        ],
+    )
+    def test_run_install_manylinux(self, environment_with_macros, input, expected):
+        parts = [f'"{i}"' if isinstance(i, str) else str(i) for i in input]
+        template = '{%- import "r.j2" as r -%}\n{{ r.run_install_manylinux(' + ", ".join(parts) + ") }}"
+        rendered = environment_with_macros.from_string(template).render()
+        assert rendered == expected
+
     @pytest.mark.parametrize(
         "_os,expected",
         [

--- a/posit-bakery/test/config/templating/test_macros.py
+++ b/posit-bakery/test/config/templating/test_macros.py
@@ -2484,7 +2484,7 @@ class TestRMacros:
         "input,expected",
         [
             pytest.param(
-                (["4.6.0"],),
+                ["4.6.0"],
                 textwrap.dedent(
                     """\
                     RUN mkdir -p /opt/R
@@ -2493,10 +2493,10 @@ class TestRMacros:
                         curl -fsSL "https://cdn.posit.co/r/manylinux_2_34/R-4.6.0-manylinux_2_34${ARCH_SUFFIX}.tar.gz" \\
                             | tar -xz -C /opt/R/"""
                 ),
-                id="single-version-default-glibc",
+                id="single-version",
             ),
             pytest.param(
-                (["4.6.0", "4.4.3"],),
+                ["4.6.0", "4.4.3"],
                 textwrap.dedent(
                     """\
                     RUN mkdir -p /opt/R
@@ -2509,25 +2509,41 @@ class TestRMacros:
                         curl -fsSL "https://cdn.posit.co/r/manylinux_2_34/R-4.4.3-manylinux_2_34${ARCH_SUFFIX}.tar.gz" \\
                             | tar -xz -C /opt/R/"""
                 ),
-                id="multiple-versions-default-glibc",
+                id="multiple-versions",
             ),
             pytest.param(
-                (["4.6.0"], "2_28"),
+                "'4.6.0,4.4.3'",
                 textwrap.dedent(
                     """\
                     RUN mkdir -p /opt/R
                     RUN ARCH=$(uname -m) && \\
                         ARCH_SUFFIX=$([ "$ARCH" = "aarch64" ] && echo "-arm64" || echo "") && \\
-                        curl -fsSL "https://cdn.posit.co/r/manylinux_2_28/R-4.6.0-manylinux_2_28${ARCH_SUFFIX}.tar.gz" \\
+                        curl -fsSL "https://cdn.posit.co/r/manylinux_2_34/R-4.6.0-manylinux_2_34${ARCH_SUFFIX}.tar.gz" \\
+                            | tar -xz -C /opt/R/
+                    RUN ARCH=$(uname -m) && \\
+                        ARCH_SUFFIX=$([ "$ARCH" = "aarch64" ] && echo "-arm64" || echo "") && \\
+                        curl -fsSL "https://cdn.posit.co/r/manylinux_2_34/R-4.4.3-manylinux_2_34${ARCH_SUFFIX}.tar.gz" \\
                             | tar -xz -C /opt/R/"""
                 ),
-                id="explicit-glibc-version",
+                id="string-versions",
             ),
         ],
     )
     def test_run_install_manylinux(self, environment_with_macros, input, expected):
-        parts = [f'"{i}"' if isinstance(i, str) else str(i) for i in input]
-        template = '{%- import "r.j2" as r -%}\n{{ r.run_install_manylinux(' + ", ".join(parts) + ") }}"
+        template = '{%- import "r.j2" as r -%}\n{{ r.run_install_manylinux(' + str(input) + ") }}"
+        rendered = environment_with_macros.from_string(template).render()
+        assert rendered == expected
+
+    def test_run_install_manylinux_explicit_glibc_version(self, environment_with_macros):
+        template = '{%- import "r.j2" as r -%}\n{{ r.run_install_manylinux(["4.6.0"], "2_28") }}'
+        expected = textwrap.dedent(
+            """\
+            RUN mkdir -p /opt/R
+            RUN ARCH=$(uname -m) && \\
+                ARCH_SUFFIX=$([ "$ARCH" = "aarch64" ] && echo "-arm64" || echo "") && \\
+                curl -fsSL "https://cdn.posit.co/r/manylinux_2_28/R-4.6.0-manylinux_2_28${ARCH_SUFFIX}.tar.gz" \\
+                    | tar -xz -C /opt/R/"""
+        )
         rendered = environment_with_macros.from_string(template).render()
         assert rendered == expected
 


### PR DESCRIPTION
Adds `install_manylinux()` and `run_install_manylinux()` alongside the existing RPM/deb path. Downloads pre-built R tarballs from `cdn.posit.co/r/manylinux_2_34/` and extracts them to `/opt/R/{version}/`, bypassing package manager dependency resolution. Arch is detected at runtime; the same Containerfile covers amd64 and arm64.

Useful for posit-dev/images-volumes, whose images are built `FROM scratch` and only carry `/opt/<tool>` — the manylinux tarball is self-contained (bundles its own non-glibc runtime deps, only requires glibc >= 2.34), unlike the deb/RPM path which dynamically links against system libraries that don't survive the copy into `scratch`.

Closes https://github.com/posit-dev/images-shared/issues/747