### PR TITLE
feat: parallel dgoss execution via shared ParallelShellExecutor

### DIFF
--- a/posit-bakery/posit_bakery/const.py
+++ b/posit-bakery/posit_bakery/const.py
@@ -35,3 +35,5 @@ POSIT_LABEL_PREFIX = "co.posit.image"
 OCI_LABEL_PREFIX = "org.opencontainers.image"
 
 JINJA2_TEMPLATE_EXTENSIONS = {".jinja2", ".j2", ".jinja"}
+
+DEFAULT_MAX_CONCURRENCY = 4

--- a/posit-bakery/posit_bakery/parallel/__init__.py
+++ b/posit-bakery/posit_bakery/parallel/__init__.py
@@ -1,0 +1,13 @@
+from posit_bakery.parallel.executor import (
+    ParallelShellExecutor,
+    ShellResult,
+    ShellTask,
+    resolve_max_workers,
+)
+
+__all__ = [
+    "ParallelShellExecutor",
+    "ShellResult",
+    "ShellTask",
+    "resolve_max_workers",
+]

--- a/posit-bakery/posit_bakery/parallel/executor.py
+++ b/posit-bakery/posit_bakery/parallel/executor.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
-import subprocess
-import time
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 from posit_bakery.settings import SETTINGS
 

--- a/posit-bakery/posit_bakery/parallel/executor.py
+++ b/posit-bakery/posit_bakery/parallel/executor.py
@@ -104,6 +104,7 @@ class ParallelShellExecutor:
         self._use_live = use_live
         self._active: set[subprocess.Popen] = set()
         self._lock = threading.Lock()
+        self._shutdown = False
 
     def _resolve_use_live(self, n_tasks: int) -> bool:
         """Decide whether to render a live table: explicit override, else TTY + not quiet + >1 task."""
@@ -129,7 +130,25 @@ class ParallelShellExecutor:
             )
 
         with self._lock:
-            self._active.add(proc)
+            if self._shutdown:
+                interrupted = True
+            else:
+                self._active.add(proc)
+                interrupted = False
+        if interrupted:
+            # An interrupt began before this child was registered; stop it now so it
+            # cannot escape termination. The returned result is discarded as run() unwinds.
+            self._stop(proc)
+            stdout, stderr = proc.communicate()
+            return ShellResult(
+                task=task,
+                returncode=proc.returncode,
+                stdout=stdout or b"",
+                stderr=stderr or b"",
+                duration=time.monotonic() - start,
+                exception=None,
+                timed_out=False,
+            )
         timed_out = False
         exception: Exception | None = None
         timeout = task.timeout if (task.timeout is not None and task.timeout > 0) else None
@@ -194,6 +213,7 @@ class ParallelShellExecutor:
         if not tasks:
             return []
 
+        self._shutdown = False
         use_live = self._resolve_use_live(len(tasks))
         results_by_key: dict[str, ShellResult] = {}
         progress: Progress | None = None
@@ -234,7 +254,10 @@ class ParallelShellExecutor:
                 future_map = {pool.submit(self._run_one, task): task for task in tasks}
                 consume(future_map)
         except BaseException:
-            # Interrupted (e.g. Ctrl-C): drop queued tasks and stop running children, then propagate.
+            # Interrupted (e.g. Ctrl-C): stop accepting/continuing work, drop queued tasks,
+            # and terminate running children, then propagate.
+            with self._lock:
+                self._shutdown = True
             pool.shutdown(wait=False, cancel_futures=True)
             self._terminate_active()
             raise

--- a/posit-bakery/posit_bakery/parallel/executor.py
+++ b/posit-bakery/posit_bakery/parallel/executor.py
@@ -105,12 +105,28 @@ class ParallelShellExecutor:
         self._active: set[subprocess.Popen] = set()
         self._lock = threading.Lock()
         self._shutdown = False
+        self._progress: Progress | None = None
+        self._progress_ids: dict[str, Any] = {}
 
     def _resolve_use_live(self, n_tasks: int) -> bool:
         """Decide whether to render a live table: explicit override, else TTY + not quiet + >1 task."""
         if self._use_live is not None:
             return self._use_live
         return self.console.is_terminal and SETTINGS.log_level < logging.ERROR and n_tasks > 1
+
+    def _mark_running(self, task: ShellTask) -> None:
+        """Flip a task's live-table row from queued to running and start its timer.
+
+        Safe to call from worker threads: Rich Progress mutations are internally locked and
+        are not console output. No-op when no live Progress is attached.
+        """
+        progress = self._progress
+        if progress is None:
+            return
+        task_id = self._progress_ids.get(task.key)
+        if task_id is not None:
+            progress.start_task(task_id)
+            progress.update(task_id, description=f"[bright_blue]running {task.display_label}")
 
     def _run_one(self, task: ShellTask) -> ShellResult:
         """Run one task as a tracked child process, enforcing task.timeout if set."""
@@ -149,6 +165,7 @@ class ParallelShellExecutor:
                 exception=None,
                 timed_out=False,
             )
+        self._mark_running(task)
         timed_out = False
         exception: Exception | None = None
         timeout = task.timeout if (task.timeout is not None and task.timeout > 0) else None
@@ -214,6 +231,8 @@ class ParallelShellExecutor:
             return []
 
         self._shutdown = False
+        self._progress = None
+        self._progress_ids = {}
         use_live = self._resolve_use_live(len(tasks))
         results_by_key: dict[str, ShellResult] = {}
         progress: Progress | None = None
@@ -227,6 +246,7 @@ class ParallelShellExecutor:
                 console=self.console,
                 transient=False,
             )
+            self._progress = progress
 
         def consume(future_map: dict) -> None:
             for future in as_completed(future_map):
@@ -247,7 +267,10 @@ class ParallelShellExecutor:
             if progress is not None:
                 with progress:
                     for task in tasks:
-                        progress_ids[task.key] = progress.add_task(f"[quiet]queued {task.display_label}", total=1)
+                        progress_ids[task.key] = progress.add_task(
+                            f"[quiet]{'queued':<7} {task.display_label}", total=1, start=False
+                        )
+                    self._progress_ids = progress_ids
                     future_map = {pool.submit(self._run_one, task): task for task in tasks}
                     consume(future_map)
             else:
@@ -263,5 +286,8 @@ class ParallelShellExecutor:
             raise
         else:
             pool.shutdown(wait=True)
+        finally:
+            self._progress = None
+            self._progress_ids = {}
 
         return [results_by_key[task.key] for task in tasks]

--- a/posit-bakery/posit_bakery/parallel/executor.py
+++ b/posit-bakery/posit_bakery/parallel/executor.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
+import logging
+import subprocess
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
+from rich.console import Console
+from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
+
+from posit_bakery.log import stderr_console
 from posit_bakery.settings import SETTINGS
 
 
@@ -52,5 +60,99 @@ def resolve_max_workers(jobs: int | None, n_tasks: int) -> int:
     return min(workers, max(1, n_tasks))
 
 
-class ParallelShellExecutor:  # implemented in Task 3
-    pass
+class ParallelShellExecutor:
+    """Run ShellTasks concurrently with bounded workers and an optional Rich live table.
+
+    Worker threads only run their subprocess and return captured bytes — they never touch
+    the logger or console. The main thread drains completions, drives the live table, and
+    invokes ``on_result`` (so callers mutate shared state without locks).
+    """
+
+    def __init__(
+        self,
+        *,
+        max_workers: int,
+        console: Console = stderr_console,
+        use_live: bool | None = None,
+    ) -> None:
+        self.max_workers = max(1, max_workers)
+        self.console = console
+        self._use_live = use_live
+
+    def _resolve_use_live(self, n_tasks: int) -> bool:
+        """Decide whether to render a live table: explicit override, else TTY + not quiet + >1 task."""
+        if self._use_live is not None:
+            return self._use_live
+        return self.console.is_terminal and SETTINGS.log_level < logging.ERROR and n_tasks > 1
+
+    def _run_one(self, task: ShellTask) -> ShellResult:
+        """Run a single task's subprocess, capturing output and any spawn failure."""
+        start = time.monotonic()
+        try:
+            completed = subprocess.run(task.cmd, env=task.env, cwd=task.cwd, capture_output=True)
+            return ShellResult(
+                task=task,
+                returncode=completed.returncode,
+                stdout=completed.stdout,
+                stderr=completed.stderr,
+                duration=time.monotonic() - start,
+            )
+        except Exception as exc:  # spawn failures (FileNotFoundError, PermissionError, ...)
+            return ShellResult(
+                task=task,
+                returncode=None,
+                stdout=b"",
+                stderr=b"",
+                duration=time.monotonic() - start,
+                exception=exc,
+            )
+
+    def run(
+        self,
+        tasks: list[ShellTask],
+        *,
+        on_result: Callable[[ShellResult], None] | None = None,
+    ) -> list[ShellResult]:
+        """Run all tasks, returning results in input order. ``on_result`` fires per task on the main thread."""
+        if not tasks:
+            return []
+
+        use_live = self._resolve_use_live(len(tasks))
+        results_by_key: dict[str, ShellResult] = {}
+        progress: Progress | None = None
+        progress_ids: dict[str, Any] = {}
+
+        if use_live:
+            progress = Progress(
+                SpinnerColumn(),
+                TextColumn("[progress.description]{task.description}"),
+                TimeElapsedColumn(),
+                console=self.console,
+                transient=False,
+            )
+
+        def drain() -> None:
+            with ThreadPoolExecutor(max_workers=self.max_workers) as pool:
+                future_map = {pool.submit(self._run_one, task): task for task in tasks}
+                for future in as_completed(future_map):
+                    result = future.result()
+                    results_by_key[result.task.key] = result
+                    if progress is not None:
+                        status = "[green3]✓" if result.ok else "[bright_red]✗"
+                        progress.update(
+                            progress_ids[result.task.key],
+                            description=f"{status} {result.task.display_label}",
+                            completed=1,
+                        )
+                    if on_result is not None:
+                        on_result(result)
+
+        if progress is not None:
+            with progress:
+                for task in tasks:
+                    progress_ids[task.key] = progress.add_task(f"[quiet]queued {task.display_label}", total=1)
+                drain()
+        else:
+            drain()
+
+        return [results_by_key[task.key] for task in tasks]

--- a/posit-bakery/posit_bakery/parallel/executor.py
+++ b/posit-bakery/posit_bakery/parallel/executor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import subprocess
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
@@ -14,6 +15,10 @@ from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 from posit_bakery.log import stderr_console
 from posit_bakery.settings import SETTINGS
 
+# Grace period (seconds) to let a SIGTERM'd child exit cleanly — e.g. dgoss removing its
+# container via its EXIT trap — before we escalate to SIGKILL.
+TERMINATE_GRACE_SECONDS = 10.0
+
 
 @dataclass
 class ShellTask:
@@ -25,6 +30,7 @@ class ShellTask:
     cwd: Path | None = None
     label: str | None = None
     payload: Any = None  # opaque caller data, passed through unchanged to ShellResult.task.payload
+    timeout: float | None = None  # seconds; None or <=0 means no timeout (enforced by the caller)
 
     @property
     def display_label(self) -> str:
@@ -42,6 +48,7 @@ class ShellResult:
     stderr: bytes
     duration: float
     exception: Exception | None = None
+    timed_out: bool = False
 
     @property
     def ok(self) -> bool:
@@ -78,6 +85,8 @@ class ParallelShellExecutor:
         self.max_workers = max(1, max_workers)
         self.console = console
         self._use_live = use_live
+        self._active: set[subprocess.Popen] = set()
+        self._lock = threading.Lock()
 
     def _resolve_use_live(self, n_tasks: int) -> bool:
         """Decide whether to render a live table: explicit override, else TTY + not quiet + >1 task."""
@@ -86,26 +95,79 @@ class ParallelShellExecutor:
         return self.console.is_terminal and SETTINGS.log_level < logging.ERROR and n_tasks > 1
 
     def _run_one(self, task: ShellTask) -> ShellResult:
-        """Run a single task's subprocess, capturing output and any spawn failure."""
+        """Run one task as a tracked child process, enforcing task.timeout if set."""
         start = time.monotonic()
         try:
-            completed = subprocess.run(task.cmd, env=task.env, cwd=task.cwd, capture_output=True)
-            return ShellResult(
-                task=task,
-                returncode=completed.returncode,
-                stdout=completed.stdout,
-                stderr=completed.stderr,
-                duration=time.monotonic() - start,
+            proc = subprocess.Popen(
+                task.cmd, env=task.env, cwd=task.cwd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
             )
         except Exception as exc:  # spawn failures (FileNotFoundError, PermissionError, ...)
             return ShellResult(
-                task=task,
-                returncode=None,
-                stdout=b"",
-                stderr=b"",
-                duration=time.monotonic() - start,
-                exception=exc,
+                task=task, returncode=None, stdout=b"", stderr=b"", duration=time.monotonic() - start, exception=exc
             )
+
+        with self._lock:
+            self._active.add(proc)
+        timed_out = False
+        exception: Exception | None = None
+        timeout = task.timeout if (task.timeout is not None and task.timeout > 0) else None
+        try:
+            try:
+                stdout, stderr = proc.communicate(timeout=timeout)
+            except subprocess.TimeoutExpired as exc:
+                timed_out = True
+                exception = exc
+                self._stop(proc)
+                stdout, stderr = proc.communicate()  # reap remaining output after the child exits
+        finally:
+            with self._lock:
+                self._active.discard(proc)
+
+        return ShellResult(
+            task=task,
+            returncode=proc.returncode,
+            stdout=stdout or b"",
+            stderr=stderr or b"",
+            duration=time.monotonic() - start,
+            exception=exception,
+            timed_out=timed_out,
+        )
+
+    @staticmethod
+    def _stop(proc: subprocess.Popen, grace: float = TERMINATE_GRACE_SECONDS) -> None:
+        """Stop a child gracefully: SIGTERM, wait up to grace, then SIGKILL if still alive."""
+        try:
+            proc.terminate()
+        except Exception:
+            return
+        try:
+            proc.wait(timeout=grace)
+        except subprocess.TimeoutExpired:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+
+    def _terminate_active(self, grace: float = TERMINATE_GRACE_SECONDS) -> None:
+        """Terminate every in-flight child: SIGTERM all, then SIGKILL stragglers after a shared grace window."""
+        with self._lock:
+            procs = list(self._active)
+        for proc in procs:
+            try:
+                proc.terminate()
+            except Exception:
+                pass
+        deadline = time.monotonic() + grace
+        for proc in procs:
+            try:
+                proc.wait(timeout=max(0.0, deadline - time.monotonic()))
+            except subprocess.TimeoutExpired:
+                try:
+                    proc.kill()
+                except Exception:
+                    pass
+            except Exception:
+                pass
 
     def run(
         self,
@@ -113,7 +175,12 @@ class ParallelShellExecutor:
         *,
         on_result: Callable[[ShellResult], None] | None = None,
     ) -> list[ShellResult]:
-        """Run all tasks, returning results in input order. ``on_result`` fires per task on the main thread."""
+        """Run all tasks, returning results in input order. ``on_result`` fires per task on the main thread.
+
+        On KeyboardInterrupt (or any BaseException) the executor cancels queued tasks and
+        terminates in-flight child processes before re-raising, so Ctrl-C is responsive and
+        does not leave orphaned children.
+        """
         if not tasks:
             return []
 
@@ -131,28 +198,37 @@ class ParallelShellExecutor:
                 transient=False,
             )
 
-        def drain() -> None:
-            with ThreadPoolExecutor(max_workers=self.max_workers) as pool:
-                future_map = {pool.submit(self._run_one, task): task for task in tasks}
-                for future in as_completed(future_map):
-                    result = future.result()
-                    results_by_key[result.task.key] = result
-                    if progress is not None:
-                        status = "[green3]✓" if result.ok else "[bright_red]✗"
-                        progress.update(
-                            progress_ids[result.task.key],
-                            description=f"{status} {result.task.display_label}",
-                            completed=1,
-                        )
-                    if on_result is not None:
-                        on_result(result)
+        def consume(future_map: dict) -> None:
+            for future in as_completed(future_map):
+                result = future.result()
+                results_by_key[result.task.key] = result
+                if progress is not None:
+                    status = "[green3]✓" if result.ok else "[bright_red]✗"
+                    progress.update(
+                        progress_ids[result.task.key],
+                        description=f"{status} {result.task.display_label}",
+                        completed=1,
+                    )
+                if on_result is not None:
+                    on_result(result)
 
-        if progress is not None:
-            with progress:
-                for task in tasks:
-                    progress_ids[task.key] = progress.add_task(f"[quiet]queued {task.display_label}", total=1)
-                drain()
+        pool = ThreadPoolExecutor(max_workers=self.max_workers)
+        try:
+            if progress is not None:
+                with progress:
+                    for task in tasks:
+                        progress_ids[task.key] = progress.add_task(f"[quiet]queued {task.display_label}", total=1)
+                    future_map = {pool.submit(self._run_one, task): task for task in tasks}
+                    consume(future_map)
+            else:
+                future_map = {pool.submit(self._run_one, task): task for task in tasks}
+                consume(future_map)
+        except BaseException:
+            # Interrupted (e.g. Ctrl-C): drop queued tasks and stop running children, then propagate.
+            pool.shutdown(wait=False, cancel_futures=True)
+            self._terminate_active()
+            raise
         else:
-            drain()
+            pool.shutdown(wait=True)
 
         return [results_by_key[task.key] for task in tasks]

--- a/posit-bakery/posit_bakery/parallel/executor.py
+++ b/posit-bakery/posit_bakery/parallel/executor.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+import os
+import signal
 import subprocess
 import threading
 import time
@@ -15,9 +17,24 @@ from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 from posit_bakery.log import stderr_console
 from posit_bakery.settings import SETTINGS
 
-# Grace period (seconds) to let a SIGTERM'd child exit cleanly — e.g. dgoss removing its
-# container via its EXIT trap — before we escalate to SIGKILL.
+# Grace period (seconds) to let a SIGTERM'd child group exit cleanly — e.g. dgoss removing
+# its container via its EXIT trap — before we escalate to SIGKILL.
 TERMINATE_GRACE_SECONDS = 10.0
+
+
+def _signal_process_group(proc: subprocess.Popen, sig: int) -> None:
+    """Send `sig` to the child's whole process group, so a wrapper (e.g. dgoss) and the
+    processes it spawned (e.g. docker) are all signalled together. Falls back to signalling
+    just the process where process groups are unavailable (non-POSIX) or the child is already
+    gone. Best-effort: never raises.
+    """
+    try:
+        os.killpg(os.getpgid(proc.pid), sig)
+    except (ProcessLookupError, PermissionError, OSError, AttributeError):
+        try:
+            proc.send_signal(sig)
+        except Exception:
+            pass
 
 
 @dataclass
@@ -99,7 +116,12 @@ class ParallelShellExecutor:
         start = time.monotonic()
         try:
             proc = subprocess.Popen(
-                task.cmd, env=task.env, cwd=task.cwd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                task.cmd,
+                env=task.env,
+                cwd=task.cwd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                start_new_session=True,
             )
         except Exception as exc:  # spawn failures (FileNotFoundError, PermissionError, ...)
             return ShellResult(
@@ -135,37 +157,25 @@ class ParallelShellExecutor:
 
     @staticmethod
     def _stop(proc: subprocess.Popen, grace: float = TERMINATE_GRACE_SECONDS) -> None:
-        """Stop a child gracefully: SIGTERM, wait up to grace, then SIGKILL if still alive."""
-        try:
-            proc.terminate()
-        except Exception:
-            return
+        """Stop a child group gracefully: SIGTERM the group, wait up to grace, then SIGKILL it."""
+        _signal_process_group(proc, signal.SIGTERM)
         try:
             proc.wait(timeout=grace)
         except subprocess.TimeoutExpired:
-            try:
-                proc.kill()
-            except Exception:
-                pass
+            _signal_process_group(proc, signal.SIGKILL)
 
     def _terminate_active(self, grace: float = TERMINATE_GRACE_SECONDS) -> None:
-        """Terminate every in-flight child: SIGTERM all, then SIGKILL stragglers after a shared grace window."""
+        """Terminate every in-flight child group: SIGTERM all, then SIGKILL stragglers after a shared grace window."""
         with self._lock:
             procs = list(self._active)
         for proc in procs:
-            try:
-                proc.terminate()
-            except Exception:
-                pass
+            _signal_process_group(proc, signal.SIGTERM)
         deadline = time.monotonic() + grace
         for proc in procs:
             try:
                 proc.wait(timeout=max(0.0, deadline - time.monotonic()))
             except subprocess.TimeoutExpired:
-                try:
-                    proc.kill()
-                except Exception:
-                    pass
+                _signal_process_group(proc, signal.SIGKILL)
             except Exception:
                 pass
 

--- a/posit-bakery/posit_bakery/parallel/executor.py
+++ b/posit-bakery/posit_bakery/parallel/executor.py
@@ -16,7 +16,7 @@ class ShellTask:
     env: dict[str, str] | None = None
     cwd: Path | None = None
     label: str | None = None
-    payload: Any = None
+    payload: Any = None  # opaque caller data, passed through unchanged to ShellResult.task.payload
 
     @property
     def display_label(self) -> str:

--- a/posit-bakery/posit_bakery/parallel/executor.py
+++ b/posit-bakery/posit_bakery/parallel/executor.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import subprocess
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+from posit_bakery.settings import SETTINGS
+
+
+@dataclass
+class ShellTask:
+    """A single subprocess invocation to run in parallel."""
+
+    key: str
+    cmd: list[str]
+    env: dict[str, str] | None = None
+    cwd: Path | None = None
+    label: str | None = None
+    payload: Any = None
+
+    @property
+    def display_label(self) -> str:
+        """Human-facing label for live output; falls back to the task key."""
+        return self.label or self.key
+
+
+@dataclass
+class ShellResult:
+    """The outcome of running a ShellTask."""
+
+    task: ShellTask
+    returncode: int | None
+    stdout: bytes
+    stderr: bytes
+    duration: float
+    exception: Exception | None = None
+
+    @property
+    def ok(self) -> bool:
+        """True when the process spawned and exited zero."""
+        return self.exception is None and self.returncode == 0
+
+
+def resolve_max_workers(jobs: int | None, n_tasks: int) -> int:
+    """Resolve the worker count: --jobs override, else SETTINGS, clamped to [1, n_tasks].
+
+    :param jobs: Explicit override (e.g. from a --jobs CLI flag). Ignored when not positive.
+    :param n_tasks: Number of tasks to run; the result never exceeds this (but is at least 1).
+    """
+    workers = jobs if (jobs is not None and jobs > 0) else SETTINGS.max_concurrency
+    workers = max(1, workers)
+    return min(workers, max(1, n_tasks))
+
+
+class ParallelShellExecutor:  # implemented in Task 3
+    pass

--- a/posit-bakery/posit_bakery/plugins/builtin/dgoss/__init__.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/dgoss/__init__.py
@@ -126,6 +126,16 @@ class DGossPlugin(BakeryToolPlugin):
                     help="Path to a build metadata file. If given, attempts to run tests against image artifacts in the file."
                 ),
             ] = None,
+            jobs: Annotated[
+                Optional[int],
+                typer.Option(
+                    "--jobs",
+                    "-j",
+                    show_default=False,
+                    help="Maximum number of dgoss commands to run concurrently. "
+                    "Defaults to the BAKERY_MAX_CONCURRENCY env var or a built-in default.",
+                ),
+            ] = None,
             clean: Annotated[
                 Optional[bool],
                 typer.Option(
@@ -170,7 +180,7 @@ class DGossPlugin(BakeryToolPlugin):
             if metadata_file:
                 c.load_build_metadata_from_file(metadata_file)
 
-            results = plugin.execute(c.base_path, c.targets, platform=platform)
+            results = plugin.execute(c.base_path, c.targets, platform=platform, jobs=jobs)
             plugin.results(results)
 
         app.add_typer(dgoss_app, name="dgoss", help="Run Goss tests against container images")
@@ -181,10 +191,11 @@ class DGossPlugin(BakeryToolPlugin):
         targets: list[ImageTarget],
         *,
         platform: str | None = None,
+        jobs: int | None = None,
         **kwargs,
     ) -> list[ToolCallResult]:
         """Execute dgoss tests against the given image targets."""
-        suite = DGossSuite(base_path, targets, platform=platform)
+        suite = DGossSuite(base_path, targets, platform=platform, jobs=jobs)
         report_collection, errors = suite.run()
 
         # Build error lookup

--- a/posit-bakery/posit_bakery/plugins/builtin/dgoss/command.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/dgoss/command.py
@@ -6,6 +6,7 @@ from typing import Annotated, Self, Literal
 from pydantic import BaseModel, Field, model_validator, computed_field
 
 from posit_bakery.image.image_target import ImageTargetContext, ImageTarget
+from posit_bakery.plugins.builtin.dgoss.options import DEFAULT_GOSS_TIMEOUT_SECONDS
 from posit_bakery.util import find_bin
 
 
@@ -54,6 +55,7 @@ class DGossCommand(BaseModel):
     test_path: Annotated[Path | None, Field(default_factory=lambda data: find_test_path(data["image_target"].context))]
     runtime_options: Annotated[str | None, Field(default=None, description="Additional runtime options for dgoss.")]
     wait: Annotated[int, Field(default=0)]
+    timeout: Annotated[int, Field(default=DEFAULT_GOSS_TIMEOUT_SECONDS)]
     image_command: Annotated[str, Field(default="sleep infinity")]
 
     @property
@@ -128,6 +130,7 @@ class DGossCommand(BaseModel):
                 args["runtime_options"] = goss_options.runtimeOptions
                 args["image_command"] = goss_options.command
                 args["wait"] = goss_options.wait
+                args["timeout"] = goss_options.timeout
         return cls(**args)
 
     @model_validator(mode="after")

--- a/posit-bakery/posit_bakery/plugins/builtin/dgoss/options.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/dgoss/options.py
@@ -5,6 +5,8 @@ from pydantic import Field
 
 from posit_bakery.config.tools.base import ToolOptions
 
+DEFAULT_GOSS_TIMEOUT_SECONDS = 900  # 15 minutes
+
 
 class GossOptions(ToolOptions):
     """Configuration options for Goss testing."""
@@ -21,6 +23,14 @@ class GossOptions(ToolOptions):
             default=0,
             description="Time to wait before running tests, in seconds. Used as the value passed to the 'GOSS_SLEEP' "
             "environment variable.",
+        ),
+    ]
+    timeout: Annotated[
+        int,
+        Field(
+            default=DEFAULT_GOSS_TIMEOUT_SECONDS,
+            description="Maximum seconds to allow a dgoss container to run before it is terminated. "
+            "Set to 0 to disable the timeout.",
         ),
     ]
 
@@ -40,5 +50,7 @@ class GossOptions(ToolOptions):
             and "runtimeOptions" not in self.model_fields_set
         ):
             merged_options.runtimeOptions = other.runtimeOptions
+        if self.__pydantic_fields__["timeout"].default == self.timeout and "timeout" not in self.model_fields_set:
+            merged_options.timeout = other.timeout
 
         return merged_options

--- a/posit-bakery/posit_bakery/plugins/builtin/dgoss/suite.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/dgoss/suite.py
@@ -50,6 +50,7 @@ class DGossSuite:
                     cwd=self.context,
                     label=str(dgoss_command.image_target),
                     payload=dgoss_command,
+                    timeout=dgoss_command.timeout if dgoss_command.timeout > 0 else None,
                 )
             )
 
@@ -65,6 +66,25 @@ class DGossSuite:
             image_subdir = results_dir / target.image_name
             image_subdir.mkdir(parents=True, exist_ok=True)
             results_file = image_subdir / f"{target.uid}.json"
+
+            if result.timed_out:
+                log.error(f"dgoss for image '{str(target)}' timed out after {dgoss_command.timeout}s")
+                errors.append(
+                    BakeryDGossError(
+                        f"dgoss execution timed out for image '{str(target)}' after {dgoss_command.timeout}s",
+                        "dgoss",
+                        cmd=dgoss_command.command,
+                        stdout=result.stdout,
+                        stderr=result.stderr,
+                        parse_error=result.exception,
+                        exit_code=result.returncode if result.returncode is not None else 1,
+                        metadata={
+                            "environment_variables": dgoss_command.dgoss_environment,
+                            "timeout": dgoss_command.timeout,
+                        },
+                    )
+                )
+                return
 
             # A spawn failure (e.g. dgoss binary missing) is an execution error, not a test failure.
             if result.exception is not None:

--- a/posit-bakery/posit_bakery/plugins/builtin/dgoss/suite.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/dgoss/suite.py
@@ -77,7 +77,7 @@ class DGossSuite:
                         stdout=result.stdout,
                         stderr=result.stderr,
                         parse_error=result.exception,
-                        exit_code=result.returncode or 1,
+                        exit_code=result.returncode or 1,  # returncode is None on spawn failure
                         metadata={"environment_variables": dgoss_command.dgoss_environment},
                     )
                 )
@@ -130,6 +130,8 @@ class DGossSuite:
             else:
                 log.warning(f"[yellow bold]Goss tests failed for '{str(target)}'")
 
+        # on_result fires on the main thread (see ParallelShellExecutor), so handle_result's
+        # mutation of report_collection / errors needs no lock.
         executor = ParallelShellExecutor(max_workers=self.max_workers)
         executor.run(tasks, on_result=handle_result)
 

--- a/posit-bakery/posit_bakery/plugins/builtin/dgoss/suite.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/dgoss/suite.py
@@ -2,25 +2,32 @@ import json
 import logging
 import os
 import shutil
-import subprocess
 from pathlib import Path
 
 import pydantic
 
 from posit_bakery.error import BakeryToolRuntimeError, BakeryToolRuntimeErrorGroup
+from posit_bakery.image.image_target import ImageTarget
+from posit_bakery.parallel import ParallelShellExecutor, ShellResult, ShellTask, resolve_max_workers
 from posit_bakery.plugins.builtin.dgoss.command import DGossCommand
 from posit_bakery.plugins.builtin.dgoss.errors import BakeryDGossError
-from posit_bakery.plugins.builtin.dgoss.report import GossJsonReportCollection, GossJsonReport
-from posit_bakery.image.image_target import ImageTarget
+from posit_bakery.plugins.builtin.dgoss.report import GossJsonReport, GossJsonReportCollection
 
 log = logging.getLogger(__name__)
 
 
 class DGossSuite:
-    def __init__(self, context: Path, image_targets: list[ImageTarget], platform: str | None = None) -> None:
+    def __init__(
+        self,
+        context: Path,
+        image_targets: list[ImageTarget],
+        platform: str | None = None,
+        jobs: int | None = None,
+    ) -> None:
         self.context = context
         self.image_targets = image_targets
         self.dgoss_commands = [DGossCommand.from_image_target(target, platform=platform) for target in image_targets]
+        self.max_workers = resolve_max_workers(jobs, len(self.dgoss_commands))
 
     def run(self) -> tuple[GossJsonReportCollection, BakeryToolRuntimeError | BakeryToolRuntimeErrorGroup | None]:
         results_dir = self.context / "results" / "dgoss"
@@ -29,44 +36,72 @@ class DGossSuite:
         results_dir.mkdir(parents=True)
 
         report_collection = GossJsonReportCollection()
-        errors = []
+        errors: list[BakeryToolRuntimeError] = []
 
+        tasks: list[ShellTask] = []
         for dgoss_command in self.dgoss_commands:
-            log.info(f"[bright_blue bold]=== Running Goss tests for '{str(dgoss_command.image_target)}' ===")
-            log.debug(f"[bright_black]Environment variables: {dgoss_command.dgoss_environment}")
-            log.debug(f"[bright_black]Executing dgoss command: {' '.join(dgoss_command.command)}")
-
             run_env = os.environ.copy()
             run_env.update(dgoss_command.dgoss_environment)
-            p = subprocess.run(dgoss_command.command, env=run_env, cwd=self.context, capture_output=True)
-            exit_code = p.returncode
+            tasks.append(
+                ShellTask(
+                    key=dgoss_command.image_target.uid,
+                    cmd=dgoss_command.command,
+                    env=run_env,
+                    cwd=self.context,
+                    label=str(dgoss_command.image_target),
+                    payload=dgoss_command,
+                )
+            )
 
-            image_subdir = results_dir / dgoss_command.image_target.image_name
+        def handle_result(result: ShellResult) -> None:
+            """Process one finished dgoss run on the main thread: parse, persist, and log."""
+            dgoss_command: DGossCommand = result.task.payload
+            target = dgoss_command.image_target
+
+            log.info(f"[bright_blue bold]=== Goss tests for '{str(target)}' ===")
+            log.debug(f"[bright_black]Environment variables: {dgoss_command.dgoss_environment}")
+            log.debug(f"[bright_black]Executed dgoss command: {' '.join(dgoss_command.command)}")
+
+            image_subdir = results_dir / target.image_name
             image_subdir.mkdir(parents=True, exist_ok=True)
-            results_file = image_subdir / f"{dgoss_command.image_target.uid}.json"
+            results_file = image_subdir / f"{target.uid}.json"
+
+            # A spawn failure (e.g. dgoss binary missing) is an execution error, not a test failure.
+            if result.exception is not None:
+                log.error(f"dgoss for image '{str(target)}' failed to execute: {result.exception}")
+                errors.append(
+                    BakeryDGossError(
+                        f"dgoss execution failed for image '{str(target)}'",
+                        "dgoss",
+                        cmd=dgoss_command.command,
+                        stdout=result.stdout,
+                        stderr=result.stderr,
+                        parse_error=result.exception,
+                        exit_code=result.returncode or 1,
+                        metadata={"environment_variables": dgoss_command.dgoss_environment},
+                    )
+                )
+                return
+
+            exit_code = result.returncode
 
             try:
-                output = p.stdout.decode("utf-8")
-                output = output.strip()
+                output = result.stdout.decode("utf-8").strip()
             except UnicodeDecodeError:
-                log.warning(f"Unexpected encoding for dgoss output for image '{str(dgoss_command.image_target)}'.")
-                output = p.stdout
+                log.warning(f"Unexpected encoding for dgoss output for image '{str(target)}'.")
+                output = result.stdout
             parse_err = None
 
             try:
                 result_data = json.loads(output)
                 output = json.dumps(result_data, indent=2)
-                report_collection.add_report(
-                    dgoss_command.image_target, GossJsonReport(filepath=results_file, **result_data)
-                )
+                report_collection.add_report(target, GossJsonReport(filepath=results_file, **result_data))
             except json.JSONDecodeError as e:
-                log.error(f"Failed to decode JSON output from dgoss for image '{str(dgoss_command.image_target)}': {e}")
+                log.error(f"Failed to decode JSON output from dgoss for image '{str(target)}': {e}")
                 parse_err = e
             except pydantic.ValidationError as e:
-                log.error(
-                    f"Failed to load result data for summary from dgoss for image '{str(dgoss_command.image_target)}: {e}"
-                )
-                log.warning(f"Test results will be excluded from '{str(dgoss_command.image_target)}' in final summary.")
+                log.error(f"Failed to load result data for summary from dgoss for image '{str(target)}: {e}")
+                log.warning(f"Test results will be excluded from '{str(target)}' in final summary.")
                 parse_err = e
 
             if not parse_err:
@@ -74,34 +109,36 @@ class DGossSuite:
                     log.info(f"Writing results to {results_file}")
                     f.write(output)
 
-            # Goss can exit 1 in multiple scenarios including test failures and incorrect configurations. From Bakery's
-            # perspective, we only want to report an error back if the execution of Goss failed in some way. Our best
-            # method of doing this is to check if both the exit code is non-zero, and we were unable to parse the output
-            # of the command.
+            # Goss exits 1 on both test failures and bad configs. Only report an execution error when the exit
+            # is non-zero AND we could not parse the output (a genuine failure to run, not a failing test).
             if exit_code != 0 and parse_err is not None:
-                log.error(f"dgoss for image '{str(dgoss_command.image_target)}' exited with code {exit_code}")
+                log.error(f"dgoss for image '{str(target)}' exited with code {exit_code}")
                 errors.append(
                     BakeryDGossError(
-                        f"dgoss execution failed for image '{str(dgoss_command.image_target)}'",
+                        f"dgoss execution failed for image '{str(target)}'",
                         "dgoss",
                         cmd=dgoss_command.command,
-                        stdout=p.stdout,
-                        stderr=p.stderr,
+                        stdout=result.stdout,
+                        stderr=result.stderr,
                         parse_error=parse_err,
                         exit_code=exit_code,
                         metadata={"environment_variables": dgoss_command.dgoss_environment},
                     )
                 )
             elif exit_code == 0:
-                log.info(f"[bright_green bold]Goss tests passed for '{str(dgoss_command.image_target)}'")
+                log.info(f"[bright_green bold]Goss tests passed for '{str(target)}'")
             else:
-                log.warning(f"[yellow bold]Goss tests failed for '{str(dgoss_command.image_target)}'")
+                log.warning(f"[yellow bold]Goss tests failed for '{str(target)}'")
+
+        executor = ParallelShellExecutor(max_workers=self.max_workers)
+        executor.run(tasks, on_result=handle_result)
 
         if errors:
+            collapsed: BakeryToolRuntimeError | BakeryToolRuntimeErrorGroup | None
             if len(errors) == 1:
-                errors = errors[0]
+                collapsed = errors[0]
             else:
-                errors = BakeryToolRuntimeErrorGroup(f"dgoss runtime errors occurred for multiple images.", errors)
+                collapsed = BakeryToolRuntimeErrorGroup("dgoss runtime errors occurred for multiple images.", errors)
         else:
-            errors = None
-        return report_collection, errors
+            collapsed = None
+        return report_collection, collapsed

--- a/posit-bakery/posit_bakery/settings.py
+++ b/posit-bakery/posit_bakery/settings.py
@@ -1,9 +1,12 @@
 import logging
+import os
 import platform
 import tempfile
 from pathlib import Path
 
 import typer
+
+from posit_bakery.const import DEFAULT_MAX_CONCURRENCY
 
 
 class Settings:
@@ -15,6 +18,7 @@ class Settings:
         self.temporary_storage: Path = Path(tempfile.gettempdir())
         self.log_level: str | int = logging.INFO
         self.architecture = self.get_host_architecture()
+        self.max_concurrency: int = int(os.environ.get("BAKERY_MAX_CONCURRENCY", DEFAULT_MAX_CONCURRENCY))
 
     @staticmethod
     def get_host_architecture() -> str:

--- a/posit-bakery/posit_bakery/settings.py
+++ b/posit-bakery/posit_bakery/settings.py
@@ -9,6 +9,20 @@ import typer
 from posit_bakery.const import DEFAULT_MAX_CONCURRENCY
 
 
+def _parse_max_concurrency() -> int:
+    """Parse BAKERY_MAX_CONCURRENCY, falling back to the default on a missing or malformed value."""
+    raw = os.environ.get("BAKERY_MAX_CONCURRENCY")
+    if raw is None or raw == "":
+        return DEFAULT_MAX_CONCURRENCY
+    try:
+        return int(raw)
+    except ValueError:
+        logging.getLogger(__name__).warning(
+            "Invalid BAKERY_MAX_CONCURRENCY=%r; falling back to default %d.", raw, DEFAULT_MAX_CONCURRENCY
+        )
+        return DEFAULT_MAX_CONCURRENCY
+
+
 class Settings:
     """Application settings and paths."""
 
@@ -18,7 +32,7 @@ class Settings:
         self.temporary_storage: Path = Path(tempfile.gettempdir())
         self.log_level: str | int = logging.INFO
         self.architecture = self.get_host_architecture()
-        self.max_concurrency: int = int(os.environ.get("BAKERY_MAX_CONCURRENCY", DEFAULT_MAX_CONCURRENCY))
+        self.max_concurrency: int = _parse_max_concurrency()
 
     @staticmethod
     def get_host_architecture() -> str:

--- a/posit-bakery/test/cli/test_run_dgoss.py
+++ b/posit-bakery/test/cli/test_run_dgoss.py
@@ -84,27 +84,3 @@ class TestRunDgossLatestFlag:
         assert result.exit_code == 0, result.stdout
         settings = mock_config.from_context.call_args[0][1]
         assert settings.latest is False
-
-
-def test_run_accepts_jobs_flag(tmp_path):
-    """`dgoss run --jobs N` forwards jobs into the plugin's execute()."""
-    from posit_bakery.plugins.builtin.dgoss import DGossPlugin
-
-    with (
-        patch("posit_bakery.plugins.builtin.dgoss.BakeryConfig") as mock_config,
-        patch.object(DGossPlugin, "execute", return_value=[]) as execute_spy,
-        patch.object(DGossPlugin, "results", return_value=None),
-    ):
-        instance = MagicMock()
-        instance.base_path = tmp_path
-        instance.targets = []
-        mock_config.from_context.return_value = instance
-
-        result = runner.invoke(
-            app,
-            ["dgoss", "run", "--context", str(tmp_path), "--jobs", "2"],
-            catch_exceptions=False,
-        )
-
-        assert result.exit_code == 0, result.output
-        assert execute_spy.call_args.kwargs["jobs"] == 2

--- a/posit-bakery/test/cli/test_run_dgoss.py
+++ b/posit-bakery/test/cli/test_run_dgoss.py
@@ -84,3 +84,27 @@ class TestRunDgossLatestFlag:
         assert result.exit_code == 0, result.stdout
         settings = mock_config.from_context.call_args[0][1]
         assert settings.latest is False
+
+
+def test_run_accepts_jobs_flag(tmp_path):
+    """`dgoss run --jobs N` forwards jobs into the plugin's execute()."""
+    from posit_bakery.plugins.builtin.dgoss import DGossPlugin
+
+    with (
+        patch("posit_bakery.plugins.builtin.dgoss.BakeryConfig") as mock_config,
+        patch.object(DGossPlugin, "execute", return_value=[]) as execute_spy,
+        patch.object(DGossPlugin, "results", return_value=None),
+    ):
+        instance = MagicMock()
+        instance.base_path = tmp_path
+        instance.targets = []
+        mock_config.from_context.return_value = instance
+
+        result = runner.invoke(
+            app,
+            ["dgoss", "run", "--context", str(tmp_path), "--jobs", "2"],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0, result.output
+        assert execute_spy.call_args.kwargs["jobs"] == 2

--- a/posit-bakery/test/config/tools/test_goss.py
+++ b/posit-bakery/test/config/tools/test_goss.py
@@ -38,3 +38,16 @@ class TestGoss:
 
         for key, value in expected.items():
             assert getattr(merged, key) == value, f"Expected {key} to be {value}, got {getattr(merged, key)}"
+
+    def test_timeout_default_is_900(self):
+        assert GossOptions().timeout == 900
+
+    def test_timeout_merge_prefers_explicit_value(self):
+        base = GossOptions()  # timeout left at default
+        override = GossOptions(timeout=120)
+        assert base.update(override).timeout == 120
+
+    def test_timeout_merge_keeps_explicit_when_set(self):
+        base = GossOptions(timeout=30)  # explicitly set
+        override = GossOptions(timeout=120)
+        assert base.update(override).timeout == 30

--- a/posit-bakery/test/parallel/test_executor.py
+++ b/posit-bakery/test/parallel/test_executor.py
@@ -181,30 +181,44 @@ class TestParallelShellExecutorTimeout:
         assert results[0].timed_out is False
         assert results[0].ok is True
 
-    def test_timeout_terminates_whole_process_group(self, tmp_path):
-        import time as _t
-
+    def test_terminate_kills_whole_process_group(self, tmp_path):
+        # A parent task spawns a grandchild that writes an incrementing heartbeat. We wait until the
+        # grandchild is actually writing (readiness) and THEN interrupt -- rather than relying on a
+        # fixed timer that races interpreter startup under heavy CI parallelism. If only the parent
+        # were signalled, the reparented grandchild would keep writing; terminating the whole process
+        # group stops it.
         hb = tmp_path / "heartbeat"
         grandchild_src = (
             "import time\n"
-            f"i = 0\n"
-            f"while True:\n"
+            "i = 0\n"
+            "while True:\n"
             f"    open({str(hb)!r}, 'w').write(str(i))\n"
-            f"    i += 1\n"
-            f"    time.sleep(0.05)\n"
+            "    i += 1\n"
+            "    time.sleep(0.05)\n"
         )
-        # Parent spawns the grandchild (which inherits the parent's new session/process group)
-        # and waits on it. If only the parent were killed, the reparented grandchild would keep
-        # writing the heartbeat; killing the whole group stops it.
         parent_src = "import subprocess, sys\ng = subprocess.Popen([sys.executable, '-c', sys.argv[1]])\ng.wait()\n"
-        tasks = [ShellTask(key="t", cmd=[sys.executable, "-c", parent_src, grandchild_src], timeout=0.5)]
-        self._executor(1).run(tasks)
+        tasks = [ShellTask(key="t", cmd=[sys.executable, "-c", parent_src, grandchild_src])]
 
-        _t.sleep(0.3)
+        def fire():
+            # Wait until the grandchild is up and writing, then interrupt; gating on readiness
+            # (rather than a fixed delay) keeps this deterministic under any runner load.
+            deadline = time.monotonic() + 30
+            while time.monotonic() < deadline and not hb.exists():
+                time.sleep(0.02)
+            time.sleep(0.1)  # let the grandchild record a few beats
+            os.kill(os.getpid(), signal.SIGINT)
+
+        threading.Thread(target=fire, daemon=True).start()
+        try:
+            self._executor(1).run(tasks)
+        except KeyboardInterrupt:
+            pass
+
+        assert hb.exists()  # grandchild started and wrote at least once
         v1 = hb.read_text()
-        _t.sleep(0.5)
+        time.sleep(0.5)
         v2 = hb.read_text()
-        assert v1 == v2  # grandchild stopped writing -> the entire process group was terminated
+        assert v1 == v2  # heartbeat frozen -> the whole process group (incl. grandchild) was terminated
 
 
 class TestParallelShellExecutorInterrupt:

--- a/posit-bakery/test/parallel/test_executor.py
+++ b/posit-bakery/test/parallel/test_executor.py
@@ -1,7 +1,11 @@
+import glob
 import io
 import os
+import signal
 import sys
+import tempfile
 import threading
+import time
 
 import pytest
 from rich.console import Console
@@ -154,3 +158,58 @@ class TestParallelShellExecutor:
         assert ex_term._resolve_use_live(2) is True
         assert ex_term._resolve_use_live(1) is False  # single task -> no live table
         assert ex_plain._resolve_use_live(2) is False  # non-terminal -> no live table
+
+
+class TestParallelShellExecutorTimeout:
+    def _executor(self, max_workers):
+        return ParallelShellExecutor(max_workers=max_workers, console=Console(file=io.StringIO()), use_live=False)
+
+    def test_timeout_marks_result(self):
+        # Sleeps 5s but times out at 0.3s -> killed, flagged timed_out, not raised.
+        tasks = [ShellTask(key="t", cmd=[sys.executable, "-c", "import time; time.sleep(5)"], timeout=0.3)]
+        start = time.monotonic()
+        results = self._executor(1).run(tasks)
+        elapsed = time.monotonic() - start
+        assert results[0].timed_out is True
+        assert results[0].ok is False
+        assert results[0].returncode != 0
+        assert elapsed < 4  # killed well before the 5s sleep would finish
+
+    def test_no_timeout_when_none(self):
+        tasks = [ShellTask(key="t", cmd=[sys.executable, "-c", "pass"], timeout=None)]
+        results = self._executor(1).run(tasks)
+        assert results[0].timed_out is False
+        assert results[0].ok is True
+
+
+class TestParallelShellExecutorInterrupt:
+    def test_sigint_cancels_queued_and_terminates_running(self, tmp_path):
+        # 8 tasks, 2 workers, each writes a start marker then sleeps 3s then an end marker.
+        # SIGINT fires 0.3s in. Expect: KeyboardInterrupt raised, no task reaches its end
+        # marker (running ones killed), not all started (queued ones cancelled), returns fast.
+        script = "import sys,time;open(sys.argv[1],'w').close();time.sleep(3);open(sys.argv[2],'w').close()"
+        tasks = [
+            ShellTask(key=str(i), cmd=[sys.executable, "-c", script, str(tmp_path / f"s{i}"), str(tmp_path / f"e{i}")])
+            for i in range(8)
+        ]
+
+        def fire():
+            time.sleep(0.3)
+            os.kill(os.getpid(), signal.SIGINT)
+
+        threading.Thread(target=fire, daemon=True).start()
+        ex = ParallelShellExecutor(max_workers=2, console=Console(file=io.StringIO()), use_live=False)
+        start = time.monotonic()
+        interrupted = False
+        try:
+            ex.run(tasks)
+        except KeyboardInterrupt:
+            interrupted = True
+        elapsed = time.monotonic() - start
+
+        started = len(glob.glob(str(tmp_path / "s*")))
+        ended = len(glob.glob(str(tmp_path / "e*")))
+        assert interrupted is True
+        assert ended == 0  # nothing ran to completion (running tasks were killed)
+        assert started < 8  # queued tasks were cancelled, not launched
+        assert elapsed < 3  # returned promptly, did not drain the full queue

--- a/posit-bakery/test/parallel/test_executor.py
+++ b/posit-bakery/test/parallel/test_executor.py
@@ -181,6 +181,31 @@ class TestParallelShellExecutorTimeout:
         assert results[0].timed_out is False
         assert results[0].ok is True
 
+    def test_timeout_terminates_whole_process_group(self, tmp_path):
+        import time as _t
+
+        hb = tmp_path / "heartbeat"
+        grandchild_src = (
+            "import time\n"
+            f"i = 0\n"
+            f"while True:\n"
+            f"    open({str(hb)!r}, 'w').write(str(i))\n"
+            f"    i += 1\n"
+            f"    time.sleep(0.05)\n"
+        )
+        # Parent spawns the grandchild (which inherits the parent's new session/process group)
+        # and waits on it. If only the parent were killed, the reparented grandchild would keep
+        # writing the heartbeat; killing the whole group stops it.
+        parent_src = "import subprocess, sys\ng = subprocess.Popen([sys.executable, '-c', sys.argv[1]])\ng.wait()\n"
+        tasks = [ShellTask(key="t", cmd=[sys.executable, "-c", parent_src, grandchild_src], timeout=0.5)]
+        self._executor(1).run(tasks)
+
+        _t.sleep(0.3)
+        v1 = hb.read_text()
+        _t.sleep(0.5)
+        v2 = hb.read_text()
+        assert v1 == v2  # grandchild stopped writing -> the entire process group was terminated
+
 
 class TestParallelShellExecutorInterrupt:
     def test_sigint_cancels_queued_and_terminates_running(self, tmp_path):

--- a/posit-bakery/test/parallel/test_executor.py
+++ b/posit-bakery/test/parallel/test_executor.py
@@ -1,7 +1,15 @@
+import io
+import os
+import sys
+import threading
+
 import pytest
+from rich.console import Console
 
 from posit_bakery.const import DEFAULT_MAX_CONCURRENCY
-from posit_bakery.parallel import ShellResult, ShellTask, resolve_max_workers
+from posit_bakery.parallel import ParallelShellExecutor, ShellResult, ShellTask, resolve_max_workers
+
+PY = sys.executable
 
 pytestmark = [pytest.mark.unit]
 
@@ -60,3 +68,89 @@ class TestResolveMaxWorkers:
 
     def test_positive_jobs_clamped_when_no_tasks(self):
         assert resolve_max_workers(5, n_tasks=0) == 1
+
+
+class TestParallelShellExecutor:
+    def _executor(self, max_workers, use_live=False):
+        # Non-terminal console + use_live=False keeps tests headless and deterministic.
+        return ParallelShellExecutor(
+            max_workers=max_workers,
+            console=Console(file=io.StringIO()),
+            use_live=use_live,
+        )
+
+    def test_empty_tasks_returns_empty(self):
+        assert self._executor(2).run([]) == []
+
+    def test_results_returned_in_input_order(self):
+        # Sleep durations are inverted vs. input order so completion order differs.
+        durations = {"a": 0.30, "b": 0.05, "c": 0.15}
+        tasks = [ShellTask(key=k, cmd=[PY, "-c", f"import time; time.sleep({d})"]) for k, d in durations.items()]
+        results = self._executor(3).run(tasks)
+        assert [r.task.key for r in results] == ["a", "b", "c"]
+
+    def test_spawn_failure_captured_not_raised(self):
+        tasks = [ShellTask(key="x", cmd=["definitely-not-a-real-binary-zzz"])]
+        results = self._executor(1).run(tasks)
+        assert results[0].returncode is None
+        assert isinstance(results[0].exception, Exception)
+        assert results[0].ok is False
+
+    def test_env_applied(self):
+        cmd = [PY, "-c", "import os,sys; sys.stdout.write(os.environ.get('FOO',''))"]
+        tasks = [ShellTask(key="e", cmd=cmd, env={**os.environ, "FOO": "bar"})]
+        results = self._executor(1).run(tasks)
+        assert results[0].stdout == b"bar"
+
+    def test_cwd_applied(self, tmp_path):
+        cmd = [PY, "-c", "import os,sys; sys.stdout.write(os.getcwd())"]
+        tasks = [ShellTask(key="d", cmd=cmd, cwd=tmp_path)]
+        results = self._executor(1).run(tasks)
+        assert results[0].stdout.decode() == str(tmp_path)
+
+    def test_on_result_called_once_per_task_on_main_thread(self):
+        tasks = [ShellTask(key=str(i), cmd=[PY, "-c", "pass"]) for i in range(5)]
+        seen_keys = []
+        seen_threads = set()
+
+        def on_result(result):
+            seen_keys.append(result.task.key)
+            seen_threads.add(threading.get_ident())
+
+        self._executor(3).run(tasks, on_result=on_result)
+        assert sorted(seen_keys) == sorted(t.key for t in tasks)
+        assert seen_threads == {threading.main_thread().ident}
+
+    def test_concurrency_bound_not_exceeded(self, tmp_path):
+        # Each task writes "<start> <end>" timestamps; assert peak overlap <= max_workers.
+        n, workers, sleep = 6, 2, 0.20
+        script = (
+            "import time,sys; s=time.time(); time.sleep({sleep}); open(sys.argv[1],'w').write(f'{{s}} {{time.time()}}')"
+        ).format(sleep=sleep)
+        tasks = [ShellTask(key=str(i), cmd=[PY, "-c", script, str(tmp_path / f"{i}.txt")]) for i in range(n)]
+        self._executor(workers).run(tasks)
+
+        intervals = []
+        for i in range(n):
+            start, end = (tmp_path / f"{i}.txt").read_text().split()
+            intervals.append((float(start), float(end)))
+
+        events = []
+        for start, end in intervals:
+            events.append((start, 1))
+            events.append((end, -1))
+        events.sort()
+        peak = running = 0
+        for _, delta in events:
+            running += delta
+            peak = max(peak, running)
+        assert peak <= workers
+
+    def test_resolve_use_live_policy(self):
+        terminal = Console(file=io.StringIO(), force_terminal=True)
+        non_terminal = Console(file=io.StringIO())
+        ex_term = ParallelShellExecutor(max_workers=2, console=terminal, use_live=None)
+        ex_plain = ParallelShellExecutor(max_workers=2, console=non_terminal, use_live=None)
+        assert ex_term._resolve_use_live(2) is True
+        assert ex_term._resolve_use_live(1) is False  # single task -> no live table
+        assert ex_plain._resolve_use_live(2) is False  # non-terminal -> no live table

--- a/posit-bakery/test/parallel/test_executor.py
+++ b/posit-bakery/test/parallel/test_executor.py
@@ -238,3 +238,17 @@ class TestParallelShellExecutorInterrupt:
         assert ended == 0  # nothing ran to completion (running tasks were killed)
         assert started < 8  # queued tasks were cancelled, not launched
         assert elapsed < 3  # returned promptly, did not drain the full queue
+
+    def test_run_one_stops_child_when_shutdown_already_started(self):
+        # If an interrupt has already flipped the shutdown flag, a child spawned by a
+        # straggler worker must be stopped immediately rather than run to completion.
+        ex = ParallelShellExecutor(max_workers=1, console=Console(file=io.StringIO()), use_live=False)
+        with ex._lock:
+            ex._shutdown = True
+        task = ShellTask(key="t", cmd=[sys.executable, "-c", "import time; time.sleep(30)"])
+        start = time.monotonic()
+        result = ex._run_one(task)
+        elapsed = time.monotonic() - start
+        assert elapsed < 3  # stopped promptly, not waited out for 30s
+        assert result.returncode != 0  # the child was signalled, not a clean exit
+        assert ex._active == set()  # never registered (or already discarded)

--- a/posit-bakery/test/parallel/test_executor.py
+++ b/posit-bakery/test/parallel/test_executor.py
@@ -53,3 +53,10 @@ class TestResolveMaxWorkers:
     def test_never_below_one(self, monkeypatch):
         monkeypatch.setattr("posit_bakery.parallel.executor.SETTINGS.max_concurrency", DEFAULT_MAX_CONCURRENCY)
         assert resolve_max_workers(None, n_tasks=0) == 1
+
+    def test_negative_jobs_ignored(self, monkeypatch):
+        monkeypatch.setattr("posit_bakery.parallel.executor.SETTINGS.max_concurrency", 5)
+        assert resolve_max_workers(-1, n_tasks=10) == 5
+
+    def test_positive_jobs_clamped_when_no_tasks(self):
+        assert resolve_max_workers(5, n_tasks=0) == 1

--- a/posit-bakery/test/parallel/test_executor.py
+++ b/posit-bakery/test/parallel/test_executor.py
@@ -1,0 +1,55 @@
+import pytest
+
+from posit_bakery.const import DEFAULT_MAX_CONCURRENCY
+from posit_bakery.parallel import ShellResult, ShellTask, resolve_max_workers
+
+pytestmark = [pytest.mark.unit]
+
+
+class TestShellTask:
+    def test_display_label_defaults_to_key(self):
+        task = ShellTask(key="abc", cmd=["true"])
+        assert task.display_label == "abc"
+
+    def test_display_label_uses_label_when_set(self):
+        task = ShellTask(key="abc", cmd=["true"], label="My Label")
+        assert task.display_label == "My Label"
+
+
+class TestShellResult:
+    def test_ok_true_on_zero_exit_no_exception(self):
+        task = ShellTask(key="a", cmd=["true"])
+        result = ShellResult(task=task, returncode=0, stdout=b"", stderr=b"", duration=0.0)
+        assert result.ok is True
+
+    def test_ok_false_on_nonzero_exit(self):
+        task = ShellTask(key="a", cmd=["false"])
+        result = ShellResult(task=task, returncode=1, stdout=b"", stderr=b"", duration=0.0)
+        assert result.ok is False
+
+    def test_ok_false_on_exception(self):
+        task = ShellTask(key="a", cmd=["nope"])
+        result = ShellResult(
+            task=task, returncode=None, stdout=b"", stderr=b"", duration=0.0, exception=FileNotFoundError()
+        )
+        assert result.ok is False
+
+
+class TestResolveMaxWorkers:
+    def test_jobs_overrides_setting(self):
+        assert resolve_max_workers(2, n_tasks=10) == 2
+
+    def test_falls_back_to_setting(self, monkeypatch):
+        monkeypatch.setattr("posit_bakery.parallel.executor.SETTINGS.max_concurrency", 3)
+        assert resolve_max_workers(None, n_tasks=10) == 3
+
+    def test_non_positive_jobs_ignored(self, monkeypatch):
+        monkeypatch.setattr("posit_bakery.parallel.executor.SETTINGS.max_concurrency", 5)
+        assert resolve_max_workers(0, n_tasks=10) == 5
+
+    def test_clamped_to_n_tasks(self):
+        assert resolve_max_workers(8, n_tasks=3) == 3
+
+    def test_never_below_one(self, monkeypatch):
+        monkeypatch.setattr("posit_bakery.parallel.executor.SETTINGS.max_concurrency", DEFAULT_MAX_CONCURRENCY)
+        assert resolve_max_workers(None, n_tasks=0) == 1

--- a/posit-bakery/test/parallel/test_executor.py
+++ b/posit-bakery/test/parallel/test_executor.py
@@ -9,6 +9,7 @@ import time
 
 import pytest
 from rich.console import Console
+from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 
 from posit_bakery.const import DEFAULT_MAX_CONCURRENCY
 from posit_bakery.parallel import ParallelShellExecutor, ShellResult, ShellTask, resolve_max_workers
@@ -158,6 +159,44 @@ class TestParallelShellExecutor:
         assert ex_term._resolve_use_live(2) is True
         assert ex_term._resolve_use_live(1) is False  # single task -> no live table
         assert ex_plain._resolve_use_live(2) is False  # non-terminal -> no live table
+
+    def test_run_one_marks_row_running(self):
+        # When a Progress is attached, _run_one flips its row from queued to running and
+        # starts the row's timer. (Completion -> ✓ happens later on the main thread, not here.)
+        progress = Progress(
+            SpinnerColumn(),
+            TextColumn("{task.description}"),
+            TimeElapsedColumn(),
+            console=Console(file=io.StringIO()),
+        )
+        ex = ParallelShellExecutor(max_workers=1, console=Console(file=io.StringIO()), use_live=False)
+        task = ShellTask(key="k", cmd=[sys.executable, "-c", "pass"], label="my-task")
+        task_id = progress.add_task("[quiet]queued  my-task", total=1, start=False)
+        ex._progress = progress
+        ex._progress_ids = {"k": task_id}
+
+        ex._run_one(task)
+
+        row = progress.tasks[task_id]
+        assert row.started is True  # _run_one started the row's timer
+        assert "running" in row.description  # row flipped to running
+
+    def test_run_one_no_progress_is_noop(self):
+        # With no Progress attached (the default), _run_one must run fine and not error.
+        ex = ParallelShellExecutor(max_workers=1, console=Console(file=io.StringIO()), use_live=False)
+        result = ex._run_one(ShellTask(key="k", cmd=[sys.executable, "-c", "pass"]))
+        assert result.ok is True
+
+    def test_run_live_progress_smoke(self):
+        # Force the live path with a terminal-like StringIO console; assert run() still
+        # returns ordered, successful results (exercises add_task(start=False) -> running -> done).
+        ex = ParallelShellExecutor(
+            max_workers=2, console=Console(file=io.StringIO(), force_terminal=True), use_live=True
+        )
+        tasks = [ShellTask(key=str(i), cmd=[sys.executable, "-c", "pass"]) for i in range(3)]
+        results = ex.run(tasks)
+        assert [r.task.key for r in results] == ["0", "1", "2"]
+        assert all(r.ok for r in results)
 
 
 class TestParallelShellExecutorTimeout:

--- a/posit-bakery/test/plugins/builtin/dgoss/test_command.py
+++ b/posit-bakery/test/plugins/builtin/dgoss/test_command.py
@@ -25,6 +25,11 @@ class TestDGossCommand:
         assert basic_standard_image_target.context.version_path / "test" == dgoss_command.test_path
         assert dgoss_command.wait == 1
 
+    def test_command_timeout_defaults_to_900(self, basic_standard_image_target):
+        """Test that DGossCommand defaults to a 900-second timeout when not specified in goss options."""
+        cmd = DGossCommand.from_image_target(basic_standard_image_target)
+        assert cmd.timeout == 900
+
     def test_dgoss_environment(self, basic_standard_image_target):
         """Test that DGossCommand dgoss_environment returns the expected environment variables."""
         dgoss_command = DGossCommand.from_image_target(image_target=basic_standard_image_target)

--- a/posit-bakery/test/plugins/builtin/dgoss/test_init.py
+++ b/posit-bakery/test/plugins/builtin/dgoss/test_init.py
@@ -88,3 +88,17 @@ class TestDgossRunLatestFlag:
         assert result.exit_code == 0, result.stdout
         settings = mock_config.from_context.call_args[0][1]
         assert settings.latest is False
+
+
+class TestDgossRunJobsFlag:
+    """The --jobs flag is forwarded to DGossPlugin.execute()."""
+
+    def test_jobs_forwarded_to_execute(self, mocked_dgoss_run):
+        _, mock_execute = mocked_dgoss_run
+        result = runner.invoke(
+            app,
+            ["dgoss", "run", "--context", BASIC_CONTEXT, "--jobs", "2"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.stdout
+        assert mock_execute.call_args.kwargs["jobs"] == 2

--- a/posit-bakery/test/plugins/builtin/dgoss/test_suite.py
+++ b/posit-bakery/test/plugins/builtin/dgoss/test_suite.py
@@ -40,3 +40,34 @@ class TestDGossSuite:
                 json.load(f)
 
         remove_images(basic_tmpconfig)
+
+    def test_run_parallel_mocked(self, get_tmpconfig, mocker):
+        """Suite.run() drives commands through the executor without a real Docker daemon."""
+        import subprocess
+
+        cfg = get_tmpconfig("basic")
+        suite = DGossSuite(cfg.base_path, cfg.targets)
+
+        goss_json = json.dumps(
+            {
+                "summary": {
+                    "test-count": 2,
+                    "failed-count": 0,
+                    "skipped-count": 0,
+                    "summary-line": "Count: 2, Failed: 0, Skipped: 0",
+                    "total-duration": 1234567,
+                }
+            }
+        ).encode("utf-8")
+        fake = subprocess.CompletedProcess(args=[], returncode=0, stdout=goss_json, stderr=b"")
+        mocker.patch("posit_bakery.parallel.executor.subprocess.run", return_value=fake)
+
+        report_collection, errors = suite.run()
+
+        assert errors is None
+        assert len(report_collection.get("test-image")) == 2
+        for target in suite.image_targets:
+            results_file = cfg.base_path / "results" / "dgoss" / target.image_name / f"{target.uid}.json"
+            assert results_file.exists()
+            with open(results_file) as f:
+                json.load(f)

--- a/posit-bakery/test/plugins/builtin/dgoss/test_suite.py
+++ b/posit-bakery/test/plugins/builtin/dgoss/test_suite.py
@@ -4,6 +4,7 @@ import subprocess
 import pytest
 
 from posit_bakery.error import BakeryToolRuntimeErrorGroup
+from posit_bakery.parallel import ShellResult
 from posit_bakery.plugins.builtin.dgoss.errors import BakeryDGossError
 from posit_bakery.plugins.builtin.dgoss.suite import DGossSuite
 from test.helpers import remove_images
@@ -45,7 +46,7 @@ class TestDGossSuite:
         remove_images(basic_tmpconfig)
 
     def test_run_parallel_mocked(self, get_tmpconfig, mocker):
-        """Suite.run() drives commands through the executor without a real Docker daemon."""
+        """Suite.run() processes successful executor results into reports + files."""
         cfg = get_tmpconfig("basic")
         suite = DGossSuite(cfg.base_path, cfg.targets)
 
@@ -60,8 +61,17 @@ class TestDGossSuite:
                 }
             }
         ).encode("utf-8")
-        fake = subprocess.CompletedProcess(args=[], returncode=0, stdout=goss_json, stderr=b"")
-        mocker.patch("posit_bakery.parallel.executor.subprocess.run", return_value=fake)
+
+        def fake_run(self, tasks, *, on_result=None):
+            results = []
+            for t in tasks:
+                r = ShellResult(task=t, returncode=0, stdout=goss_json, stderr=b"", duration=1.0)
+                results.append(r)
+                if on_result is not None:
+                    on_result(r)
+            return results
+
+        mocker.patch("posit_bakery.plugins.builtin.dgoss.suite.ParallelShellExecutor.run", fake_run)
 
         report_collection, errors = suite.run()
 
@@ -82,10 +92,24 @@ class TestDGossSuite:
     def test_run_spawn_failure_records_errors(self, get_tmpconfig, mocker):
         cfg = get_tmpconfig("basic")
         suite = DGossSuite(cfg.base_path, cfg.targets)
-        mocker.patch(
-            "posit_bakery.parallel.executor.subprocess.run",
-            side_effect=FileNotFoundError("dgoss not found"),
-        )
+
+        def fake_run(self, tasks, *, on_result=None):
+            results = []
+            for t in tasks:
+                r = ShellResult(
+                    task=t,
+                    returncode=None,
+                    stdout=b"",
+                    stderr=b"",
+                    duration=0.0,
+                    exception=FileNotFoundError("dgoss not found"),
+                )
+                results.append(r)
+                if on_result is not None:
+                    on_result(r)
+            return results
+
+        mocker.patch("posit_bakery.plugins.builtin.dgoss.suite.ParallelShellExecutor.run", fake_run)
 
         report_collection, errors = suite.run()
 
@@ -93,3 +117,47 @@ class TestDGossSuite:
         assert isinstance(errors, BakeryToolRuntimeErrorGroup)
         assert len(errors.exceptions) == 2
         assert all(isinstance(e, BakeryDGossError) for e in errors.exceptions)
+
+    def test_run_timeout_records_error(self, get_tmpconfig, mocker):
+        cfg = get_tmpconfig("basic")
+        suite = DGossSuite(cfg.base_path, cfg.targets)
+
+        def fake_run(self, tasks, *, on_result=None):
+            results = []
+            for t in tasks:
+                r = ShellResult(
+                    task=t,
+                    returncode=-15,
+                    stdout=b"",
+                    stderr=b"",
+                    duration=900.0,
+                    exception=subprocess.TimeoutExpired(t.cmd, 900),
+                    timed_out=True,
+                )
+                results.append(r)
+                if on_result is not None:
+                    on_result(r)
+            return results
+
+        mocker.patch("posit_bakery.plugins.builtin.dgoss.suite.ParallelShellExecutor.run", fake_run)
+
+        report_collection, errors = suite.run()
+
+        assert len(report_collection) == 0
+        assert isinstance(errors, BakeryToolRuntimeErrorGroup)
+        assert len(errors.exceptions) == 2
+        assert all("timed out" in str(e).lower() for e in errors.exceptions)
+
+    def test_run_passes_timeout_to_tasks(self, get_tmpconfig, mocker):
+        captured = {}
+
+        def fake_run(self, tasks, *, on_result=None):
+            captured["tasks"] = tasks
+            return []
+
+        cfg = get_tmpconfig("basic")
+        suite = DGossSuite(cfg.base_path, cfg.targets)
+        mocker.patch("posit_bakery.plugins.builtin.dgoss.suite.ParallelShellExecutor.run", fake_run)
+        suite.run()
+        assert captured["tasks"]
+        assert all(t.timeout == 900 for t in captured["tasks"])  # default 900 from GossOptions

--- a/posit-bakery/test/plugins/builtin/dgoss/test_suite.py
+++ b/posit-bakery/test/plugins/builtin/dgoss/test_suite.py
@@ -1,4 +1,5 @@
 import json
+import subprocess
 
 import pytest
 
@@ -43,8 +44,6 @@ class TestDGossSuite:
 
     def test_run_parallel_mocked(self, get_tmpconfig, mocker):
         """Suite.run() drives commands through the executor without a real Docker daemon."""
-        import subprocess
-
         cfg = get_tmpconfig("basic")
         suite = DGossSuite(cfg.base_path, cfg.targets)
 

--- a/posit-bakery/test/plugins/builtin/dgoss/test_suite.py
+++ b/posit-bakery/test/plugins/builtin/dgoss/test_suite.py
@@ -3,6 +3,8 @@ import subprocess
 
 import pytest
 
+from posit_bakery.error import BakeryToolRuntimeErrorGroup
+from posit_bakery.plugins.builtin.dgoss.errors import BakeryDGossError
 from posit_bakery.plugins.builtin.dgoss.suite import DGossSuite
 from test.helpers import remove_images
 
@@ -70,3 +72,24 @@ class TestDGossSuite:
             assert results_file.exists()
             with open(results_file) as f:
                 json.load(f)
+
+    def test_jobs_sets_max_workers(self, get_config_obj):
+        cfg = get_config_obj("basic")
+        # jobs is clamped to the number of commands (2 targets in the basic config)
+        assert DGossSuite(cfg.base_path, cfg.targets, jobs=1).max_workers == 1
+        assert DGossSuite(cfg.base_path, cfg.targets, jobs=5).max_workers == 2
+
+    def test_run_spawn_failure_records_errors(self, get_tmpconfig, mocker):
+        cfg = get_tmpconfig("basic")
+        suite = DGossSuite(cfg.base_path, cfg.targets)
+        mocker.patch(
+            "posit_bakery.parallel.executor.subprocess.run",
+            side_effect=FileNotFoundError("dgoss not found"),
+        )
+
+        report_collection, errors = suite.run()
+
+        assert len(report_collection) == 0
+        assert isinstance(errors, BakeryToolRuntimeErrorGroup)
+        assert len(errors.exceptions) == 2
+        assert all(isinstance(e, BakeryDGossError) for e in errors.exceptions)

--- a/posit-bakery/test/test_settings.py
+++ b/posit-bakery/test/test_settings.py
@@ -1,0 +1,16 @@
+import pytest
+
+from posit_bakery.const import DEFAULT_MAX_CONCURRENCY
+from posit_bakery.settings import Settings
+
+pytestmark = [pytest.mark.unit]
+
+
+class TestSettingsMaxConcurrency:
+    def test_defaults_to_constant(self, monkeypatch):
+        monkeypatch.delenv("BAKERY_MAX_CONCURRENCY", raising=False)
+        assert Settings().max_concurrency == DEFAULT_MAX_CONCURRENCY
+
+    def test_reads_env_var(self, monkeypatch):
+        monkeypatch.setenv("BAKERY_MAX_CONCURRENCY", "9")
+        assert Settings().max_concurrency == 9

--- a/posit-bakery/test/test_settings.py
+++ b/posit-bakery/test/test_settings.py
@@ -14,3 +14,11 @@ class TestSettingsMaxConcurrency:
     def test_reads_env_var(self, monkeypatch):
         monkeypatch.setenv("BAKERY_MAX_CONCURRENCY", "9")
         assert Settings().max_concurrency == 9
+
+    def test_invalid_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("BAKERY_MAX_CONCURRENCY", "abc")
+        assert Settings().max_concurrency == DEFAULT_MAX_CONCURRENCY
+
+    def test_empty_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("BAKERY_MAX_CONCURRENCY", "")
+        assert Settings().max_concurrency == DEFAULT_MAX_CONCURRENCY


### PR DESCRIPTION
## Summary

Adds bounded-concurrency parallel execution of `dgoss` test commands, built on a new **tool-agnostic** `posit_bakery/parallel/` module so other plugins (hadolint, wizcli) and future sequential builds can adopt the same pattern.

- **`posit_bakery/parallel/`** — `ShellTask`, `ShellResult`, `resolve_max_workers`, and `ParallelShellExecutor` (a `ThreadPoolExecutor`-backed runner). Worker threads only run their subprocess and return captured bytes; the main thread drains completions, drives an optional Rich live status table, and invokes a per-result callback — so consumers mutate shared state without locks. Results are returned in input order; spawn failures are captured (never crash the run).
- **Concurrency control** — `--jobs/-j` CLI flag on `bakery dgoss run` → `BAKERY_MAX_CONCURRENCY` env / `SETTINGS.max_concurrency` → default of `4` (modest, since each task is a Docker container). Malformed env values fall back to the default with a warning instead of crashing the CLI.
- **Streaming/logging** — the live `Progress` table shares the same `stderr_console` as the logger, so per-task detail (flushed on completion, on the main thread) renders cleanly above the live region with no interleaving. The table auto-disables on non-TTY/CI, `--quiet`, or single-task runs, falling back to plain logging.
- **dgoss** — `DGossSuite.run()` now dispatches through the executor while preserving its exact `(GossJsonReportCollection, errors)` return contract; per-result parse/persist/classify logic is unchanged.

Design spec and implementation plan live under `docs/superpowers/` (gitignored, not committed).

## Test Plan

- [x] `just test` — 1639 passed
- [x] New unit tests: executor (ordering, bounded concurrency, spawn-failure capture, env/cwd, main-thread callback, live-display policy), `resolve_max_workers`, settings env parsing (incl. malformed/empty fallback)
- [x] dgoss suite tests: mocked parallel happy-path, `jobs`→`max_workers` wiring, spawn-failure → `BakeryDGossError`
- [x] CLI test: `dgoss run --jobs 2` forwards `jobs=2` through to the suite
- [ ] Manual smoke (requires Docker + built images): `bakery dgoss run --jobs 2 -v` shows the live status table + per-target detail, then the Goss summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)