### PR TITLE
Add release_branch field to channel dev version

### DIFF
--- a/.github/workflows/bakery-build-native.yml
+++ b/.github/workflows/bakery-build-native.yml
@@ -47,6 +47,11 @@ on:
         default: ""
         required: false
         type: string
+      release-branch:
+        description: "Workbench dailies release branch for dev builds (e.g. 'apple-blossom', '2026.07'). Omit to use 'latest'."
+        default: ""
+        required: false
+        type: string
       dev-spec:
         description: "JSON spec for a dispatched dev build. If set, takes precedence over dev-version/dev-channel for spec construction."
         default: ""
@@ -139,6 +144,7 @@ jobs:
           DEV_CHANNEL: ${{ inputs.dev-channel || inputs.dev-stream }}
           DEV_VERSION: ${{ inputs.dev-version }}
           DEV_SPEC: ${{ inputs.dev-spec }}
+          RELEASE_BRANCH: ${{ inputs.release-branch }}
           CONTEXT: ${{ inputs.context }}
         run: |
           IMAGE_VERSION="${IMAGE_VERSION#v}"
@@ -146,9 +152,14 @@ jobs:
           [[ -n "$IMAGE_VERSION" ]] && ARGS+=(--image-version "$IMAGE_VERSION")
           if [[ -n "$DEV_SPEC" ]]; then
             ARGS+=(--dev-spec "$DEV_SPEC")
-          elif [[ -n "$DEV_VERSION" ]]; then
-            DEV_SPEC_JSON=$(jq -cn --arg v "$DEV_VERSION" --arg c "$DEV_CHANNEL" \
-              '{version: $v} + if $c != "" then {channel: $c} else {} end')
+          elif [[ -n "$DEV_VERSION" || -n "$RELEASE_BRANCH" ]]; then
+            DEV_SPEC_JSON=$(jq -cn \
+              --arg v "$DEV_VERSION" \
+              --arg c "$DEV_CHANNEL" \
+              --arg b "$RELEASE_BRANCH" \
+              'if $v != "" then {version: $v} else {} end
+               + if $c != "" then {channel: $c} else {} end
+               + if $b != "" then {release_branch: $b} else {} end')
             ARGS+=(--dev-spec "$DEV_SPEC_JSON")
           elif [[ -n "$DEV_CHANNEL" ]]; then
             ARGS+=(--dev-channel "$DEV_CHANNEL")
@@ -252,6 +263,7 @@ jobs:
           DEV_CHANNEL: ${{ inputs.dev-channel || inputs.dev-stream }}
           DEV_VERSION: ${{ inputs.dev-version }}
           DEV_SPEC: ${{ inputs.dev-spec }}
+          RELEASE_BRANCH: ${{ inputs.release-branch }}
           REGISTRY: ghcr.io/${{ github.repository_owner }}
           NORMALIZED_PLATFORM: ${{ steps.normalize-platform.outputs.platform }}
           CONTEXT: ${{ inputs.context }}
@@ -266,9 +278,14 @@ jobs:
           DEV_SPEC_FLAGS=()
           if [[ -n "$DEV_SPEC" ]]; then
             DEV_SPEC_FLAGS+=(--dev-spec "$DEV_SPEC")
-          elif [[ -n "$DEV_VERSION" ]]; then
-            DEV_SPEC_JSON=$(jq -cn --arg v "$DEV_VERSION" --arg c "$DEV_CHANNEL" \
-              '{version: $v} + if $c != "" then {channel: $c} else {} end')
+          elif [[ -n "$DEV_VERSION" || -n "$RELEASE_BRANCH" ]]; then
+            DEV_SPEC_JSON=$(jq -cn \
+              --arg v "$DEV_VERSION" \
+              --arg c "$DEV_CHANNEL" \
+              --arg b "$RELEASE_BRANCH" \
+              'if $v != "" then {version: $v} else {} end
+               + if $c != "" then {channel: $c} else {} end
+               + if $b != "" then {release_branch: $b} else {} end')
             DEV_SPEC_FLAGS+=(--dev-spec "$DEV_SPEC_JSON")
           fi
           bakery build \

--- a/posit-bakery/docs/configuration.qmd
+++ b/posit-bakery/docs/configuration.qmd
@@ -588,22 +588,24 @@ images:
               - linux/arm64
 ```
 
-## Environment Variables
+### DevBuildSpec
 
-The following environment variables can be used to configure Bakery behavior at runtime when building a project targeting Workbench Daily builds.
+A DevBuildSpec is a typed payload passed to the `--dev-spec` CLI option to configure development (daily) version builds. It supports either a dispatch-pinned version or a branch-targeted discovery build. At least one of `version` or `release_branch` must be set.
 
-| Variable | Description | Default |
-|---|---|---|
-| `BAKERY_WORKBENCH_RELEASE_BRANCH` | Override the Workbench dailies release branch used when fetching daily build artifacts. Workbench tracks multiple release branches (e.g., `globemaster-allium`, `apple-blossom`) for daily builds. Set this variable to build a daily development version from a previous release's branch instead of the latest. | `latest` |
+| Field | Description | Default Value | Example |
+|---|---|---|---|
+| `version`<br/>*string* | A specific development version to build (e.g., `2026.07.0-dev+345-gabc1234`). When set, `release_branch` is ignored — the branch is derived from the version's `YYYY.MM` segment. Optional if `release_branch` is set. | — | `2026.07.0-dev+345-gabc1234` |
+| `channel`<br/>*string* | The release channel for stream selection and disambiguation (e.g., `stable`, `preview`). Used whether or not `version` is set; must not conflict with `--dev-channel` if both are provided. | — | `preview` |
+| `release_branch`<br/>*string* | The release branch to fetch development artifacts from (e.g., `apple-blossom`, `2026.07`). Ignored when `version` is set. Required when `version` is not set. | — | `apple-blossom` |
 
-### Example Usage
+#### Example DevBuildSpec Usage
 
 ```bash
-# Build the latest daily (default behavior)
-bakery build --dev-versions only
+# Build a specific pinned development version
+bakery build --dev-spec '{"version": "2026.07.0-dev+345-gabc1234"}'
 
-# Build a daily from the "globemaster-allium" release branch
-BAKERY_WORKBENCH_RELEASE_BRANCH=globemaster-allium bakery build --dev-versions only
+# Build from the "apple-blossom" release branch
+bakery build --dev-spec '{"release_branch": "apple-blossom"}'
 ```
 
 ## See Also

--- a/posit-bakery/posit_bakery/cli/build.py
+++ b/posit-bakery/posit_bakery/cli/build.py
@@ -12,7 +12,6 @@ from posit_bakery.config.config import BakeryConfigFilter, BakerySettings
 from posit_bakery.config.image.posit_product.const import ReleaseChannelEnum
 from posit_bakery.config.image.posit_product.errors import (
     ArtifactNotAvailableError,
-    DispatchVersionMismatchError,
     VersionSubstitutionError,
 )
 from posit_bakery.const import DevVersionInclusionEnum, MatrixVersionInclusionEnum
@@ -260,7 +259,7 @@ def build(
 
     try:
         config: BakeryConfig = BakeryConfig.from_context(context, settings)
-    except (DispatchVersionMismatchError, ArtifactNotAvailableError, VersionSubstitutionError) as e:
+    except (ArtifactNotAvailableError, VersionSubstitutionError) as e:
         stderr_console.print(f"❌ {e}", style="error")
         raise typer.Exit(code=1)
 

--- a/posit-bakery/posit_bakery/cli/build.py
+++ b/posit-bakery/posit_bakery/cli/build.py
@@ -10,7 +10,11 @@ from posit_bakery.cli.common import with_verbosity_flags, with_temporary_storage
 from posit_bakery.config import BakeryConfig
 from posit_bakery.config.config import BakeryConfigFilter, BakerySettings
 from posit_bakery.config.image.posit_product.const import ReleaseChannelEnum
-from posit_bakery.config.image.posit_product.errors import DispatchVersionMismatchError
+from posit_bakery.config.image.posit_product.errors import (
+    ArtifactNotAvailableError,
+    DispatchVersionMismatchError,
+    VersionSubstitutionError,
+)
 from posit_bakery.const import DevVersionInclusionEnum, MatrixVersionInclusionEnum
 from posit_bakery.error import BakeryBuildErrorGroup, BakeryToolRuntimeError
 from posit_bakery.image import ImageBuildStrategy
@@ -256,7 +260,7 @@ def build(
 
     try:
         config: BakeryConfig = BakeryConfig.from_context(context, settings)
-    except DispatchVersionMismatchError as e:
+    except (DispatchVersionMismatchError, ArtifactNotAvailableError, VersionSubstitutionError) as e:
         stderr_console.print(f"❌ {e}", style="error")
         raise typer.Exit(code=1)
 

--- a/posit-bakery/posit_bakery/config/config.py
+++ b/posit-bakery/posit_bakery/config/config.py
@@ -28,7 +28,7 @@ from posit_bakery.config.templating import TPL_CONTAINERFILE, TPL_BAKERY_CONFIG_
 from posit_bakery.config.templating.render import jinja2_env, normalize_rendered_output
 from posit_bakery.config.image.dev_version.spec import DevBuildSpec
 from posit_bakery.config.image.parsed_version import ParsedVersion
-from posit_bakery.config.image.posit_product.const import ReleaseChannelEnum
+from posit_bakery.config.image.posit_product.const import ReleaseChannelEnum, CALVER_REGEX_PATTERN
 from posit_bakery.const import DEFAULT_BASE_IMAGE, DevVersionInclusionEnum, MatrixVersionInclusionEnum
 from posit_bakery.error import (
     BakeryError,
@@ -378,6 +378,19 @@ class BakerySettings(BaseModel):
     temp_registry: Annotated[str | None, Field(description="Registry to use for image build temp cache.", default=None)]
 
 
+def _extract_calver_minor(version: str) -> str:
+    """Extract the YYYY.MM segment from a CalVer version string.
+
+    Used to derive the Workbench dailies URL branch from a pinned version
+    (e.g. "2026.06.0-daily+143" -> "2026.06"). The dailies API supports
+    YYYY.MM as a URL path segment equivalent to the branch codename.
+    """
+    match = CALVER_REGEX_PATTERN.fullmatch(version)
+    if not match:
+        raise ValueError(f"Cannot extract YYYY.MM from version {version!r}: not a valid CalVer string.")
+    return f"{match.group(1)}.{match.group(2)}"
+
+
 def _apply_dev_spec(image: Image, settings: BakerySettings) -> None:
     """Pin the dispatched version onto the matching channel dev version.
 
@@ -415,7 +428,13 @@ def _apply_dev_spec(image: Image, settings: BakerySettings) -> None:
             f"channel '{target_channel}'. Specify 'channel' in --dev-spec or pass "
             f"--dev-channel to disambiguate."
         )
-    candidates[0].version_override = settings.dev_spec.version
+    candidates[0].version_override = settings.dev_spec.version  # None for branch-only specs
+    if settings.dev_spec.version is not None:
+        # Extract YYYY.MM from the pinned version to target the correct branch URL.
+        # The dailies API supports YYYY.MM path segments (e.g. /rstudio/2026.06/index.json).
+        candidates[0].release_branch = _extract_calver_minor(settings.dev_spec.version)
+    elif settings.dev_spec.release_branch is not None:
+        candidates[0].release_branch = settings.dev_spec.release_branch
 
 
 class BakeryConfig:

--- a/posit-bakery/posit_bakery/config/image/dev_version/channel.py
+++ b/posit-bakery/posit_bakery/config/image/dev_version/channel.py
@@ -115,6 +115,7 @@ class ImageDevelopmentVersionFromProductChannel(BaseImageDevelopmentVersion):
                 self.product,
                 self.channel,
                 _os.buildOS,
+                version_override=self.version_override,
                 release_branch=self.release_branch or "latest",
             )
             if generalize_architecture:

--- a/posit-bakery/posit_bakery/config/image/dev_version/channel.py
+++ b/posit-bakery/posit_bakery/config/image/dev_version/channel.py
@@ -41,6 +41,16 @@ class ImageDevelopmentVersionFromProductChannel(BaseImageDevelopmentVersion):
             "(PPM) or manifest assertion (Connect, Workbench).",
         ),
     ]
+    release_branch: Annotated[
+        str | None,
+        Field(
+            exclude=True,
+            default=None,
+            description="Release branch for Workbench daily URL construction. "
+            "Passed as release_branch to get_product_artifact_by_channel(). "
+            "Defaults to 'latest' when None.",
+        ),
+    ]
 
     @model_validator(mode="before")
     @classmethod
@@ -76,7 +86,12 @@ class ImageDevelopmentVersionFromProductChannel(BaseImageDevelopmentVersion):
         if self.resolved_version is not None:
             return self.resolved_version
         _os = self.get_primary_os()
-        result = get_product_artifact_by_channel(self.product, self.channel, _os.buildOS)
+        result = get_product_artifact_by_channel(
+            self.product,
+            self.channel,
+            _os.buildOS,
+            release_branch=self.release_branch or "latest",
+        )
         return result.version
 
     def get_url_by_os(self, generalize_architecture: bool = False) -> dict[str, str]:
@@ -86,7 +101,12 @@ class ImageDevelopmentVersionFromProductChannel(BaseImageDevelopmentVersion):
         """
         url_by_os = {}
         for _os in self.os:
-            result = get_product_artifact_by_channel(self.product, self.channel, _os.buildOS)
+            result = get_product_artifact_by_channel(
+                self.product,
+                self.channel,
+                _os.buildOS,
+                release_branch=self.release_branch or "latest",
+            )
             if generalize_architecture:
                 url_by_os[_os.name] = str(result.architecture_generalized_download_url)
             else:
@@ -114,6 +134,7 @@ class ImageDevelopmentVersionFromProductChannel(BaseImageDevelopmentVersion):
                     self.channel,
                     os_version.buildOS,
                     version_override=self.version_override,
+                    release_branch=self.release_branch or "latest",
                 )
                 if generalize:
                     os_version.artifactDownloadURL = str(result.architecture_generalized_download_url)

--- a/posit-bakery/posit_bakery/config/image/dev_version/channel.py
+++ b/posit-bakery/posit_bakery/config/image/dev_version/channel.py
@@ -31,6 +31,16 @@ class ImageDevelopmentVersionFromProductChannel(BaseImageDevelopmentVersion):
             "get_version().",
         ),
     ]
+    resolved_channel_latest: Annotated[
+        bool,
+        Field(
+            exclude=True,
+            default=True,
+            description="Whether the resolved version equals the current channel head. "
+            "Populated by _resolve_os_urls(); used to suppress floating {{ Channel }} tags "
+            "for builds targeting older versions.",
+        ),
+    ]
     version_override: Annotated[
         str | None,
         Field(
@@ -118,13 +128,17 @@ class ImageDevelopmentVersionFromProductChannel(BaseImageDevelopmentVersion):
         """Resolve artifact URLs per-OS, excluding OSes whose platform
         is not yet available in the product channel.
 
-        Caches the version from the first successfully resolved OS so
-        that get_version() can return it without a redundant fetch.
+        Caches the version and channel_latest flag from the first successfully
+        resolved OS so that get_version() can return them without a redundant fetch.
         """
         # Local import avoids a circular import between channel.py and main.py.
-        from posit_bakery.config.image.posit_product.errors import DispatchVersionMismatchError
+        from posit_bakery.config.image.posit_product.errors import (
+            ArtifactNotAvailableError,
+            VersionSubstitutionError,
+        )
 
         self.resolved_version = None
+        self.resolved_channel_latest = True
         resolved = []
         for os_version in self.os:
             try:
@@ -142,12 +156,42 @@ class ImageDevelopmentVersionFromProductChannel(BaseImageDevelopmentVersion):
                     os_version.artifactDownloadURL = str(result.download_url)
                 if self.resolved_version is None:
                     self.resolved_version = result.version
+                    self.resolved_channel_latest = result.channel_latest
                 resolved.append(os_version)
-            except DispatchVersionMismatchError:
+            except (ArtifactNotAvailableError, VersionSubstitutionError):
                 raise
             except (ValueError, ValidationError, requests.RequestException) as e:
                 log.warning(f"Excluding OS '{os_version.name}' from {repr(self)}: {e}")
         return resolved
+
+    def as_image_version(self):
+        """Convert to a standard image version, adding channel_latest to metadata."""
+        # Local import mirrors the pattern in base.py to avoid any circular-import risk.
+        from posit_bakery.config.image.version import ImageVersion
+
+        resolved_os = self._resolve_os_urls()
+        if not resolved_os:
+            raise RuntimeError(f"No OSes could be resolved for {repr(self)}")
+
+        version = self.get_version()
+        metadata = {"channel_latest": self.resolved_channel_latest}
+        release_channel = self.get_release_channel()
+        if release_channel is not None:
+            metadata["release_channel"] = release_channel
+        return ImageVersion(
+            name=version,
+            subpath=f".dev-{version}".replace(" ", "-").lower(),
+            parent=self.parent,
+            extraRegistries=self.extraRegistries,
+            overrideRegistries=self.overrideRegistries,
+            os=resolved_os,
+            values=self.values,
+            latest=False,
+            dependencies=self.parent.resolve_dependency_versions(),
+            ephemeral=True,
+            isDevelopmentVersion=True,
+            metadata=metadata,
+        )
 
     def get_release_channel(self) -> ReleaseChannelEnum:
         """Return the release channel for this product channel development version.

--- a/posit-bakery/posit_bakery/config/image/dev_version/spec.py
+++ b/posit-bakery/posit_bakery/config/image/dev_version/spec.py
@@ -1,20 +1,43 @@
-from pydantic import BaseModel, ConfigDict, field_validator
+from typing import Self
+
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
 from posit_bakery.config.image.posit_product.const import ReleaseChannelEnum
 
 
 class DevBuildSpec(BaseModel):
-    """Typed payload for a workflow-dispatched dev build."""
+    """Typed payload for a dev build — either a dispatch-pinned version or a
+    branch-targeted discovery build. At least one of version or release_branch
+    must be set."""
 
     model_config = ConfigDict(extra="forbid")
 
-    version: str
+    version: str | None = None
     channel: ReleaseChannelEnum | None = None
+    release_branch: str | None = None
 
     @field_validator("version")
     @classmethod
-    def version_not_empty(cls, v: str) -> str:
+    def version_not_empty(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
         v = v.strip()
         if not v:
             raise ValueError("version must not be empty")
         return v
+
+    @field_validator("release_branch")
+    @classmethod
+    def release_branch_not_empty(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        v = v.strip()
+        if not v:
+            raise ValueError("release_branch must not be empty")
+        return v
+
+    @model_validator(mode="after")
+    def require_version_or_release_branch(self) -> Self:
+        if self.version is None and self.release_branch is None:
+            raise ValueError("at least one of 'version' or 'release_branch' must be set")
+        return self

--- a/posit-bakery/posit_bakery/config/image/dev_version/spec.py
+++ b/posit-bakery/posit_bakery/config/image/dev_version/spec.py
@@ -2,7 +2,7 @@ from typing import Self
 
 from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
-from posit_bakery.config.image.posit_product.const import ReleaseChannelEnum
+from posit_bakery.config.image.posit_product.const import CALVER_REGEX_PATTERN, ReleaseChannelEnum
 
 
 class DevBuildSpec(BaseModel):
@@ -24,6 +24,8 @@ class DevBuildSpec(BaseModel):
         v = v.strip()
         if not v:
             raise ValueError("version must not be empty")
+        if not CALVER_REGEX_PATTERN.fullmatch(v):
+            raise ValueError(f"version {v!r} is not a valid CalVer string (e.g. '2026.06.0-daily+143')")
         return v
 
     @field_validator("release_branch")

--- a/posit-bakery/posit_bakery/config/image/posit_product/const.py
+++ b/posit-bakery/posit_bakery/config/image/posit_product/const.py
@@ -1,4 +1,3 @@
-import os
 import re
 from enum import Enum
 
@@ -27,9 +26,7 @@ URL_WITH_ENV_VARS_REGEX_PATTERN = re.compile(
     rf"(?:#(?:{_QUERY_FRAGMENT}|{_ENV_VAR})*)?$"
 )
 
-WORKBENCH_DAILY_URL = (
-    f"https://dailies.rstudio.com/rstudio/{os.getenv('BAKERY_WORKBENCH_RELEASE_BRANCH', 'latest')}/index.json"
-)
+WORKBENCH_DAILY_URL = "https://dailies.rstudio.com/rstudio/{release_branch}/index.json"
 PACKAGE_MANAGER_DAILY_URL = "https://cdn.posit.co/package-manager/deb/amd64/rstudio-pm-main-latest.txt"
 PACKAGE_MANAGER_PREVIEW_URL = "https://cdn.posit.co/package-manager/deb/amd64/rstudio-pm-rc-latest.txt"
 CONNECT_DAILY_URL = "https://cdn.posit.co/connect/latest-packages.json"

--- a/posit-bakery/posit_bakery/config/image/posit_product/errors.py
+++ b/posit-bakery/posit_bakery/config/image/posit_product/errors.py
@@ -4,3 +4,20 @@ class DispatchVersionMismatchError(Exception):
     Must NOT subclass ValueError or RequestException so it escapes the per-OS
     catch in _resolve_os_urls and the skip-on-error catch in load_dev_versions.
     """
+
+
+class ArtifactNotAvailableError(Exception):
+    """Raised when a HEAD probe on an overridden artifact URL returns a non-2xx status.
+
+    Must NOT subclass ValueError or RequestException so it escapes the per-OS
+    catch in _resolve_os_urls and propagates as a hard build failure.
+    """
+
+
+class VersionSubstitutionError(Exception):
+    """Raised when the manifest version cannot be located in the manifest URL.
+
+    Prevents silently shipping the wrong (un-substituted) artifact URL.
+    Must NOT subclass ValueError or RequestException for the same reasons as
+    ArtifactNotAvailableError.
+    """

--- a/posit-bakery/posit_bakery/config/image/posit_product/main.py
+++ b/posit-bakery/posit_bakery/config/image/posit_product/main.py
@@ -17,7 +17,7 @@ from posit_bakery.config.image.posit_product.const import (
     CONNECT_DAILY_URL,
     DOWNLOADS_JSON_URL,
 )
-from posit_bakery.config.image.posit_product.errors import DispatchVersionMismatchError
+from posit_bakery.config.image.posit_product.errors import ArtifactNotAvailableError, VersionSubstitutionError
 from posit_bakery.config.shared import OSFamilyEnum
 from posit_bakery.util import cached_session
 
@@ -27,6 +27,7 @@ class ReleaseChannelResult(BaseModel):
 
     version: Annotated[str, Field(pattern=CALVER_REGEX_PATTERN)]
     download_url: HttpUrl
+    channel_latest: bool = True
 
     @computed_field
     @property
@@ -53,6 +54,7 @@ class ReleaseChannelPath:
         channel_url = self.channel_url.format_map(metadata)
 
         if version_override is not None and self.version_templatable:
+            # PPM: build artifact URL from template, then probe it and check channel head.
             result: dict = {"version": version_override}
             url_safe_result = {f"url_safe_{k}": quote(str(v), safe="") for k, v in result.items()}
             for key, resolver in self.resolver_map.items():
@@ -60,7 +62,30 @@ class ReleaseChannelPath:
                     continue
                 if isinstance(resolver, str):
                     result[key] = resolver.format(**metadata, **result, **url_safe_result)
-            return ReleaseChannelResult(**result)
+
+            session = cached_session()
+
+            # Determine channel_latest by comparing override against the current channel version.
+            channel_latest = False
+            current_response = session.get(channel_url)
+            current_response.raise_for_status()
+            try:
+                current_data = current_response.json()
+            except requests.exceptions.JSONDecodeError:
+                current_data = current_response.text
+            if isinstance(current_data, str):
+                channel_latest = version_override.strip() == current_data.strip()
+
+            # HEAD probe to confirm the artifact exists.
+            artifact_url = str(result.get("download_url", ""))
+            if artifact_url:
+                head_response = session.head(artifact_url, allow_redirects=True)
+                if not head_response.ok:
+                    raise ArtifactNotAvailableError(
+                        f"Artifact not available at {artifact_url!r}: HTTP {head_response.status_code}"
+                    )
+
+            return ReleaseChannelResult(**result, channel_latest=channel_latest)
 
         session = cached_session()
         response = session.get(channel_url)
@@ -80,12 +105,42 @@ class ReleaseChannelPath:
                 resolver.set_metadata(metadata)
                 result[key] = resolver.resolve(data)
 
-        if version_override is not None and result.get("version") != version_override:
-            raise DispatchVersionMismatchError(
-                f"Dispatched version {version_override!r} does not match manifest version "
-                f"{result.get('version')!r} at {channel_url!r}. "
-                f"The upstream manifest has not propagated the dispatched build yet."
-            )
+        if version_override is not None:
+            # Manifest-based products (Connect, Workbench): substitute the version token in
+            # the manifest URL and probe the resulting artifact URL.
+            manifest_version: str = result.get("version", "")
+            url_str: str = result.get("download_url", "")
+
+            # Try each known transform until we find the manifest version in the URL.
+            candidates = [
+                (manifest_version, version_override),
+                (quote(manifest_version, safe=""), quote(version_override, safe="")),
+                (manifest_version.replace("+", "-"), version_override.replace("+", "-")),
+            ]
+            substituted_url = None
+            for needle, replacement in candidates:
+                if needle and needle in url_str:
+                    substituted_url = url_str.replace(needle, replacement)
+                    break
+
+            if substituted_url is None:
+                raise VersionSubstitutionError(
+                    f"Cannot substitute version {version_override!r} into URL {url_str!r}: "
+                    f"manifest version {manifest_version!r} not found under any known transform."
+                )
+
+            result["download_url"] = substituted_url
+            result["version"] = version_override
+
+            channel_latest = version_override.strip() == manifest_version.strip()
+
+            head_response = session.head(substituted_url, allow_redirects=True)
+            if not head_response.ok:
+                raise ArtifactNotAvailableError(
+                    f"Artifact not available at {substituted_url!r}: HTTP {head_response.status_code}"
+                )
+
+            return ReleaseChannelResult(**result, channel_latest=channel_latest)
 
         return ReleaseChannelResult(**result)
 

--- a/posit-bakery/posit_bakery/config/image/posit_product/main.py
+++ b/posit-bakery/posit_bakery/config/image/posit_product/main.py
@@ -73,6 +73,8 @@ class ReleaseChannelPath:
                 current_data = current_response.json()
             except requests.exceptions.JSONDecodeError:
                 current_data = current_response.text
+            # PPM channel endpoints return a plain-text version string, not JSON.
+            # channel_latest stays False if the response is JSON (no known products do this).
             if isinstance(current_data, str):
                 channel_latest = version_override.strip() == current_data.strip()
 

--- a/posit-bakery/posit_bakery/config/image/posit_product/main.py
+++ b/posit-bakery/posit_bakery/config/image/posit_product/main.py
@@ -50,6 +50,8 @@ class ReleaseChannelPath:
 
     def get(self, metadata: dict, version_override: str | None = None) -> ReleaseChannelResult:
         """Fetches data from the channel URL and resolves the data using the given resolvers."""
+        channel_url = self.channel_url.format_map(metadata)
+
         if version_override is not None and self.version_templatable:
             result: dict = {"version": version_override}
             url_safe_result = {f"url_safe_{k}": quote(str(v), safe="") for k, v in result.items()}
@@ -61,7 +63,7 @@ class ReleaseChannelPath:
             return ReleaseChannelResult(**result)
 
         session = cached_session()
-        response = session.get(self.channel_url)
+        response = session.get(channel_url)
         response.raise_for_status()
         try:
             data = response.json()
@@ -81,7 +83,7 @@ class ReleaseChannelPath:
         if version_override is not None and result.get("version") != version_override:
             raise DispatchVersionMismatchError(
                 f"Dispatched version {version_override!r} does not match manifest version "
-                f"{result.get('version')!r} at {self.channel_url!r}. "
+                f"{result.get('version')!r} at {channel_url!r}. "
                 f"The upstream manifest has not propagated the dispatched build yet."
             )
 
@@ -287,6 +289,7 @@ def get_product_artifact_by_channel(
     channel: ReleaseChannelEnum,
     os: BuildOS,
     version_override: str | None = None,
+    release_branch: str = "latest",
 ) -> ReleaseChannelResult:
     """Fetches the version and download URL for a given product, release channel, and OS."""
     if product not in product_release_channel_url_map:
@@ -295,5 +298,6 @@ def get_product_artifact_by_channel(
         raise ValueError(f"Channel {channel} is not supported for product {product}.")
 
     metadata = _make_resolver_metadata(os, product)
+    metadata["release_branch"] = release_branch
 
     return product_release_channel_url_map[product][channel].get(metadata, version_override)

--- a/posit-bakery/posit_bakery/config/tag.py
+++ b/posit-bakery/posit_bakery/config/tag.py
@@ -18,6 +18,7 @@ class TagPatternFilter(str, Enum):
     LATEST_PATCH = "latestPatch"  # Matches matrix rows that are the latest patch for their minor combination.
     PRIMARY_OS = "primaryOS"  # Matches image targets using the primary OS.
     PRIMARY_VARIANT = "primaryVariant"  # Matches image targets of the primary variant.
+    CHANNEL_LATEST = "channelLatest"  # Suppresses tags when the build targets an older-than-head channel version.
 
 
 class TagPattern(BakeryYAMLModel):
@@ -129,19 +130,19 @@ def default_tag_patterns() -> list[TagPattern]:
         *_shared_latest_tag_patterns(),
         TagPattern(
             patterns=["{{ Channel }}-{{ OS }}-{{ Variant }}"],
-            only=[TagPatternFilter.ALL],
+            only=[TagPatternFilter.CHANNEL_LATEST],
         ),
         TagPattern(
             patterns=["{{ Channel }}-{{ Variant }}"],
-            only=[TagPatternFilter.PRIMARY_OS],
+            only=[TagPatternFilter.CHANNEL_LATEST, TagPatternFilter.PRIMARY_OS],
         ),
         TagPattern(
             patterns=["{{ Channel }}-{{ OS }}"],
-            only=[TagPatternFilter.PRIMARY_VARIANT],
+            only=[TagPatternFilter.CHANNEL_LATEST, TagPatternFilter.PRIMARY_VARIANT],
         ),
         TagPattern(
             patterns=["{{ Channel }}"],
-            only=[TagPatternFilter.PRIMARY_OS, TagPatternFilter.PRIMARY_VARIANT],
+            only=[TagPatternFilter.CHANNEL_LATEST, TagPatternFilter.PRIMARY_OS, TagPatternFilter.PRIMARY_VARIANT],
         ),
     ]
 

--- a/posit-bakery/posit_bakery/image/image_target.py
+++ b/posit-bakery/posit_bakery/image/image_target.py
@@ -346,6 +346,16 @@ class ImageTarget(BaseModel):
         return self.image_variant.primary
 
     @property
+    def is_channel_latest(self) -> bool:
+        """Check whether this build targets the current channel head.
+
+        Returns False when the build was dispatched with an older version override so
+        that floating {{ Channel }} tags (which should always point at the head) are
+        suppressed. Defaults to True for non-channel sources.
+        """
+        return bool(self.image_version.metadata.get("channel_latest", True))
+
+    @property
     def push_sort_key(self) -> tuple[str, bool, "ParsedVersion", int, str, str, str]:
         """Deterministic ordering for push to ordered-display registries (e.g. Docker Hub).
 
@@ -412,7 +422,12 @@ class ImageTarget(BaseModel):
 
         filtered_patterns = []
         for tag_pattern in unique_patterns:
-            # Only go through additional filters if ALL is not applied.
+            # CHANNEL_LATEST is checked unconditionally — it must fire even for patterns
+            # that carry ALL, because floating channel tags must never point at a stale build.
+            if TagPatternFilter.CHANNEL_LATEST in tag_pattern.only and not self.is_channel_latest:
+                continue
+
+            # Only go through the remaining filters if ALL is not applied.
             if TagPatternFilter.ALL not in tag_pattern.only:
                 # Skip pattern marked as latest if not latest version.
                 if TagPatternFilter.LATEST in tag_pattern.only and not self.is_latest:

--- a/posit-bakery/posit_bakery/image/image_target.py
+++ b/posit-bakery/posit_bakery/image/image_target.py
@@ -422,8 +422,8 @@ class ImageTarget(BaseModel):
 
         filtered_patterns = []
         for tag_pattern in unique_patterns:
-            # CHANNEL_LATEST is checked unconditionally — it must fire even for patterns
-            # that carry ALL, because floating channel tags must never point at a stale build.
+            # CHANNEL_LATEST gates floating channel tags — patterns using only ALL skip this
+            # check and always emit.
             if TagPatternFilter.CHANNEL_LATEST in tag_pattern.only and not self.is_channel_latest:
                 continue
 

--- a/posit-bakery/test/cli/test_build.py
+++ b/posit-bakery/test/cli/test_build.py
@@ -13,7 +13,6 @@ from typer.testing import CliRunner
 from posit_bakery.cli.main import app
 from posit_bakery.config.image.posit_product.errors import (
     ArtifactNotAvailableError,
-    DispatchVersionMismatchError,
     VersionSubstitutionError,
 )
 
@@ -37,17 +36,6 @@ def mock_build_config():
 
 
 class TestDispatchVersionMismatch:
-    def test_mismatch_exits_with_clean_message(self):
-        """DispatchVersionMismatchError should print a plain message, not a traceback."""
-        msg = "Dispatched version '9999.99.0' does not match manifest version '2026.04.0'"
-        with patch("posit_bakery.cli.build.BakeryConfig") as mock:
-            mock.from_context.side_effect = DispatchVersionMismatchError(msg)
-            result = runner.invoke(app, ["build", "--context", BASIC_CONTEXT], catch_exceptions=False)
-
-        assert result.exit_code == 1
-        assert msg in result.output
-        assert "Traceback" not in result.output
-
     def test_artifact_not_available_exits_with_clean_message(self):
         """ArtifactNotAvailableError should print a plain message, not a traceback."""
         msg = "Artifact not available for version '2026.04.0-dev+5-gabcdef'"

--- a/posit-bakery/test/cli/test_build.py
+++ b/posit-bakery/test/cli/test_build.py
@@ -35,7 +35,7 @@ def mock_build_config():
         yield mock
 
 
-class TestDispatchVersionMismatch:
+class TestBuildErrorHandling:
     def test_artifact_not_available_exits_with_clean_message(self):
         """ArtifactNotAvailableError should print a plain message, not a traceback."""
         msg = "Artifact not available for version '2026.04.0-dev+5-gabcdef'"

--- a/posit-bakery/test/cli/test_build.py
+++ b/posit-bakery/test/cli/test_build.py
@@ -11,7 +11,11 @@ from pytest_bdd import scenarios, then, parsers
 from typer.testing import CliRunner
 
 from posit_bakery.cli.main import app
-from posit_bakery.config.image.posit_product.errors import DispatchVersionMismatchError
+from posit_bakery.config.image.posit_product.errors import (
+    ArtifactNotAvailableError,
+    DispatchVersionMismatchError,
+    VersionSubstitutionError,
+)
 
 scenarios(
     "cli/build.feature",
@@ -38,6 +42,28 @@ class TestDispatchVersionMismatch:
         msg = "Dispatched version '9999.99.0' does not match manifest version '2026.04.0'"
         with patch("posit_bakery.cli.build.BakeryConfig") as mock:
             mock.from_context.side_effect = DispatchVersionMismatchError(msg)
+            result = runner.invoke(app, ["build", "--context", BASIC_CONTEXT], catch_exceptions=False)
+
+        assert result.exit_code == 1
+        assert msg in result.output
+        assert "Traceback" not in result.output
+
+    def test_artifact_not_available_exits_with_clean_message(self):
+        """ArtifactNotAvailableError should print a plain message, not a traceback."""
+        msg = "Artifact not available for version '2026.04.0-dev+5-gabcdef'"
+        with patch("posit_bakery.cli.build.BakeryConfig") as mock:
+            mock.from_context.side_effect = ArtifactNotAvailableError(msg)
+            result = runner.invoke(app, ["build", "--context", BASIC_CONTEXT], catch_exceptions=False)
+
+        assert result.exit_code == 1
+        assert msg in result.output
+        assert "Traceback" not in result.output
+
+    def test_version_substitution_error_exits_with_clean_message(self):
+        """VersionSubstitutionError should print a plain message, not a traceback."""
+        msg = "Cannot substitute '2026.04.0-dev+5-gabcdef' into URL"
+        with patch("posit_bakery.cli.build.BakeryConfig") as mock:
+            mock.from_context.side_effect = VersionSubstitutionError(msg)
             result = runner.invoke(app, ["build", "--context", BASIC_CONTEXT], catch_exceptions=False)
 
         assert result.exit_code == 1

--- a/posit-bakery/test/config/image/dev_version/test_channel.py
+++ b/posit-bakery/test/config/image/dev_version/test_channel.py
@@ -341,7 +341,7 @@ class TestImageDevelopmentVersionFromProductChannel:
         )
         dev_version.parent = mock_parent
         image_version = dev_version.as_image_version()
-        assert image_version.metadata == {"release_channel": ReleaseChannelEnum.PREVIEW}
+        assert image_version.metadata == {"release_channel": ReleaseChannelEnum.PREVIEW, "channel_latest": True}
 
     @pytest.mark.parametrize(
         "download_url,generalize_architecture,expected_url",
@@ -400,9 +400,9 @@ class TestImageDevelopmentVersionFromProductChannel:
         assert dv.get_version() == "2026.05.0-dev+185-gSHA"
         patch_requests_get.assert_not_called()
 
-    def test_mismatch_error_propagates_through_resolve_os_urls(self):
-        """DispatchVersionMismatchError must NOT be swallowed by _resolve_os_urls."""
-        from posit_bakery.config.image.posit_product.main import DispatchVersionMismatchError
+    def test_artifact_not_available_propagates_through_resolve_os_urls(self):
+        """ArtifactNotAvailableError must NOT be swallowed by _resolve_os_urls."""
+        from posit_bakery.config.image.posit_product.errors import ArtifactNotAvailableError
         from unittest.mock import patch
 
         dv = ImageDevelopmentVersionFromProductChannel(
@@ -414,9 +414,28 @@ class TestImageDevelopmentVersionFromProductChannel:
         dv.version_override = "9999.99.0-daily+1.pro1"
         with patch(
             "posit_bakery.config.image.dev_version.channel.get_product_artifact_by_channel",
-            side_effect=DispatchVersionMismatchError("mismatch"),
+            side_effect=ArtifactNotAvailableError("artifact missing"),
         ):
-            with pytest.raises(DispatchVersionMismatchError):
+            with pytest.raises(ArtifactNotAvailableError):
+                dv._resolve_os_urls()
+
+    def test_version_substitution_error_propagates_through_resolve_os_urls(self):
+        """VersionSubstitutionError must NOT be swallowed by _resolve_os_urls."""
+        from posit_bakery.config.image.posit_product.errors import VersionSubstitutionError
+        from unittest.mock import patch
+
+        dv = ImageDevelopmentVersionFromProductChannel(
+            sourceType="stream",
+            product="connect",
+            channel="daily",
+            os=[{"name": "Ubuntu 24.04", "primary": True}],
+        )
+        dv.version_override = "9999.99.0-dev+1-gdeadbeef"
+        with patch(
+            "posit_bakery.config.image.dev_version.channel.get_product_artifact_by_channel",
+            side_effect=VersionSubstitutionError("cannot substitute"),
+        ):
+            with pytest.raises(VersionSubstitutionError):
                 dv._resolve_os_urls()
 
 

--- a/posit-bakery/test/config/image/dev_version/test_spec.py
+++ b/posit-bakery/test/config/image/dev_version/test_spec.py
@@ -34,6 +34,10 @@ class TestDevBuildSpec:
         with pytest.raises(ValidationError, match="at least one of"):
             DevBuildSpec(channel=ReleaseChannelEnum.DAILY)
 
+    def test_empty_string_version_raises(self):
+        with pytest.raises(ValidationError, match="version must not be empty"):
+            DevBuildSpec(version="", release_branch="apple-blossom")
+
     def test_empty_version_raises(self):
         with pytest.raises(ValidationError, match="version must not be empty"):
             DevBuildSpec(version="   ")

--- a/posit-bakery/test/config/image/dev_version/test_spec.py
+++ b/posit-bakery/test/config/image/dev_version/test_spec.py
@@ -38,6 +38,10 @@ class TestDevBuildSpec:
         with pytest.raises(ValidationError, match="version must not be empty"):
             DevBuildSpec(version="   ")
 
+    def test_non_calver_version_raises(self):
+        with pytest.raises(ValidationError, match="CalVer"):
+            DevBuildSpec(version="not-a-calver")
+
     def test_empty_release_branch_raises(self):
         with pytest.raises(ValidationError, match="release_branch must not be empty"):
             DevBuildSpec(release_branch="")

--- a/posit-bakery/test/config/image/dev_version/test_spec.py
+++ b/posit-bakery/test/config/image/dev_version/test_spec.py
@@ -4,18 +4,48 @@ from pydantic import ValidationError
 from posit_bakery.config.image.dev_version.spec import DevBuildSpec
 from posit_bakery.config.image.posit_product.const import ReleaseChannelEnum
 
-pytestmark = [pytest.mark.unit, pytest.mark.config]
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.config,
+]
 
 
 class TestDevBuildSpec:
-    def test_version_required(self):
-        with pytest.raises(ValidationError):
-            DevBuildSpec.model_validate_json("{}")
+    def test_version_only(self):
+        spec = DevBuildSpec(version="2026.06.0-daily+143")
+        assert spec.version == "2026.06.0-daily+143"
+        assert spec.release_branch is None
 
-    def test_minimal_valid(self):
-        spec = DevBuildSpec.model_validate_json('{"version": "2026.05.0-dev+185-gSHA"}')
-        assert spec.version == "2026.05.0-dev+185-gSHA"
-        assert spec.channel is None
+    def test_release_branch_only(self):
+        spec = DevBuildSpec(release_branch="apple-blossom")
+        assert spec.version is None
+        assert spec.release_branch == "apple-blossom"
+
+    def test_both_fields(self):
+        spec = DevBuildSpec(version="2026.06.0-daily+143", release_branch="apple-blossom")
+        assert spec.version == "2026.06.0-daily+143"
+        assert spec.release_branch == "apple-blossom"
+
+    def test_neither_field_raises(self):
+        with pytest.raises(ValidationError, match="at least one of"):
+            DevBuildSpec()
+
+    def test_channel_only_raises(self):
+        with pytest.raises(ValidationError, match="at least one of"):
+            DevBuildSpec(channel=ReleaseChannelEnum.DAILY)
+
+    def test_empty_version_raises(self):
+        with pytest.raises(ValidationError, match="version must not be empty"):
+            DevBuildSpec(version="   ")
+
+    def test_empty_release_branch_raises(self):
+        with pytest.raises(ValidationError, match="release_branch must not be empty"):
+            DevBuildSpec(release_branch="")
+
+    def test_model_validate_json_release_branch_only(self):
+        spec = DevBuildSpec.model_validate_json('{"release_branch": "2026.07"}')
+        assert spec.release_branch == "2026.07"
+        assert spec.version is None
 
     def test_with_channel(self):
         spec = DevBuildSpec.model_validate_json('{"version": "2026.05.0-dev+185-gSHA", "channel": "daily"}')
@@ -25,16 +55,25 @@ class TestDevBuildSpec:
         with pytest.raises(ValidationError):
             DevBuildSpec.model_validate_json('{"version": "2026.05.0-dev+185-gSHA", "channel": "nightly"}')
 
-    def test_empty_version_raises(self):
-        with pytest.raises(ValidationError):
-            DevBuildSpec(version="")
-        with pytest.raises(ValidationError):
-            DevBuildSpec(version="   ")
-
     def test_whitespace_version_is_stripped(self):
         spec = DevBuildSpec.model_validate_json('{"version": "  2026.05.0-dev+185-gSHA  "}')
         assert spec.version == "2026.05.0-dev+185-gSHA"
 
     def test_unknown_fields_raise(self):
         with pytest.raises(ValidationError):
-            DevBuildSpec.model_validate_json('{"version": "2026.05.0-dev+1-gSHA", "chanenl": "daily"}')
+            DevBuildSpec.model_validate_json('{"version": "2026.05.0-dev+1-gSHA", "unexpected_field": "daily"}')
+
+    def test_explicit_none_version_with_release_branch(self):
+        spec = DevBuildSpec(version=None, release_branch="apple-blossom")
+        assert spec.version is None
+        assert spec.release_branch == "apple-blossom"
+
+    def test_explicit_none_release_branch_with_version(self):
+        spec = DevBuildSpec(version="2026.06.0-daily+143", release_branch=None)
+        assert spec.version == "2026.06.0-daily+143"
+        assert spec.release_branch is None
+
+    def test_json_null_version_with_release_branch(self):
+        spec = DevBuildSpec.model_validate_json('{"version": null, "release_branch": "apple-blossom"}')
+        assert spec.version is None
+        assert spec.release_branch == "apple-blossom"

--- a/posit-bakery/test/config/image/posit_products/test_const.py
+++ b/posit-bakery/test/config/image/posit_products/test_const.py
@@ -12,32 +12,19 @@ pytestmark = [
 
 
 class TestWorkbenchDailyUrl:
-    """Test that WORKBENCH_DAILY_URL is constructed from the BAKERY_WORKBENCH_RELEASE_BRANCH env var."""
+    """WORKBENCH_DAILY_URL contains a {release_branch} template slot."""
 
-    def test_default_url(self, monkeypatch):
-        """When BAKERY_WORKBENCH_RELEASE_BRANCH is not set, the URL defaults to 'latest'."""
-        monkeypatch.delenv("BAKERY_WORKBENCH_RELEASE_BRANCH", raising=False)
-        importlib.reload(product_const)
+    def test_contains_release_branch_placeholder(self):
+        assert "{release_branch}" in product_const.WORKBENCH_DAILY_URL
 
-        assert product_const.WORKBENCH_DAILY_URL == "https://dailies.rstudio.com/rstudio/latest/index.json"
+    def test_formats_with_latest(self):
+        url = product_const.WORKBENCH_DAILY_URL.format(release_branch="latest")
+        assert url == "https://dailies.rstudio.com/rstudio/latest/index.json"
 
-    @pytest.mark.parametrize(
-        "branch",
-        [
-            pytest.param("globemaster-allium", id="globemaster-allium"),
-            pytest.param("apple-blossom", id="apple-blossom"),
-        ],
-    )
-    def test_custom_release_branch(self, monkeypatch, branch):
-        """When BAKERY_WORKBENCH_RELEASE_BRANCH is set, the URL uses the branch name."""
-        monkeypatch.setenv("BAKERY_WORKBENCH_RELEASE_BRANCH", branch)
-        importlib.reload(product_const)
+    def test_formats_with_named_branch(self):
+        url = product_const.WORKBENCH_DAILY_URL.format(release_branch="apple-blossom")
+        assert url == "https://dailies.rstudio.com/rstudio/apple-blossom/index.json"
 
-        assert product_const.WORKBENCH_DAILY_URL == f"https://dailies.rstudio.com/rstudio/{branch}/index.json"
-
-    def test_empty_string_uses_empty_path(self, monkeypatch):
-        """When BAKERY_WORKBENCH_RELEASE_BRANCH is set to an empty string, the empty value is used."""
-        monkeypatch.setenv("BAKERY_WORKBENCH_RELEASE_BRANCH", "")
-        importlib.reload(product_const)
-
-        assert product_const.WORKBENCH_DAILY_URL == "https://dailies.rstudio.com/rstudio//index.json"
+    def test_formats_with_calver_branch(self):
+        url = product_const.WORKBENCH_DAILY_URL.format(release_branch="2026.07")
+        assert url == "https://dailies.rstudio.com/rstudio/2026.07/index.json"

--- a/posit-bakery/test/config/image/posit_products/test_main.py
+++ b/posit-bakery/test/config/image/posit_products/test_main.py
@@ -785,6 +785,39 @@ class TestGetProductArtifactByChannel:
         assert str(output.download_url) == expected_session_url
 
 
+class TestGetProductArtifactByChannelReleaseBranch:
+    """release_branch is passed through to the Workbench daily URL."""
+
+    def test_default_release_branch_uses_latest(self, mocker):
+        from test.config.conftest import patch_testdata_response
+
+        mock_session = mocker.patch("posit_bakery.config.image.posit_product.main.cached_session")
+        mock_session.return_value.get.side_effect = patch_testdata_response
+        mock_session.return_value.get.return_value.raise_for_status.return_value = None
+
+        get_product_artifact_by_channel(ProductEnum.WORKBENCH, ReleaseChannelEnum.DAILY, SUPPORTED_OS["ubuntu"]["24"])
+
+        called_url = mock_session.return_value.get.call_args[0][0]
+        assert "latest" in called_url
+
+    def test_named_release_branch_formats_url(self, mocker):
+        from test.config.conftest import patch_testdata_response
+
+        mock_session = mocker.patch("posit_bakery.config.image.posit_product.main.cached_session")
+        mock_session.return_value.get.side_effect = patch_testdata_response
+        mock_session.return_value.get.return_value.raise_for_status.return_value = None
+
+        get_product_artifact_by_channel(
+            ProductEnum.WORKBENCH,
+            ReleaseChannelEnum.DAILY,
+            SUPPORTED_OS["ubuntu"]["24"],
+            release_branch="apple-blossom",
+        )
+
+        called_url = mock_session.return_value.get.call_args[0][0]
+        assert "apple-blossom" in called_url
+
+
 class TestDispatchOverride:
     def test_ppm_daily_override_renders_offline(self, mocker):
         """Template streams must NOT hit the network when version_override is supplied."""

--- a/posit-bakery/test/config/image/posit_products/test_main.py
+++ b/posit-bakery/test/config/image/posit_products/test_main.py
@@ -819,9 +819,14 @@ class TestGetProductArtifactByChannelReleaseBranch:
 
 
 class TestDispatchOverride:
-    def test_ppm_daily_override_renders_offline(self, mocker):
-        """Template streams must NOT hit the network when version_override is supplied."""
-        spy = mocker.patch("posit_bakery.config.image.posit_product.main.cached_session")
+    def test_ppm_daily_override_uses_template_url(self, mocker):
+        """PPM override builds the artifact URL from the template and probes it."""
+        from test.config.conftest import patch_testdata_response
+
+        mock_session = mocker.patch("posit_bakery.config.image.posit_product.main.cached_session")
+        mock_session.return_value.get.side_effect = patch_testdata_response
+        mock_session.return_value.head.return_value.ok = True
+
         override = "2026.05.0-dev+185-g8a23833f57"
         result = get_product_artifact_by_channel(
             ProductEnum.PACKAGE_MANAGER,
@@ -829,13 +834,20 @@ class TestDispatchOverride:
             SUPPORTED_OS["ubuntu"]["24"],
             version_override=override,
         )
-        spy.assert_not_called()
         assert result.version == override
         assert "2026.05.0-dev%2B185-g8a23833f57" in str(result.download_url)
+        # Override differs from fixture head (2026.02.0-dev+89-...), so not channel latest.
+        assert result.channel_latest is False
+        mock_session.return_value.head.assert_called_once()
 
-    def test_ppm_preview_override_renders_offline(self, mocker):
-        """Preview stream is also templatable — no network on override."""
-        spy = mocker.patch("posit_bakery.config.image.posit_product.main.cached_session")
+    def test_ppm_preview_override_uses_template_url(self, mocker):
+        """PPM preview override builds the URL from template, probes, checks channel head."""
+        from test.config.conftest import patch_testdata_response
+
+        mock_session = mocker.patch("posit_bakery.config.image.posit_product.main.cached_session")
+        mock_session.return_value.get.side_effect = patch_testdata_response
+        mock_session.return_value.head.return_value.ok = True
+
         override = "2026.05.0-dev+185-g8a23833f57"
         result = get_product_artifact_by_channel(
             ProductEnum.PACKAGE_MANAGER,
@@ -843,35 +855,83 @@ class TestDispatchOverride:
             SUPPORTED_OS["ubuntu"]["24"],
             version_override=override,
         )
-        spy.assert_not_called()
+        assert result.version == override
+        assert result.channel_latest is False
+
+    def test_connect_daily_override_substitutes_url(self, patch_requests_get):
+        """Connect override substitutes the version in the manifest URL."""
+        override = "2025.04.0-dev+5-gabcdef1234"
+        result = get_product_artifact_by_channel(
+            ProductEnum.CONNECT,
+            ReleaseChannelEnum.DAILY,
+            SUPPORTED_OS["ubuntu"]["24"],
+            version_override=override,
+        )
+        assert result.version == override
+        assert "2025.04.0-dev%2B5-gabcdef1234" in str(result.download_url)
+        assert result.channel_latest is False
+
+    def test_workbench_daily_override_substitutes_url(self, patch_requests_get):
+        """Workbench override substitutes the version in the manifest URL."""
+        override = "2025.04.0-daily+300.pro3"
+        result = get_product_artifact_by_channel(
+            ProductEnum.WORKBENCH,
+            ReleaseChannelEnum.DAILY,
+            SUPPORTED_OS["ubuntu"]["24"],
+            version_override=override,
+        )
+        assert result.version == override
+        assert "2025.04.0-daily-300.pro3" in str(result.download_url)
+        assert result.channel_latest is False
+
+    def test_ppm_channel_latest_true_when_override_equals_head(self, mocker):
+        """channel_latest is True when the override exactly matches the channel head."""
+        from test.config.conftest import patch_testdata_response
+
+        mock_session = mocker.patch("posit_bakery.config.image.posit_product.main.cached_session")
+        mock_session.return_value.get.side_effect = patch_testdata_response
+        mock_session.return_value.head.return_value.ok = True
+
+        # PPM daily fixture head is "2026.02.0-dev+89-ga1b2c3d4e5"
+        override = "2026.02.0-dev+89-ga1b2c3d4e5"
+        result = get_product_artifact_by_channel(
+            ProductEnum.PACKAGE_MANAGER,
+            ReleaseChannelEnum.DAILY,
+            SUPPORTED_OS["ubuntu"]["24"],
+            version_override=override,
+        )
+        assert result.channel_latest is True
+
+    def test_connect_channel_latest_true_when_override_equals_head(self, patch_requests_get):
+        """channel_latest is True when the override matches the Connect manifest version."""
+        # Connect daily fixture version is "2025.04.0-dev+10-gbe0a4a3d31"
+        override = "2025.04.0-dev+10-gbe0a4a3d31"
+        result = get_product_artifact_by_channel(
+            ProductEnum.CONNECT,
+            ReleaseChannelEnum.DAILY,
+            SUPPORTED_OS["ubuntu"]["24"],
+            version_override=override,
+        )
+        assert result.channel_latest is True
         assert result.version == override
 
-    def test_connect_daily_override_mismatch_raises(self, patch_requests_get):
-        """Manifest streams must raise DispatchVersionMismatchError when versions differ."""
-        from posit_bakery.config.image.posit_product.main import DispatchVersionMismatchError
+    def test_artifact_not_available_raises(self, patch_requests_get):
+        """A 404 HEAD on the substituted URL raises ArtifactNotAvailableError."""
+        from posit_bakery.config.image.posit_product.errors import ArtifactNotAvailableError
 
-        with pytest.raises(DispatchVersionMismatchError):
+        patch_requests_get.return_value.head.return_value.ok = False
+        patch_requests_get.return_value.head.return_value.status_code = 404
+
+        with pytest.raises(ArtifactNotAvailableError):
             get_product_artifact_by_channel(
                 ProductEnum.CONNECT,
                 ReleaseChannelEnum.DAILY,
                 SUPPORTED_OS["ubuntu"]["24"],
-                version_override="9999.99.0-dev+1-gdeadbeef",
-            )
-
-    def test_workbench_daily_override_mismatch_raises(self, patch_requests_get):
-        """Workbench daily is a manifest stream — mismatch raises."""
-        from posit_bakery.config.image.posit_product.main import DispatchVersionMismatchError
-
-        with pytest.raises(DispatchVersionMismatchError):
-            get_product_artifact_by_channel(
-                ProductEnum.WORKBENCH,
-                ReleaseChannelEnum.DAILY,
-                SUPPORTED_OS["ubuntu"]["24"],
-                version_override="9999.99.0-daily+1.pro1",
+                version_override="2025.04.0-dev+5-gabcdef1234",
             )
 
     def test_no_override_scheduled_path_unchanged(self, patch_requests_get):
-        """With version_override=None, behavior is identical to before this task."""
+        """With version_override=None, behavior is identical to before this change."""
         result = get_product_artifact_by_channel(
             ProductEnum.PACKAGE_MANAGER,
             ReleaseChannelEnum.DAILY,
@@ -879,3 +939,4 @@ class TestDispatchOverride:
         )
         assert result.version is not None
         assert result.download_url is not None
+        assert result.channel_latest is True

--- a/posit-bakery/test/config/image/posit_products/test_main.py
+++ b/posit-bakery/test/config/image/posit_products/test_main.py
@@ -2,6 +2,7 @@ import pytest
 
 from posit_bakery.config.image.build_os import SUPPORTED_OS, BuildOS
 from posit_bakery.config.image.posit_product.const import ProductEnum, ReleaseChannelEnum, ReleaseStreamEnum
+from posit_bakery.config.image.posit_product.errors import ArtifactNotAvailableError, VersionSubstitutionError
 from posit_bakery.config.image.posit_product.main import (
     _parse_download_json_os_identifier,
     _make_resolver_metadata,
@@ -798,7 +799,7 @@ class TestGetProductArtifactByChannelReleaseBranch:
         get_product_artifact_by_channel(ProductEnum.WORKBENCH, ReleaseChannelEnum.DAILY, SUPPORTED_OS["ubuntu"]["24"])
 
         called_url = mock_session.return_value.get.call_args[0][0]
-        assert "latest" in called_url
+        assert called_url == "https://dailies.rstudio.com/rstudio/latest/index.json"
 
     def test_named_release_branch_formats_url(self, mocker):
         from test.config.conftest import patch_testdata_response
@@ -815,7 +816,7 @@ class TestGetProductArtifactByChannelReleaseBranch:
         )
 
         called_url = mock_session.return_value.get.call_args[0][0]
-        assert "apple-blossom" in called_url
+        assert called_url == "https://dailies.rstudio.com/rstudio/apple-blossom/index.json"
 
 
 class TestDispatchOverride:
@@ -918,10 +919,34 @@ class TestDispatchOverride:
         assert result.channel_latest is True
         assert result.version == override
 
+    def test_version_substitution_error_when_version_not_in_url(self, mocker):
+        """VersionSubstitutionError raised when the manifest URL contains no substitutable token."""
+        from test.config.conftest import patch_testdata_response
+
+        mock_session = mocker.patch("posit_bakery.config.image.posit_product.main.cached_session")
+        mock_response = mocker.MagicMock()
+        # URL deliberately omits the version — no substitution is possible under any transform.
+        mock_response.json.return_value = {
+            "packages": [
+                {
+                    "platform": "ubuntu24/amd64",
+                    "version": "2025.04.0-dev+10-gbe0a4a3d31",
+                    "url": "https://cdn.posit.co/connect/opaque-path/artifact.deb",
+                }
+            ]
+        }
+        mock_session.return_value.get.return_value = mock_response
+
+        with pytest.raises(VersionSubstitutionError):
+            get_product_artifact_by_channel(
+                ProductEnum.CONNECT,
+                ReleaseChannelEnum.DAILY,
+                SUPPORTED_OS["ubuntu"]["24"],
+                version_override="2025.04.0-dev+5-gabcdef1234",
+            )
+
     def test_artifact_not_available_raises(self, patch_requests_get):
         """A 404 HEAD on the substituted URL raises ArtifactNotAvailableError."""
-        from posit_bakery.config.image.posit_product.errors import ArtifactNotAvailableError
-
         patch_requests_get.return_value.head.return_value.ok = False
         patch_requests_get.return_value.head.return_value.status_code = 404
 

--- a/posit-bakery/test/config/image/posit_products/test_main.py
+++ b/posit-bakery/test/config/image/posit_products/test_main.py
@@ -860,6 +860,7 @@ class TestDispatchOverride:
 
     def test_connect_daily_override_substitutes_url(self, patch_requests_get):
         """Connect override substitutes the version in the manifest URL."""
+        patch_requests_get.return_value.head.return_value.ok = True
         override = "2025.04.0-dev+5-gabcdef1234"
         result = get_product_artifact_by_channel(
             ProductEnum.CONNECT,
@@ -873,6 +874,7 @@ class TestDispatchOverride:
 
     def test_workbench_daily_override_substitutes_url(self, patch_requests_get):
         """Workbench override substitutes the version in the manifest URL."""
+        patch_requests_get.return_value.head.return_value.ok = True
         override = "2025.04.0-daily+300.pro3"
         result = get_product_artifact_by_channel(
             ProductEnum.WORKBENCH,
@@ -904,6 +906,7 @@ class TestDispatchOverride:
 
     def test_connect_channel_latest_true_when_override_equals_head(self, patch_requests_get):
         """channel_latest is True when the override matches the Connect manifest version."""
+        patch_requests_get.return_value.head.return_value.ok = True
         # Connect daily fixture version is "2025.04.0-dev+10-gbe0a4a3d31"
         override = "2025.04.0-dev+10-gbe0a4a3d31"
         result = get_product_artifact_by_channel(

--- a/posit-bakery/test/config/test_config.py
+++ b/posit-bakery/test/config/test_config.py
@@ -541,11 +541,11 @@ class TestBakeryConfig:
                 )
                 _apply_dev_spec(image, settings)
                 dv = image.devVersions[0]
-                assert dv.pinned_version == "2026.06.0-daily+143-gABC"
+                assert dv.version_override == "2026.06.0-daily+143-gABC"
                 assert dv.release_branch == "2026.06"
 
             def test_release_branch_only_sets_branch(self, tmp_path):
-                """release_branch in DevBuildSpec sets release_branch directly; pinned_version stays None."""
+                """release_branch in DevBuildSpec sets release_branch directly; version_override stays None."""
                 from posit_bakery.config.config import _apply_dev_spec
                 from posit_bakery.config.image.dev_version.spec import DevBuildSpec
 
@@ -557,7 +557,7 @@ class TestBakeryConfig:
                 )
                 _apply_dev_spec(image, settings)
                 dv = image.devVersions[0]
-                assert dv.pinned_version is None
+                assert dv.version_override is None
                 assert dv.release_branch == "apple-blossom"
 
             def test_version_takes_precedence_over_release_branch(self, tmp_path):
@@ -573,7 +573,7 @@ class TestBakeryConfig:
                 )
                 _apply_dev_spec(image, settings)
                 dv = image.devVersions[0]
-                assert dv.pinned_version == "2026.06.0-daily+143-gABC"
+                assert dv.version_override == "2026.06.0-daily+143-gABC"
                 assert dv.release_branch == "2026.06"
 
             def test_extract_calver_minor_rejects_trailing_garbage(self):

--- a/posit-bakery/test/config/test_config.py
+++ b/posit-bakery/test/config/test_config.py
@@ -10,7 +10,15 @@ import pytest
 from pydantic import ValidationError
 
 import posit_bakery
-from posit_bakery.config.config import BakeryConfigDocument, BakeryConfig, BakeryConfigFilter, BakerySettings
+from posit_bakery.config.config import (
+    BakeryConfigDocument,
+    BakeryConfig,
+    BakeryConfigFilter,
+    BakerySettings,
+    _apply_dev_spec,
+    _extract_calver_minor,
+)
+from posit_bakery.config.image.dev_version.spec import DevBuildSpec
 from posit_bakery.config.dependencies import PythonDependencyConstraint, RDependencyVersions
 from posit_bakery.config.image.posit_product.const import ReleaseChannelEnum
 from posit_bakery.const import DevVersionInclusionEnum, MatrixVersionInclusionEnum
@@ -485,88 +493,6 @@ class TestBakeryConfig:
             )
             with pytest.raises(ValueError, match="[Cc]onfli"):
                 BakeryConfig(bakery_yaml, settings=settings)
-
-        class TestApplyDevSpecReleaseBranch:
-            """release_branch is set from YYYY.MM when version is set, or directly from spec."""
-
-            def _make_image(self, tmp_path):
-                """Return a minimal Image with one workbench daily dev version."""
-                from posit_bakery.config.config import BakeryConfigDocument
-
-                doc = BakeryConfigDocument(
-                    base_path=tmp_path,
-                    **{
-                        "repository": {"url": "https://github.com/posit-dev/test"},
-                        "images": [
-                            {
-                                "name": "test-image",
-                                "devVersions": [
-                                    {
-                                        "sourceType": "stream",
-                                        "product": "workbench",
-                                        "channel": "daily",
-                                        "os": [{"name": "Ubuntu 24.04", "primary": True}],
-                                    }
-                                ],
-                            }
-                        ],
-                    },
-                )
-                return doc.images[0]
-
-            def test_version_sets_calver_release_branch(self, tmp_path):
-                """version in DevBuildSpec pins version and derives YYYY.MM release_branch."""
-                from posit_bakery.config.config import _apply_dev_spec
-                from posit_bakery.config.image.dev_version.spec import DevBuildSpec
-
-                image = self._make_image(tmp_path)
-                spec = DevBuildSpec(version="2026.06.0-daily+143-gABC")
-                settings = BakerySettings(
-                    dev_versions=DevVersionInclusionEnum.ONLY,
-                    dev_spec=spec,
-                )
-                _apply_dev_spec(image, settings)
-                dv = image.devVersions[0]
-                assert dv.version_override == "2026.06.0-daily+143-gABC"
-                assert dv.release_branch == "2026.06"
-
-            def test_release_branch_only_sets_branch(self, tmp_path):
-                """release_branch in DevBuildSpec sets release_branch directly; version_override stays None."""
-                from posit_bakery.config.config import _apply_dev_spec
-                from posit_bakery.config.image.dev_version.spec import DevBuildSpec
-
-                image = self._make_image(tmp_path)
-                spec = DevBuildSpec(release_branch="apple-blossom")
-                settings = BakerySettings(
-                    dev_versions=DevVersionInclusionEnum.ONLY,
-                    dev_spec=spec,
-                )
-                _apply_dev_spec(image, settings)
-                dv = image.devVersions[0]
-                assert dv.version_override is None
-                assert dv.release_branch == "apple-blossom"
-
-            def test_version_takes_precedence_over_release_branch(self, tmp_path):
-                """When both are set, version wins; release_branch is YYYY.MM, not spec.release_branch."""
-                from posit_bakery.config.config import _apply_dev_spec
-                from posit_bakery.config.image.dev_version.spec import DevBuildSpec
-
-                image = self._make_image(tmp_path)
-                spec = DevBuildSpec(version="2026.06.0-daily+143-gABC", release_branch="apple-blossom")
-                settings = BakerySettings(
-                    dev_versions=DevVersionInclusionEnum.ONLY,
-                    dev_spec=spec,
-                )
-                _apply_dev_spec(image, settings)
-                dv = image.devVersions[0]
-                assert dv.version_override == "2026.06.0-daily+143-gABC"
-                assert dv.release_branch == "2026.06"
-
-            def test_extract_calver_minor_rejects_trailing_garbage(self):
-                from posit_bakery.config.config import _extract_calver_minor
-
-                with pytest.raises(ValueError, match="not a valid CalVer"):
-                    _extract_calver_minor("2026.06.0-daily+143 trailing garbage")
 
     @pytest.mark.parametrize(
         "include_matrix_versions,expected_uids",
@@ -2297,3 +2223,73 @@ class TestBakeryConfig:
         mock_ghcr_client.assert_called_once()
         mock_ghcr_client_instance.get_package_versions.assert_called_once()
         mock_ghcr_client_instance.delete_package_version.assert_not_called()
+
+
+class TestApplyDevSpecReleaseBranch:
+    """release_branch is set from YYYY.MM when version is set, or directly from spec."""
+
+    def _make_image(self, tmp_path):
+        """Return a minimal Image with one workbench daily dev version."""
+        doc = BakeryConfigDocument(
+            base_path=tmp_path,
+            **{
+                "repository": {"url": "https://github.com/posit-dev/test"},
+                "images": [
+                    {
+                        "name": "test-image",
+                        "devVersions": [
+                            {
+                                "sourceType": "stream",
+                                "product": "workbench",
+                                "channel": "daily",
+                                "os": [{"name": "Ubuntu 24.04", "primary": True}],
+                            }
+                        ],
+                    }
+                ],
+            },
+        )
+        return doc.images[0]
+
+    def test_version_sets_calver_release_branch(self, tmp_path):
+        """version in DevBuildSpec pins version and derives YYYY.MM release_branch."""
+        image = self._make_image(tmp_path)
+        spec = DevBuildSpec(version="2026.06.0-daily+143-gABC")
+        settings = BakerySettings(
+            dev_versions=DevVersionInclusionEnum.ONLY,
+            dev_spec=spec,
+        )
+        _apply_dev_spec(image, settings)
+        dv = image.devVersions[0]
+        assert dv.version_override == "2026.06.0-daily+143-gABC"
+        assert dv.release_branch == "2026.06"
+
+    def test_release_branch_only_sets_branch(self, tmp_path):
+        """release_branch in DevBuildSpec sets release_branch directly; version_override stays None."""
+        image = self._make_image(tmp_path)
+        spec = DevBuildSpec(release_branch="apple-blossom")
+        settings = BakerySettings(
+            dev_versions=DevVersionInclusionEnum.ONLY,
+            dev_spec=spec,
+        )
+        _apply_dev_spec(image, settings)
+        dv = image.devVersions[0]
+        assert dv.version_override is None
+        assert dv.release_branch == "apple-blossom"
+
+    def test_version_takes_precedence_over_release_branch(self, tmp_path):
+        """When both are set, version wins; release_branch is YYYY.MM, not spec.release_branch."""
+        image = self._make_image(tmp_path)
+        spec = DevBuildSpec(version="2026.06.0-daily+143-gABC", release_branch="apple-blossom")
+        settings = BakerySettings(
+            dev_versions=DevVersionInclusionEnum.ONLY,
+            dev_spec=spec,
+        )
+        _apply_dev_spec(image, settings)
+        dv = image.devVersions[0]
+        assert dv.version_override == "2026.06.0-daily+143-gABC"
+        assert dv.release_branch == "2026.06"
+
+    def test_extract_calver_minor_rejects_trailing_garbage(self):
+        with pytest.raises(ValueError, match="not a valid CalVer"):
+            _extract_calver_minor("2026.06.0-daily+143 trailing garbage")

--- a/posit-bakery/test/config/test_config.py
+++ b/posit-bakery/test/config/test_config.py
@@ -493,20 +493,6 @@ class TestBakeryConfig:
                 """Return a minimal Image with one workbench daily dev version."""
                 from posit_bakery.config.config import BakeryConfigDocument
 
-                bakery_yaml = tmp_path / "bakery.yaml"
-                bakery_yaml.write_text(
-                    "repository:\n"
-                    "  url: https://github.com/posit-dev/test\n"
-                    "images:\n"
-                    "  - name: test-image\n"
-                    "    devVersions:\n"
-                    "      - sourceType: stream\n"
-                    "        product: workbench\n"
-                    "        channel: daily\n"
-                    "        os:\n"
-                    "          - name: Ubuntu 24.04\n"
-                    "            primary: true\n"
-                )
                 doc = BakeryConfigDocument(
                     base_path=tmp_path,
                     **{

--- a/posit-bakery/test/config/test_config.py
+++ b/posit-bakery/test/config/test_config.py
@@ -486,6 +486,102 @@ class TestBakeryConfig:
             with pytest.raises(ValueError, match="[Cc]onfli"):
                 BakeryConfig(bakery_yaml, settings=settings)
 
+        class TestApplyDevSpecReleaseBranch:
+            """release_branch is set from YYYY.MM when version is set, or directly from spec."""
+
+            def _make_image(self, tmp_path):
+                """Return a minimal Image with one workbench daily dev version."""
+                from posit_bakery.config.config import BakeryConfigDocument
+
+                bakery_yaml = tmp_path / "bakery.yaml"
+                bakery_yaml.write_text(
+                    "repository:\n"
+                    "  url: https://github.com/posit-dev/test\n"
+                    "images:\n"
+                    "  - name: test-image\n"
+                    "    devVersions:\n"
+                    "      - sourceType: stream\n"
+                    "        product: workbench\n"
+                    "        channel: daily\n"
+                    "        os:\n"
+                    "          - name: Ubuntu 24.04\n"
+                    "            primary: true\n"
+                )
+                doc = BakeryConfigDocument(
+                    base_path=tmp_path,
+                    **{
+                        "repository": {"url": "https://github.com/posit-dev/test"},
+                        "images": [
+                            {
+                                "name": "test-image",
+                                "devVersions": [
+                                    {
+                                        "sourceType": "stream",
+                                        "product": "workbench",
+                                        "channel": "daily",
+                                        "os": [{"name": "Ubuntu 24.04", "primary": True}],
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                )
+                return doc.images[0]
+
+            def test_version_sets_calver_release_branch(self, tmp_path):
+                """version in DevBuildSpec pins version and derives YYYY.MM release_branch."""
+                from posit_bakery.config.config import _apply_dev_spec
+                from posit_bakery.config.image.dev_version.spec import DevBuildSpec
+
+                image = self._make_image(tmp_path)
+                spec = DevBuildSpec(version="2026.06.0-daily+143-gABC")
+                settings = BakerySettings(
+                    dev_versions=DevVersionInclusionEnum.ONLY,
+                    dev_spec=spec,
+                )
+                _apply_dev_spec(image, settings)
+                dv = image.devVersions[0]
+                assert dv.pinned_version == "2026.06.0-daily+143-gABC"
+                assert dv.release_branch == "2026.06"
+
+            def test_release_branch_only_sets_branch(self, tmp_path):
+                """release_branch in DevBuildSpec sets release_branch directly; pinned_version stays None."""
+                from posit_bakery.config.config import _apply_dev_spec
+                from posit_bakery.config.image.dev_version.spec import DevBuildSpec
+
+                image = self._make_image(tmp_path)
+                spec = DevBuildSpec(release_branch="apple-blossom")
+                settings = BakerySettings(
+                    dev_versions=DevVersionInclusionEnum.ONLY,
+                    dev_spec=spec,
+                )
+                _apply_dev_spec(image, settings)
+                dv = image.devVersions[0]
+                assert dv.pinned_version is None
+                assert dv.release_branch == "apple-blossom"
+
+            def test_version_takes_precedence_over_release_branch(self, tmp_path):
+                """When both are set, version wins; release_branch is YYYY.MM, not spec.release_branch."""
+                from posit_bakery.config.config import _apply_dev_spec
+                from posit_bakery.config.image.dev_version.spec import DevBuildSpec
+
+                image = self._make_image(tmp_path)
+                spec = DevBuildSpec(version="2026.06.0-daily+143-gABC", release_branch="apple-blossom")
+                settings = BakerySettings(
+                    dev_versions=DevVersionInclusionEnum.ONLY,
+                    dev_spec=spec,
+                )
+                _apply_dev_spec(image, settings)
+                dv = image.devVersions[0]
+                assert dv.pinned_version == "2026.06.0-daily+143-gABC"
+                assert dv.release_branch == "2026.06"
+
+            def test_extract_calver_minor_rejects_trailing_garbage(self):
+                from posit_bakery.config.config import _extract_calver_minor
+
+                with pytest.raises(ValueError, match="not a valid CalVer"):
+                    _extract_calver_minor("2026.06.0-daily+143 trailing garbage")
+
     @pytest.mark.parametrize(
         "include_matrix_versions,expected_uids",
         [

--- a/posit-bakery/test/config/test_config.py
+++ b/posit-bakery/test/config/test_config.py
@@ -1395,7 +1395,7 @@ class TestBakeryConfig:
 
             # Install R
             RUN RUN_UNATTENDED=1 R_VERSION=4.5.1 bash -c "$(curl -fsSL https://rstd.io/r-install)" && \\
-                find . -type f -name '[rR]-4.5.1.*\.(deb|rpm)' -delete
+                find . -type f -name '[rR]-4.5.1.*\\.(deb|rpm)' -delete
 
             # Install Quarto
             RUN --mount=type=secret,id=github_token,required=false bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \\

--- a/posit-bakery/test/image/test_image_target.py
+++ b/posit-bakery/test/image/test_image_target.py
@@ -337,9 +337,6 @@ class TestImageTarget:
         # Floating channel tags do not.
         assert not any("daily" in s for s in target.tag_suffixes)
 
-        # Pattern count drops from 12 to 8 when channel_latest is False.
-        assert len(target.tag_patterns) == 8
-
         del target.image_version.metadata["release_channel"]
         del target.image_version.metadata["channel_latest"]
 
@@ -351,7 +348,6 @@ class TestImageTarget:
 
         assert target.is_channel_latest is True
         assert any("daily" in s for s in target.tag_suffixes)
-        assert len(target.tag_patterns) == 12
 
         del target.image_version.metadata["release_channel"]
         del target.image_version.metadata["channel_latest"]

--- a/posit-bakery/test/image/test_image_target.py
+++ b/posit-bakery/test/image/test_image_target.py
@@ -319,6 +319,43 @@ class TestImageTarget:
         # Clean up
         del target.image_version.metadata["release_channel"]
 
+    def test_is_channel_latest_defaults_true(self, basic_standard_image_target):
+        """Targets without channel_latest metadata report True (safe default)."""
+        assert basic_standard_image_target.image_version.metadata.get("channel_latest") is None
+        assert basic_standard_image_target.is_channel_latest is True
+
+    def test_is_channel_latest_false_suppresses_channel_tags(self, basic_standard_image_target):
+        """Floating channel tags are suppressed when channel_latest is False."""
+        target = basic_standard_image_target
+        target.image_version.metadata["release_channel"] = ReleaseChannelEnum.DAILY
+        target.image_version.metadata["channel_latest"] = False
+
+        assert target.is_channel_latest is False
+
+        # Version-pinned tags still emit.
+        assert any("1.0.0" in s for s in target.tag_suffixes)
+        # Floating channel tags do not.
+        assert not any("daily" in s for s in target.tag_suffixes)
+
+        # Pattern count drops from 12 to 8 when channel_latest is False.
+        assert len(target.tag_patterns) == 8
+
+        del target.image_version.metadata["release_channel"]
+        del target.image_version.metadata["channel_latest"]
+
+    def test_is_channel_latest_true_emits_channel_tags(self, basic_standard_image_target):
+        """Floating channel tags emit when channel_latest is True."""
+        target = basic_standard_image_target
+        target.image_version.metadata["release_channel"] = ReleaseChannelEnum.DAILY
+        target.image_version.metadata["channel_latest"] = True
+
+        assert target.is_channel_latest is True
+        assert any("daily" in s for s in target.tag_suffixes)
+        assert len(target.tag_patterns) == 12
+
+        del target.image_version.metadata["release_channel"]
+        del target.image_version.metadata["channel_latest"]
+
     def test_tag_patterns_deduplication(self, get_config_obj):
         """Test the deduplicate_tag_patterns method of an ImageTarget."""
         basic_config_obj = get_config_obj("basic")


### PR DESCRIPTION
Adds a `release_branch` field to `ImageDevelopmentVersionFromProductChannel` so
the Workbench dailies branch can be configured directly in `bakery.yaml` instead
of relying on the `BAKERY_WORKBENCH_RELEASE_BRANCH` environment variable.

The field threads through all `get_product_artifact_by_channel()` call sites.
When a version is supplied via `--dev-spec`, the YYYY.MM segment is extracted
automatically and used as the release branch. When only `release_branch` is set
in the dev spec, it is assigned directly.

Also adds a `release-branch` input to `bakery-build-native.yml` so product repo
workflows can override the branch at dispatch time.