### PR TITLE
Run uv self update before Python install in build stage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,6 +192,7 @@ out/
 .claude/settings.local.json
 .claude/worktrees/
 .claude/plans/
+refs/
 
 # Claude playwright-cli files
 .playwright-cli/

--- a/posit-bakery/posit_bakery/config/templating/macros/python.j2
+++ b/posit-bakery/posit_bakery/config/templating/macros/python.j2
@@ -53,7 +53,7 @@ ENV UV_PYTHON_PREFERENCE=only-managed
 
 {{ prerun | trim }}
 {%- endif %}
-{{ run_uv_python_install(versions) }}
+RUN uv self update && uv python install {{ versions | join(' ') }}
 {{ run_normalize_uv_python_paths(versions) | indent(4) }}
 {%- endmacro %}
 

--- a/posit-bakery/test/config/templating/test_macros.py
+++ b/posit-bakery/test/config/templating/test_macros.py
@@ -1272,7 +1272,7 @@ class TestPythonMacros:
             ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
             ENV UV_PYTHON_INSTALL_DIR=/opt/python
             ENV UV_PYTHON_PREFERENCE=only-managed
-            RUN uv python install 3.12.11 3.11.9
+            RUN uv self update && uv python install 3.12.11 3.11.9
             RUN mv /opt/python/cpython-3.12.11-linux-*/ /opt/python/3.12.11 && \\
                 mv /opt/python/cpython-3.11.9-linux-*/ /opt/python/3.11.9
 
@@ -1295,7 +1295,7 @@ class TestPythonMacros:
             ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
             ENV UV_PYTHON_INSTALL_DIR=/opt/python
             ENV UV_PYTHON_PREFERENCE=only-managed
-            RUN uv python install 3.12.11 3.11.9
+            RUN uv self update && uv python install 3.12.11 3.11.9
             RUN mv /opt/python/cpython-3.12.11-linux-*/ /opt/python/3.12.11 && \\
                 mv /opt/python/cpython-3.11.9-linux-*/ /opt/python/3.11.9
 
@@ -1320,7 +1320,7 @@ class TestPythonMacros:
             ENV UV_PYTHON_PREFERENCE=only-managed
 
             ARG PYTHON_VERSION
-            RUN uv python install $PYTHON_VERSION
+            RUN uv self update && uv python install $PYTHON_VERSION
             RUN mv /opt/python/cpython-$PYTHON_VERSION-linux-*/ /opt/python/$PYTHON_VERSION
 
             """

--- a/posit-bakery/test/config/test_config.py
+++ b/posit-bakery/test/config/test_config.py
@@ -1268,7 +1268,7 @@ class TestBakeryConfig:
             ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
             ENV UV_PYTHON_INSTALL_DIR=/opt/python
             ENV UV_PYTHON_PREFERENCE=only-managed
-            RUN uv python install 3.13.7
+            RUN uv self update && uv python install 3.13.7
             RUN mv /opt/python/cpython-3.13.7-linux-*/ /opt/python/3.13.7
 
 

--- a/posit-bakery/test/resources/matrix/test-matrix/matrix/Containerfile.ubuntu2404
+++ b/posit-bakery/test/resources/matrix/test-matrix/matrix/Containerfile.ubuntu2404
@@ -6,7 +6,7 @@ ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
 
 ARG PYTHON_VERSION
-RUN uv python install $PYTHON_VERSION
+RUN uv self update && uv python install $PYTHON_VERSION
 RUN mv /opt/python/cpython-$PYTHON_VERSION-linux-*/ /opt/python/$PYTHON_VERSION
 
 

--- a/posit-bakery/test/resources/with-macros/test-image/1.0.0/Containerfile.ubuntu2204.std
+++ b/posit-bakery/test/resources/with-macros/test-image/1.0.0/Containerfile.ubuntu2204.std
@@ -4,7 +4,7 @@ FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
-RUN uv python install 3.13.7
+RUN uv self update && uv python install 3.13.7
 RUN mv /opt/python/cpython-3.13.7-linux-*/ /opt/python/3.13.7
 
 


### PR DESCRIPTION
Adds `uv self update` before `uv python install` in the Python build-stage macro so the build always uses the latest uv when installing Python, rather than whatever version ships in the base image.

Updates tests and rendered test fixtures to match. Also gitignores `refs/`.