### PR TITLE
fix(ci): absorb GHCR eventual consistency in publish path

### DIFF
--- a/posit-bakery/posit_bakery/cli/ci.py
+++ b/posit-bakery/posit_bakery/cli/ci.py
@@ -294,6 +294,7 @@ def publish(
     """
     # Imports kept local to mirror existing patterns and to avoid bloating
     # module load time when this command isn't invoked.
+    from posit_bakery.error import BakeryToolRuntimeError
     from posit_bakery.plugins.builtin.oras.oras import (
         OrasIndexCopyWorkflow,
         OrasIndexCreateWorkflow,
@@ -365,10 +366,17 @@ def publish(
     all_sources = sorted({s for t in targets for s in t.get_merge_sources()})
     if all_sources:
         log.info(f"Waiting for {len(all_sources)} source digest(s) to be readable before publishing.")
-        wait = OrasWaitForSourcesWorkflow(
-            oras_bin=oras_bin,
-            sources=all_sources,
-        ).run(dry_run=dry_run)
+        try:
+            wait = OrasWaitForSourcesWorkflow(
+                oras_bin=oras_bin,
+                sources=all_sources,
+            ).run(dry_run=dry_run)
+        except BakeryToolRuntimeError as e:
+            # A non-transient registry error (auth, bad reference, ...) while
+            # probing sources is fatal and won't self-heal — surface it cleanly
+            # rather than letting it escape as an unhandled traceback.
+            log.error(f"Failed while waiting for source digests: {e.dump_stderr() or e}")
+            raise typer.Exit(code=1)
         if not wait.success:
             log.error(f"Source digests not available: {wait.error}")
             raise typer.Exit(code=1)

--- a/posit-bakery/posit_bakery/cli/ci.py
+++ b/posit-bakery/posit_bakery/cli/ci.py
@@ -298,6 +298,7 @@ def publish(
         OrasIndexCopyWorkflow,
         OrasIndexCreateWorkflow,
         OrasIndexVerifyWorkflow,
+        OrasWaitForSourcesWorkflow,
         find_oras_bin,
     )
     from posit_bakery.plugins.registry import get_plugin
@@ -354,6 +355,25 @@ def publish(
         (t for uid in loaded_targets if (t := config.get_image_target_by_uid(uid)) is not None),
         key=lambda t: t.push_sort_key,
     )
+
+    # Pre-flight: wait for every per-platform source digest to be readable
+    # before we touch them. Those manifests are pushed by digest from separate
+    # build runners, and registries with read-after-write (eventual
+    # consistency) behaviour — notably GHCR — can briefly 404 them. Polling
+    # here turns propagation lag into condition-based waiting and logs exactly
+    # which digest lagged, rather than failing a downstream phase opaquely.
+    all_sources = sorted({s for t in targets for s in t.get_merge_sources()})
+    if all_sources:
+        log.info(f"Waiting for {len(all_sources)} source digest(s) to be readable before publishing.")
+        wait = OrasWaitForSourcesWorkflow(
+            oras_bin=oras_bin,
+            sources=all_sources,
+        ).run(dry_run=dry_run)
+        if not wait.success:
+            log.error(f"Source digests not available: {wait.error}")
+            raise typer.Exit(code=1)
+        if wait.ready:
+            log.info(f"All {len(wait.ready)} source digest(s) readable after {wait.waited_seconds:.0f}s.")
 
     # Phase 1: index create. Failures abort.
     temp_refs: dict[str, str] = {}

--- a/posit-bakery/posit_bakery/plugins/builtin/oras/oras.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/oras/oras.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from posit_bakery.error import BakeryToolRuntimeError
 from posit_bakery.image.image_target import ImageTarget, Tag
-from posit_bakery.retry import RetryPolicy, retry_on_transient
+from posit_bakery.retry import RetryPolicy, is_transient_error, retry_on_transient
 from posit_bakery.util import find_bin
 
 log = logging.getLogger(__name__)
@@ -366,8 +366,10 @@ class OrasWaitForSourcesWorkflow(BaseModel):
                 plain_http=self.plain_http,
             ).run(dry_run=False)
             return True
-        except BakeryToolRuntimeError:
-            return False
+        except BakeryToolRuntimeError as e:
+            if is_transient_error(e):
+                return False
+            raise
 
     def run(
         self,

--- a/posit-bakery/posit_bakery/plugins/builtin/oras/oras.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/oras/oras.py
@@ -2,14 +2,16 @@ import hashlib
 import itertools
 import logging
 import subprocess
+import time
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Annotated, Self
+from typing import Annotated, Callable, Self
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from posit_bakery.error import BakeryToolRuntimeError
 from posit_bakery.image.image_target import ImageTarget, Tag
+from posit_bakery.retry import RetryPolicy, retry_on_transient
 from posit_bakery.util import find_bin
 
 log = logging.getLogger(__name__)
@@ -200,6 +202,7 @@ class OrasIndexCreateWorkflow(BaseModel):
     image_target: Annotated[ImageTarget, Field(description="Target this index represents.")]
     annotations: Annotated[dict[str, str], Field(default_factory=dict)]
     plain_http: Annotated[bool, Field(default=False)]
+    retry_policy: Annotated[RetryPolicy, Field(default_factory=RetryPolicy)]
 
     @property
     def temp_index_tag(self) -> str:
@@ -209,14 +212,22 @@ class OrasIndexCreateWorkflow(BaseModel):
         )
 
     def run(self, dry_run: bool = False) -> OrasIndexCreateResult:
+        # Retry transient registry errors: the per-platform source manifests
+        # are pushed by digest from separate runners and may not yet be
+        # readable here due to registry eventual consistency.
+        cmd = OrasManifestIndexCreate(
+            oras_bin=self.oras_bin,
+            sources=self.image_target.get_merge_sources(),
+            destination=self.temp_index_tag,
+            annotations=self.annotations,
+            plain_http=self.plain_http,
+        )
         try:
-            OrasManifestIndexCreate(
-                oras_bin=self.oras_bin,
-                sources=self.image_target.get_merge_sources(),
-                destination=self.temp_index_tag,
-                annotations=self.annotations,
-                plain_http=self.plain_http,
-            ).run(dry_run=dry_run)
+            retry_on_transient(
+                lambda: cmd.run(dry_run=dry_run),
+                policy=self.retry_policy,
+                description=f"index-create for '{self.image_target.uid}'",
+            )
             return OrasIndexCreateResult(success=True, temp_ref=self.temp_index_tag)
         except BakeryToolRuntimeError as e:
             log.error(f"oras index-create failed: {e}")
@@ -239,18 +250,26 @@ class OrasIndexCopyWorkflow(BaseModel):
     oras_bin: Annotated[str, Field(description="Path to the oras binary.")]
     image_target: Annotated[ImageTarget, Field(description="Target whose tags to fan out to.")]
     plain_http: Annotated[bool, Field(default=False)]
+    retry_policy: Annotated[RetryPolicy, Field(default_factory=RetryPolicy)]
 
     def run(self, source: str, dry_run: bool = False) -> OrasIndexCopyResult:
         try:
             destinations = []
             for destination, tags in itertools.groupby(self.image_target.tags, lambda x: x.destination):
                 combined = destination + ":" + ",".join(t.suffix for t in tags)
-                OrasCopy(
+                copy = OrasCopy(
                     oras_bin=self.oras_bin,
                     source=source,
                     destination=combined,
                     plain_http=self.plain_http,
-                ).run(dry_run=dry_run)
+                )
+                # Retry transient registry errors: the temp-registry source
+                # index may still be propagating when the copy first reads it.
+                retry_on_transient(
+                    lambda c=copy: c.run(dry_run=dry_run),
+                    policy=self.retry_policy,
+                    description=f"index-copy for '{self.image_target.uid}' -> {combined}",
+                )
                 destinations.append(combined)
             return OrasIndexCopyResult(success=True, destinations=destinations)
         except BakeryToolRuntimeError as e:
@@ -301,6 +320,106 @@ class OrasIndexVerifyWorkflow(BaseModel):
         except BakeryToolRuntimeError as e:
             log.error(f"oras manifest verify failed: {e}")
             return OrasIndexVerifyResult(success=False, verified=verified, error=str(e))
+
+
+class OrasSourcesReadyResult(BaseModel):
+    """Result of a pre-flight source-digest availability wait."""
+
+    success: Annotated[bool, Field(description="Whether every source digest became readable before the timeout.")]
+    ready: Annotated[
+        list[str], Field(default_factory=list, description="Source refs confirmed readable, in resolution order.")
+    ]
+    missing: Annotated[
+        list[str], Field(default_factory=list, description="Source refs still unreadable when the wait gave up.")
+    ]
+    waited_seconds: Annotated[float, Field(default=0.0, description="Wall-clock seconds spent waiting.")]
+    error: Annotated[str | None, Field(default=None, description="Diagnostic message on timeout.")]
+
+
+class OrasWaitForSourcesWorkflow(BaseModel):
+    """Poll source digests until they are all readable from the registry.
+
+    Per-platform manifests are pushed *by digest* from separate build runners,
+    and registries with read-after-write (eventual consistency) behaviour —
+    notably GHCR — may briefly 404 those digests when the publish runner first
+    asks for them. This pre-flight turns "hope it has propagated" into
+    condition-based waiting: each source is probed with ``oras manifest fetch
+    --descriptor`` (a lightweight existence check) and removed from the pending
+    set once it resolves. The wait succeeds as soon as every source resolves,
+    and fails (logging exactly which digests lagged) once ``timeout`` elapses.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    oras_bin: Annotated[str, Field(description="Path to the oras binary.")]
+    sources: Annotated[list[str], Field(description="Source refs (registry refs, typically by-digest) to await.")]
+    timeout: Annotated[float, Field(default=600.0, description="Maximum seconds to wait for all sources (10 min).")]
+    poll_interval: Annotated[float, Field(default=5.0, description="Seconds between polling sweeps.")]
+    plain_http: Annotated[bool, Field(default=False)]
+
+    def _is_available(self, ref: str) -> bool:
+        try:
+            OrasManifestFetch(
+                oras_bin=self.oras_bin,
+                reference=ref,
+                descriptor=True,
+                plain_http=self.plain_http,
+            ).run(dry_run=False)
+            return True
+        except BakeryToolRuntimeError:
+            return False
+
+    def run(
+        self,
+        dry_run: bool = False,
+        *,
+        sleep: Callable[[float], None] = time.sleep,
+        now: Callable[[], float] = time.monotonic,
+    ) -> OrasSourcesReadyResult:
+        """Probe each source until all resolve or ``timeout`` elapses.
+
+        :param dry_run: When True, report success without contacting the
+            registry (nothing has been pushed to wait on).
+        :param sleep: Sleep function, injectable for testing.
+        :param now: Monotonic clock, injectable for testing.
+        """
+        unique_sources = list(dict.fromkeys(self.sources))
+        if dry_run or not unique_sources:
+            return OrasSourcesReadyResult(success=True, ready=unique_sources)
+
+        start = now()
+        ready: list[str] = []
+        pending = list(unique_sources)
+        while True:
+            still_pending: list[str] = []
+            for ref in pending:
+                if self._is_available(ref):
+                    ready.append(ref)
+                else:
+                    still_pending.append(ref)
+            pending = still_pending
+
+            if not pending:
+                return OrasSourcesReadyResult(success=True, ready=ready, waited_seconds=now() - start)
+
+            elapsed = now() - start
+            if elapsed >= self.timeout:
+                return OrasSourcesReadyResult(
+                    success=False,
+                    ready=ready,
+                    missing=pending,
+                    waited_seconds=elapsed,
+                    error=(
+                        f"{len(pending)} source digest(s) still unreadable after {elapsed:.0f}s "
+                        f"(timeout {self.timeout:.0f}s): {', '.join(pending)}"
+                    ),
+                )
+
+            log.info(
+                f"Waiting on {len(pending)} source digest(s) to become readable "
+                f"({elapsed:.0f}s/{self.timeout:.0f}s elapsed); retrying in {self.poll_interval:.0f}s."
+            )
+            sleep(self.poll_interval)
 
 
 class OrasMergeWorkflowResult(BaseModel):

--- a/posit-bakery/posit_bakery/plugins/builtin/soci/soci.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/soci/soci.py
@@ -15,6 +15,7 @@ from posit_bakery.error import BakeryToolRuntimeError
 from posit_bakery.image.image_target import ImageTarget
 from posit_bakery.plugins.builtin.oras.oras import OrasCopy
 from posit_bakery.plugins.builtin.soci.options import SociOptions
+from posit_bakery.retry import RetryPolicy, retry_on_transient
 from posit_bakery.util import find_bin
 
 log = logging.getLogger(__name__)
@@ -134,6 +135,7 @@ class SociConvertWorkflow(BaseModel):
     image_target: Annotated[ImageTarget, Field(description="The image target.")]
     options: Annotated[SociOptions, Field(description="Per-target SOCI configuration.")]
     source_ref: Annotated[str, Field(description="Temp-registry ref to convert from.")]
+    retry_policy: Annotated[RetryPolicy, Field(default_factory=RetryPolicy)]
 
     @property
     def destination_ref(self) -> str:
@@ -183,13 +185,20 @@ class SociConvertWorkflow(BaseModel):
         out_layout = scratch / "out"
         try:
             # 1. registry -> OCI layout. The layout tag is arbitrary; soci
-            #    reads the whole layout.
-            OrasCopy(
+            #    reads the whole layout. Retry transient registry errors: the
+            #    temp-registry index/children may still be propagating when
+            #    this pull first reads them (registry eventual consistency).
+            pull = OrasCopy(
                 oras_bin=self.oras_bin,
                 source=self.source_ref,
                 destination=f"{src_layout}:image",
                 to_oci_layout=True,
-            ).run(dry_run=dry_run)
+            )
+            retry_on_transient(
+                lambda: pull.run(dry_run=dry_run),
+                policy=self.retry_policy,
+                description=f"soci pull for '{self.image_target.uid}'",
+            )
 
             # 2. convert local layout -> local layout (directory so we can read
             #    the resulting index.json for its digest).

--- a/posit-bakery/posit_bakery/retry.py
+++ b/posit-bakery/posit_bakery/retry.py
@@ -1,0 +1,159 @@
+"""Retry-with-backoff helpers for transient registry errors.
+
+Registry-touching operations (oras manifest index create, oras cp, oras
+manifest fetch, the SOCI pull/push) intermittently fail against registries
+that exhibit read-after-write (eventual consistency) behaviour — most visibly
+GHCR, where a manifest pushed *by digest* from one runner is briefly
+unreadable by digest from another. The failure is transient: the manifest is
+durably present, just not yet replicated when first requested.
+
+:func:`retry_on_transient` wraps a registry call so that *transient* failures
+(``not found`` / ``manifest unknown`` / 5xx / timeouts / rate limits) are
+retried a handful of times with exponential backoff, while non-transient
+failures still fail fast. Counts and timings are configurable via the
+``BAKERY_REGISTRY_RETRY_*`` environment variables.
+"""
+
+import logging
+import os
+import re
+import time
+from typing import Annotated, Callable, TypeVar
+
+from pydantic import BaseModel, Field
+
+from posit_bakery.error import BakeryToolRuntimeError
+
+log = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+# Substrings/patterns (matched case-insensitively against the failed command's
+# message + stdout + stderr) that mark an error as transient and worth
+# retrying. Anything not matched here fails fast — a genuine bad reference,
+# auth failure, or malformed manifest should not be retried.
+_TRANSIENT_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(p, re.IGNORECASE)
+    for p in (
+        r"not found",
+        r"manifest unknown",
+        r"blob unknown",
+        r"name unknown",
+        r"\b5\d\d\b",  # 5xx HTTP status codes
+        r"\b429\b",  # too many requests
+        r"too many requests",
+        r"temporarily unavailable",
+        r"timeout",
+        r"timed out",
+        r"i/o timeout",
+        r"connection reset",
+        r"connection refused",
+        r"\beof\b",
+    )
+)
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        log.warning(f"Ignoring invalid {name}={raw!r}; using default {default}.")
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        log.warning(f"Ignoring invalid {name}={raw!r}; using default {default}.")
+        return default
+
+
+class RetryPolicy(BaseModel):
+    """Exponential-backoff retry configuration.
+
+    Defaults are read from the environment at construction time so CI can tune
+    them without code changes:
+
+    - ``BAKERY_REGISTRY_RETRY_ATTEMPTS`` (default 5)
+    - ``BAKERY_REGISTRY_RETRY_INITIAL_BACKOFF`` seconds (default 2.0)
+    - ``BAKERY_REGISTRY_RETRY_MAX_BACKOFF`` seconds (default 32.0)
+    - ``BAKERY_REGISTRY_RETRY_MULTIPLIER`` (default 2.0)
+    """
+
+    max_attempts: Annotated[int, Field(default_factory=lambda: _env_int("BAKERY_REGISTRY_RETRY_ATTEMPTS", 5), ge=1)]
+    initial_backoff: Annotated[
+        float, Field(default_factory=lambda: _env_float("BAKERY_REGISTRY_RETRY_INITIAL_BACKOFF", 2.0), ge=0)
+    ]
+    max_backoff: Annotated[
+        float, Field(default_factory=lambda: _env_float("BAKERY_REGISTRY_RETRY_MAX_BACKOFF", 32.0), ge=0)
+    ]
+    multiplier: Annotated[
+        float, Field(default_factory=lambda: _env_float("BAKERY_REGISTRY_RETRY_MULTIPLIER", 2.0), ge=1)
+    ]
+
+
+def is_transient_error(error: BakeryToolRuntimeError) -> bool:
+    """Return True if ``error`` looks like a transient registry error.
+
+    The decision is text-based: the error's message plus a generous slice of
+    its stdout/stderr are scanned for any known transient signature.
+    """
+    parts = [
+        error.message or "",
+        error.dump_stdout(lines=50),
+        error.dump_stderr(lines=50),
+    ]
+    haystack = "\n".join(p for p in parts if p)
+    return any(pattern.search(haystack) for pattern in _TRANSIENT_PATTERNS)
+
+
+def retry_on_transient(
+    func: Callable[[], T],
+    *,
+    policy: RetryPolicy | None = None,
+    description: str = "registry operation",
+) -> T:
+    """Call ``func`` retrying transient :class:`BakeryToolRuntimeError`s.
+
+    On a transient failure the call is retried up to ``policy.max_attempts``
+    times with exponential backoff (``initial_backoff`` growing by
+    ``multiplier``, capped at ``max_backoff``). Non-transient errors and the
+    final transient error are re-raised unchanged.
+
+    :param func: Zero-argument callable performing the registry operation.
+    :param policy: Retry configuration; a default (env-tunable) policy is used
+        when omitted.
+    :param description: Human-readable label for log messages.
+    :return: Whatever ``func`` returns on success.
+    :raises BakeryToolRuntimeError: The last error if all attempts fail or the
+        first non-transient error encountered.
+    """
+    policy = policy or RetryPolicy()
+    backoff = policy.initial_backoff
+    for attempt in range(1, policy.max_attempts + 1):
+        try:
+            return func()
+        except BakeryToolRuntimeError as e:
+            if not is_transient_error(e):
+                raise
+            if attempt >= policy.max_attempts:
+                log.error(
+                    f"{description} failed after {attempt} attempt(s); giving up. Last error: {e.dump_stderr() or e}"
+                )
+                raise
+            log.warning(
+                f"{description} hit a transient registry error "
+                f"(attempt {attempt}/{policy.max_attempts}); retrying in {backoff:.1f}s. "
+                f"Error: {e.dump_stderr() or e}"
+            )
+            time.sleep(backoff)
+            backoff = min(backoff * policy.multiplier, policy.max_backoff)
+    # Unreachable: the loop either returns or raises on the final attempt.
+    raise AssertionError("retry_on_transient exhausted its loop without returning or raising")

--- a/posit-bakery/posit_bakery/retry.py
+++ b/posit-bakery/posit_bakery/retry.py
@@ -53,26 +53,34 @@ _TRANSIENT_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
 )
 
 
-def _env_int(name: str, default: int) -> int:
+def _env_int(name: str, default: int, min_value: int = 0) -> int:
     raw = os.environ.get(name)
     if raw is None or raw.strip() == "":
         return default
     try:
-        return int(raw)
+        value = int(raw)
     except ValueError:
         log.warning(f"Ignoring invalid {name}={raw!r}; using default {default}.")
         return default
+    if value < min_value:
+        log.warning(f"Ignoring {name}={raw!r}; using default {default}.")
+        return default
+    return value
 
 
-def _env_float(name: str, default: float) -> float:
+def _env_float(name: str, default: float, min_value: float = 0.0) -> float:
     raw = os.environ.get(name)
     if raw is None or raw.strip() == "":
         return default
     try:
-        return float(raw)
+        value = float(raw)
     except ValueError:
         log.warning(f"Ignoring invalid {name}={raw!r}; using default {default}.")
         return default
+    if value < min_value:
+        log.warning(f"Ignoring {name}={raw!r}; using default {default}.")
+        return default
+    return value
 
 
 class RetryPolicy(BaseModel):
@@ -87,15 +95,15 @@ class RetryPolicy(BaseModel):
     - ``BAKERY_REGISTRY_RETRY_MULTIPLIER`` (default 2.0)
     """
 
-    max_attempts: Annotated[int, Field(default_factory=lambda: _env_int("BAKERY_REGISTRY_RETRY_ATTEMPTS", 5), ge=1)]
+    max_attempts: Annotated[int, Field(default_factory=lambda: _env_int("BAKERY_REGISTRY_RETRY_ATTEMPTS", 5, 1), ge=1)]
     initial_backoff: Annotated[
-        float, Field(default_factory=lambda: _env_float("BAKERY_REGISTRY_RETRY_INITIAL_BACKOFF", 2.0), ge=0)
+        float, Field(default_factory=lambda: _env_float("BAKERY_REGISTRY_RETRY_INITIAL_BACKOFF", 2.0, 0), ge=0)
     ]
     max_backoff: Annotated[
-        float, Field(default_factory=lambda: _env_float("BAKERY_REGISTRY_RETRY_MAX_BACKOFF", 32.0), ge=0)
+        float, Field(default_factory=lambda: _env_float("BAKERY_REGISTRY_RETRY_MAX_BACKOFF", 32.0, 0), ge=0)
     ]
     multiplier: Annotated[
-        float, Field(default_factory=lambda: _env_float("BAKERY_REGISTRY_RETRY_MULTIPLIER", 2.0), ge=1)
+        float, Field(default_factory=lambda: _env_float("BAKERY_REGISTRY_RETRY_MULTIPLIER", 2.0, 1), ge=1)
     ]
 
 

--- a/posit-bakery/test/cli/test_ci.py
+++ b/posit-bakery/test/cli/test_ci.py
@@ -79,7 +79,24 @@ def patch_image_target_merge_method(mocker):
             result.verified = self.image_target.tags.as_strings()
             return result
 
+    class MockOrasWaitForSourcesWorkflow:
+        def __init__(self, oras_bin, sources, **kwargs):
+            self.oras_bin = oras_bin
+            self.sources = sources
+
+        def run(self, dry_run=False, **kwargs):
+            result = MagicMock()
+            result.success = True
+            result.ready = list(self.sources)
+            result.missing = []
+            result.waited_seconds = 0.0
+            return result
+
     # Patch the imports inside the publish function
+    mocker.patch(
+        "posit_bakery.plugins.builtin.oras.oras.OrasWaitForSourcesWorkflow",
+        MockOrasWaitForSourcesWorkflow,
+    )
     mocker.patch(
         "posit_bakery.plugins.builtin.oras.oras.OrasIndexCreateWorkflow",
         MockOrasIndexCreateWorkflow,

--- a/posit-bakery/test/cli/test_ci_publish.py
+++ b/posit-bakery/test/cli/test_ci_publish.py
@@ -165,3 +165,43 @@ def test_publish_aborts_when_sources_never_ready(tmp_path):
     assert result.exit_code == 1
     # Aborted before SOCI convert.
     fake_soci.execute.assert_not_called()
+
+
+def test_publish_surfaces_clean_error_on_non_transient_wait_failure(tmp_path):
+    """A non-transient registry error during the wait exits cleanly (code 1)
+    rather than escaping as an unhandled traceback."""
+    from posit_bakery.error import BakeryToolRuntimeError
+
+    sources = ["ghcr.io/posit-dev/test/tmp@sha256:amd64"]
+    target = _fake_target("uid1", merge_sources=sources)
+    target.settings.temp_registry = "ghcr.io/posit-dev"
+
+    fake_config = MagicMock()
+    fake_config.base_path = tmp_path
+    fake_config.load_build_metadata_from_file.return_value = ["uid1"]
+    fake_config.get_image_target_by_uid.return_value = target
+
+    fake_wait_instance = MagicMock()
+    fake_wait_instance.run.side_effect = BakeryToolRuntimeError(
+        message="oras command failed",
+        tool_name="oras",
+        cmd=["oras", "manifest", "fetch"],
+        stdout=b"",
+        stderr=b"unauthorized: authentication required",
+    )
+
+    fake_soci = MagicMock()
+
+    runner = CliRunner()
+    with (
+        patch("posit_bakery.cli.ci.BakeryConfig.from_context", return_value=fake_config),
+        patch("posit_bakery.plugins.builtin.oras.oras.find_oras_bin", return_value="oras"),
+        patch("posit_bakery.plugins.builtin.oras.oras.OrasWaitForSourcesWorkflow", return_value=fake_wait_instance),
+        patch("posit_bakery.plugins.registry.get_plugin", return_value=fake_soci),
+    ):
+        result = runner.invoke(app, ["ci", "publish", "meta.json"], env=_WIDE_TERM_ENV)
+
+    # Clean exit, not an unhandled exception.
+    assert result.exit_code == 1
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+    fake_soci.execute.assert_not_called()

--- a/posit-bakery/test/cli/test_ci_publish.py
+++ b/posit-bakery/test/cli/test_ci_publish.py
@@ -33,11 +33,13 @@ def test_publish_command_flags_present():
     assert "--enable-soci" not in result.stdout
 
 
-def _fake_target(uid: str):
+def _fake_target(uid: str, merge_sources: list[str] | None = None):
     t = MagicMock()
     t.uid = uid
     t.push_sort_key = 0
-    t.get_merge_sources.return_value = []  # skip phase 1 (index-create)
+    # Default: no merge sources, which skips phase 1 (index-create) and the
+    # pre-flight source wait.
+    t.get_merge_sources.return_value = merge_sources or []
     return t
 
 
@@ -74,3 +76,92 @@ def test_publish_invokes_soci_execute_without_mode(tmp_path):
     assert captured["called"] is True
     # No mode/standalone selector is threaded through anymore.
     assert "standalone" not in captured["kwargs"]
+
+
+def test_publish_waits_for_sources_then_proceeds(tmp_path):
+    """The pre-flight wait is invoked with the targets' merge-source digests."""
+    sources = [
+        "ghcr.io/posit-dev/test/tmp@sha256:amd64",
+        "ghcr.io/posit-dev/test/tmp@sha256:arm64",
+    ]
+    target = _fake_target("uid1", merge_sources=sources)
+    target.settings.temp_registry = "ghcr.io/posit-dev"
+
+    fake_config = MagicMock()
+    fake_config.base_path = tmp_path
+    fake_config.load_build_metadata_from_file.return_value = ["uid1"]
+    fake_config.get_image_target_by_uid.return_value = target
+
+    captured = {}
+
+    fake_wait_instance = MagicMock()
+    fake_wait_instance.run.return_value = MagicMock(success=True, ready=sources, missing=[], waited_seconds=3.0)
+
+    def fake_wait_ctor(**kwargs):
+        captured["wait_kwargs"] = kwargs
+        return fake_wait_instance
+
+    fake_soci = MagicMock()
+    fake_soci.execute.return_value = []
+
+    # Make the downstream phases succeed so we exercise the path past the wait.
+    fake_create_result = MagicMock(success=True, temp_ref="ghcr.io/posit-dev/test/tmp:created")
+    fake_copy_result = MagicMock(success=True, destinations=["ghcr.io/posit-dev/test:1.0.0"], error=None)
+    fake_verify_result = MagicMock(success=True, verified=["ghcr.io/posit-dev/test:1.0.0"], error=None)
+
+    runner = CliRunner()
+    with (
+        patch("posit_bakery.cli.ci.BakeryConfig.from_context", return_value=fake_config),
+        patch("posit_bakery.plugins.builtin.oras.oras.find_oras_bin", return_value="oras"),
+        patch("posit_bakery.plugins.builtin.oras.oras.OrasWaitForSourcesWorkflow", side_effect=fake_wait_ctor),
+        patch(
+            "posit_bakery.plugins.builtin.oras.oras.OrasIndexCreateWorkflow",
+            return_value=MagicMock(run=MagicMock(return_value=fake_create_result)),
+        ),
+        patch(
+            "posit_bakery.plugins.builtin.oras.oras.OrasIndexCopyWorkflow",
+            return_value=MagicMock(run=MagicMock(return_value=fake_copy_result)),
+        ),
+        patch(
+            "posit_bakery.plugins.builtin.oras.oras.OrasIndexVerifyWorkflow",
+            return_value=MagicMock(run=MagicMock(return_value=fake_verify_result)),
+        ),
+        patch("posit_bakery.plugins.registry.get_plugin", return_value=fake_soci),
+    ):
+        result = runner.invoke(app, ["ci", "publish", "meta.json"], env=_WIDE_TERM_ENV)
+
+    assert result.exit_code == 0, result.stdout
+    fake_wait_instance.run.assert_called_once()
+    assert sorted(captured["wait_kwargs"]["sources"]) == sorted(sources)
+
+
+def test_publish_aborts_when_sources_never_ready(tmp_path):
+    """A wait timeout aborts the publish before any phase runs."""
+    sources = ["ghcr.io/posit-dev/test/tmp@sha256:amd64"]
+    target = _fake_target("uid1", merge_sources=sources)
+    target.settings.temp_registry = "ghcr.io/posit-dev"
+
+    fake_config = MagicMock()
+    fake_config.base_path = tmp_path
+    fake_config.load_build_metadata_from_file.return_value = ["uid1"]
+    fake_config.get_image_target_by_uid.return_value = target
+
+    fake_wait_instance = MagicMock()
+    fake_wait_instance.run.return_value = MagicMock(
+        success=False, ready=[], missing=sources, waited_seconds=600.0, error="still unreadable"
+    )
+
+    fake_soci = MagicMock()
+
+    runner = CliRunner()
+    with (
+        patch("posit_bakery.cli.ci.BakeryConfig.from_context", return_value=fake_config),
+        patch("posit_bakery.plugins.builtin.oras.oras.find_oras_bin", return_value="oras"),
+        patch("posit_bakery.plugins.builtin.oras.oras.OrasWaitForSourcesWorkflow", return_value=fake_wait_instance),
+        patch("posit_bakery.plugins.registry.get_plugin", return_value=fake_soci),
+    ):
+        result = runner.invoke(app, ["ci", "publish", "meta.json"], env=_WIDE_TERM_ENV)
+
+    assert result.exit_code == 1
+    # Aborted before SOCI convert.
+    fake_soci.execute.assert_not_called()

--- a/posit-bakery/test/plugins/builtin/oras/test_oras.py
+++ b/posit-bakery/test/plugins/builtin/oras/test_oras.py
@@ -20,7 +20,9 @@ from posit_bakery.plugins.builtin.oras.oras import (
     OrasManifestIndexCreate,
     OrasMergeWorkflow,
     OrasMergeWorkflowResult,
+    OrasWaitForSourcesWorkflow,
 )
+from posit_bakery.retry import RetryPolicy
 
 pytestmark = [
     pytest.mark.unit,
@@ -789,3 +791,177 @@ class TestOrasMergeWorkflowIntegration:
 
         assert workflow.plain_http is True
         assert workflow.oras_bin == "oras"
+
+
+class TestOrasIndexCreateWorkflowRetry:
+    """The index-create primitive retries transient registry errors."""
+
+    @pytest.fixture
+    def workflow(self, mock_image_target_factory):
+        target = mock_image_target_factory()
+        return OrasIndexCreateWorkflow(
+            oras_bin="oras",
+            image_target=target,
+            annotations={"k": "v"},
+            retry_policy=RetryPolicy(max_attempts=5, initial_backoff=1.0),
+        )
+
+    def test_retries_transient_not_found_then_succeeds(self, workflow):
+        attempts = {"n": 0}
+
+        def side_effect(cmd, capture_output):
+            attempts["n"] += 1
+            if attempts["n"] < 3:
+                return subprocess.CompletedProcess(args=cmd, returncode=1, stdout=b"", stderr=b"sha256:abc: not found")
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=b"", stderr=b"")
+
+        with patch("subprocess.run", side_effect=side_effect), patch("posit_bakery.retry.time.sleep") as sleep:
+            result = workflow.run()
+
+        assert result.success is True
+        assert attempts["n"] == 3
+        assert sleep.call_count == 2
+
+    def test_non_transient_error_fails_without_retry(self, workflow):
+        with (
+            patch("subprocess.run") as mock_run,
+            patch("posit_bakery.retry.time.sleep") as sleep,
+        ):
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=1, stdout=b"", stderr=b"unauthorized: authentication required"
+            )
+            result = workflow.run()
+
+        assert result.success is False
+        assert mock_run.call_count == 1
+        sleep.assert_not_called()
+
+
+class TestOrasIndexCopyWorkflowRetry:
+    """The index-copy primitive retries transient registry errors."""
+
+    def test_retries_transient_then_succeeds(self, mock_image_target_factory):
+        target = mock_image_target_factory()
+        workflow = OrasIndexCopyWorkflow(
+            oras_bin="oras",
+            image_target=target,
+            retry_policy=RetryPolicy(max_attempts=5, initial_backoff=1.0),
+        )
+
+        attempts = {"n": 0}
+
+        def side_effect(cmd, capture_output):
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                return subprocess.CompletedProcess(args=cmd, returncode=1, stdout=b"", stderr=b"manifest unknown")
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=b"", stderr=b"")
+
+        with patch("subprocess.run", side_effect=side_effect), patch("posit_bakery.retry.time.sleep"):
+            result = workflow.run(source="ghcr.io/posit-dev/test-image/tmp:src")
+
+        assert result.success is True
+        # 1 failed + 1 retried success for the single destination.
+        assert attempts["n"] == 2
+
+
+class TestOrasWaitForSourcesWorkflow:
+    """Tests for the pre-flight source-digest availability wait."""
+
+    def _ok(self, cmd):
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=b"{}", stderr=b"")
+
+    def _missing(self, cmd):
+        return subprocess.CompletedProcess(args=cmd, returncode=1, stdout=b"", stderr=b"not found")
+
+    def test_all_sources_ready_first_sweep(self):
+        wf = OrasWaitForSourcesWorkflow(
+            oras_bin="oras",
+            sources=[
+                "ghcr.io/posit-dev/test/tmp@sha256:a",
+                "ghcr.io/posit-dev/test/tmp@sha256:b",
+            ],
+        )
+        sleep = MagicMock()
+        with patch("subprocess.run", side_effect=lambda cmd, capture_output: self._ok(cmd)):
+            result = wf.run(sleep=sleep, now=lambda: 0.0)
+
+        assert result.success is True
+        assert result.ready == [
+            "ghcr.io/posit-dev/test/tmp@sha256:a",
+            "ghcr.io/posit-dev/test/tmp@sha256:b",
+        ]
+        assert result.missing == []
+        sleep.assert_not_called()
+
+    def test_waits_until_source_appears(self):
+        wf = OrasWaitForSourcesWorkflow(
+            oras_bin="oras",
+            sources=["ghcr.io/posit-dev/test/tmp@sha256:a"],
+            poll_interval=5.0,
+            timeout=600.0,
+        )
+        # First sweep: missing. Second sweep: present.
+        responses = {"n": 0}
+
+        def side_effect(cmd, capture_output):
+            responses["n"] += 1
+            return self._missing(cmd) if responses["n"] == 1 else self._ok(cmd)
+
+        clock = {"t": 0.0}
+
+        def now():
+            return clock["t"]
+
+        def sleep(seconds):
+            clock["t"] += seconds
+
+        with patch("subprocess.run", side_effect=side_effect):
+            result = wf.run(sleep=sleep, now=now)
+
+        assert result.success is True
+        assert result.ready == ["ghcr.io/posit-dev/test/tmp@sha256:a"]
+        assert result.waited_seconds == 5.0
+
+    def test_times_out_and_reports_missing(self):
+        wf = OrasWaitForSourcesWorkflow(
+            oras_bin="oras",
+            sources=[
+                "ghcr.io/posit-dev/test/tmp@sha256:a",
+                "ghcr.io/posit-dev/test/tmp@sha256:b",
+            ],
+            poll_interval=5.0,
+            timeout=10.0,
+        )
+
+        # 'a' is always present; 'b' never appears.
+        def side_effect(cmd, capture_output):
+            ref = cmd[-1]
+            return self._ok(cmd) if ref.endswith("sha256:a") else self._missing(cmd)
+
+        clock = {"t": 0.0}
+
+        def sleep(seconds):
+            clock["t"] += seconds
+
+        with patch("subprocess.run", side_effect=side_effect):
+            result = wf.run(sleep=sleep, now=lambda: clock["t"])
+
+        assert result.success is False
+        assert result.ready == ["ghcr.io/posit-dev/test/tmp@sha256:a"]
+        assert result.missing == ["ghcr.io/posit-dev/test/tmp@sha256:b"]
+        assert "still unreadable" in result.error
+
+    def test_dry_run_skips_polling(self):
+        wf = OrasWaitForSourcesWorkflow(oras_bin="oras", sources=["ghcr.io/posit-dev/test/tmp@sha256:a"])
+        with patch("subprocess.run") as mock_run:
+            result = wf.run(dry_run=True)
+        mock_run.assert_not_called()
+        assert result.success is True
+
+    def test_no_sources_is_success(self):
+        wf = OrasWaitForSourcesWorkflow(oras_bin="oras", sources=[])
+        with patch("subprocess.run") as mock_run:
+            result = wf.run()
+        mock_run.assert_not_called()
+        assert result.success is True
+        assert result.ready == []

--- a/posit-bakery/test/plugins/builtin/oras/test_oras.py
+++ b/posit-bakery/test/plugins/builtin/oras/test_oras.py
@@ -951,6 +951,29 @@ class TestOrasWaitForSourcesWorkflow:
         assert result.missing == ["ghcr.io/posit-dev/test/tmp@sha256:b"]
         assert "still unreadable" in result.error
 
+    def test_non_transient_error_raises_immediately(self):
+        """A non-transient fetch error (e.g. auth) must not be polled on — it
+        raises right away instead of burning the full timeout."""
+        wf = OrasWaitForSourcesWorkflow(
+            oras_bin="oras",
+            sources=["ghcr.io/posit-dev/test/tmp@sha256:a"],
+            poll_interval=5.0,
+            timeout=600.0,
+        )
+        sleep = MagicMock()
+
+        def side_effect(cmd, capture_output):
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=1, stdout=b"", stderr=b"unauthorized: authentication required"
+            )
+
+        with patch("subprocess.run", side_effect=side_effect):
+            with pytest.raises(BakeryToolRuntimeError):
+                wf.run(sleep=sleep, now=lambda: 0.0)
+
+        # Failed fast: no backoff sleep, no waiting for the timeout.
+        sleep.assert_not_called()
+
     def test_dry_run_skips_polling(self):
         wf = OrasWaitForSourcesWorkflow(oras_bin="oras", sources=["ghcr.io/posit-dev/test/tmp@sha256:a"])
         with patch("subprocess.run") as mock_run:

--- a/posit-bakery/test/plugins/builtin/soci/test_workflow.py
+++ b/posit-bakery/test/plugins/builtin/soci/test_workflow.py
@@ -153,6 +153,41 @@ def test_cleans_up_scratch_dir_on_failure(workflow, tmp_path):
     assert not scratch.exists()
 
 
+def test_pull_retries_transient_then_succeeds(mock_target):
+    """A transient registry error on the SOCI pull is retried, not fatal."""
+    from posit_bakery.retry import RetryPolicy
+
+    workflow = SociConvertWorkflow(
+        soci_bin="soci",
+        oras_bin="oras",
+        image_target=mock_target,
+        options=SociOptions(enabled=True),
+        source_ref="ghcr.io/posit-dev/test-image/tmp:merged",
+        retry_policy=RetryPolicy(max_attempts=5, initial_backoff=1.0),
+    )
+
+    attempts = {"pull": 0}
+
+    def fake_run(cmd, capture_output):
+        # First oras cp is the registry -> layout pull; fail it transiently once.
+        if cmd[:2] == ["oras", "cp"] and "--to-oci-layout" in cmd:
+            attempts["pull"] += 1
+            if attempts["pull"] == 1:
+                return subprocess.CompletedProcess(args=cmd, returncode=1, stdout=b"", stderr=b"sha256:x: not found")
+        return _ok_proc(cmd)
+
+    with (
+        patch("subprocess.run", side_effect=fake_run),
+        patch("posit_bakery.retry.time.sleep") as sleep,
+        patch.object(SociConvertWorkflow, "_read_converted_digest", return_value="sha256:abc123"),
+    ):
+        result = workflow.run()
+
+    assert result.success is True
+    assert attempts["pull"] == 2
+    sleep.assert_called_once()
+
+
 def test_read_converted_digest_reads_index_json(workflow, tmp_path):
     layout = tmp_path / "out"
     layout.mkdir()

--- a/posit-bakery/test/test_retry.py
+++ b/posit-bakery/test/test_retry.py
@@ -1,0 +1,152 @@
+"""Tests for the retry-with-backoff helper."""
+
+from unittest.mock import patch
+
+import pytest
+
+from posit_bakery.error import BakeryToolRuntimeError
+from posit_bakery.retry import RetryPolicy, is_transient_error, retry_on_transient
+
+pytestmark = [pytest.mark.unit]
+
+
+def _tool_error(message="oras command failed", stderr=b"", exit_code=1):
+    return BakeryToolRuntimeError(
+        message=message,
+        tool_name="oras",
+        cmd=["oras", "manifest", "fetch"],
+        stdout=b"",
+        stderr=stderr,
+        exit_code=exit_code,
+    )
+
+
+class TestIsTransientError:
+    @pytest.mark.parametrize(
+        "stderr",
+        [
+            b"ghcr.io/posit-dev/workbench/tmp@sha256:abc: not found",
+            b"manifest unknown",
+            b"blob unknown to registry",
+            b"received unexpected HTTP status: 503 Service Unavailable",
+            b"429 Too Many Requests",
+            b"net/http: request canceled (Client.Timeout exceeded)",
+            b"dial tcp: i/o timeout",
+            b"read tcp: connection reset by peer",
+            b"unexpected EOF",
+        ],
+    )
+    def test_detects_transient(self, stderr):
+        assert is_transient_error(_tool_error(stderr=stderr)) is True
+
+    @pytest.mark.parametrize(
+        "stderr",
+        [
+            b"unauthorized: authentication required",
+            b"denied: requested access to the resource is denied",
+            b"invalid reference format",
+            b"",
+        ],
+    )
+    def test_non_transient(self, stderr):
+        assert is_transient_error(_tool_error(stderr=stderr)) is False
+
+    def test_matches_against_message_too(self):
+        err = _tool_error(message="could not find the manifest: not found", stderr=b"")
+        assert is_transient_error(err) is True
+
+
+class TestRetryOnTransient:
+    def test_returns_on_first_success(self):
+        calls = []
+
+        def fn():
+            calls.append(1)
+            return "ok"
+
+        with patch("posit_bakery.retry.time.sleep") as sleep:
+            result = retry_on_transient(fn, policy=RetryPolicy(max_attempts=5))
+
+        assert result == "ok"
+        assert len(calls) == 1
+        sleep.assert_not_called()
+
+    def test_retries_then_succeeds(self):
+        attempts = {"n": 0}
+
+        def fn():
+            attempts["n"] += 1
+            if attempts["n"] < 3:
+                raise _tool_error(stderr=b"sha256:deadbeef: not found")
+            return "ok"
+
+        with patch("posit_bakery.retry.time.sleep") as sleep:
+            result = retry_on_transient(
+                fn, policy=RetryPolicy(max_attempts=5, initial_backoff=2.0, multiplier=2.0, max_backoff=32.0)
+            )
+
+        assert result == "ok"
+        assert attempts["n"] == 3
+        # Slept before attempt 2 and attempt 3: 2s then 4s (exponential).
+        assert [c.args[0] for c in sleep.call_args_list] == [2.0, 4.0]
+
+    def test_non_transient_fails_fast(self):
+        attempts = {"n": 0}
+
+        def fn():
+            attempts["n"] += 1
+            raise _tool_error(stderr=b"unauthorized: authentication required")
+
+        with patch("posit_bakery.retry.time.sleep") as sleep:
+            with pytest.raises(BakeryToolRuntimeError):
+                retry_on_transient(fn, policy=RetryPolicy(max_attempts=5))
+
+        assert attempts["n"] == 1
+        sleep.assert_not_called()
+
+    def test_exhausts_and_reraises_last_error(self):
+        attempts = {"n": 0}
+
+        def fn():
+            attempts["n"] += 1
+            raise _tool_error(stderr=b"sha256:abc: not found")
+
+        with patch("posit_bakery.retry.time.sleep") as sleep:
+            with pytest.raises(BakeryToolRuntimeError):
+                retry_on_transient(fn, policy=RetryPolicy(max_attempts=3, initial_backoff=1.0))
+
+        assert attempts["n"] == 3
+        # Slept between the 3 attempts (after attempt 1 and 2).
+        assert sleep.call_count == 2
+
+    def test_backoff_is_capped_at_max(self):
+        def fn():
+            raise _tool_error(stderr=b"503 service unavailable")
+
+        with patch("posit_bakery.retry.time.sleep") as sleep:
+            with pytest.raises(BakeryToolRuntimeError):
+                retry_on_transient(
+                    fn,
+                    policy=RetryPolicy(max_attempts=5, initial_backoff=10.0, multiplier=10.0, max_backoff=20.0),
+                )
+
+        # 10, then 100->capped 20, then 20, then 20.
+        assert [c.args[0] for c in sleep.call_args_list] == [10.0, 20.0, 20.0, 20.0]
+
+
+class TestRetryPolicyEnv:
+    def test_reads_defaults_from_env(self, monkeypatch):
+        monkeypatch.setenv("BAKERY_REGISTRY_RETRY_ATTEMPTS", "9")
+        monkeypatch.setenv("BAKERY_REGISTRY_RETRY_INITIAL_BACKOFF", "1.5")
+        monkeypatch.setenv("BAKERY_REGISTRY_RETRY_MAX_BACKOFF", "60")
+        monkeypatch.setenv("BAKERY_REGISTRY_RETRY_MULTIPLIER", "3")
+        policy = RetryPolicy()
+        assert policy.max_attempts == 9
+        assert policy.initial_backoff == 1.5
+        assert policy.max_backoff == 60.0
+        assert policy.multiplier == 3.0
+
+    def test_invalid_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("BAKERY_REGISTRY_RETRY_ATTEMPTS", "not-a-number")
+        policy = RetryPolicy()
+        assert policy.max_attempts == 5


### PR DESCRIPTION
## Summary

Fixes the intermittent `bakery ci publish` failures tracked in #591, where digest-addressed manifests are reported `not found` by GHCR. Per-platform images are pushed *by digest* from separate runners, and the merge runner references those digests before GHCR has finished replicating them — with no retry or wait anywhere in the publish path, the first transient `not found` fails the job (a plain re-run almost always succeeds).

Implements both recommended fixes from #591.

### 1. Pre-flight source-digest wait (solution #2)

`OrasWaitForSourcesWorkflow` polls every per-platform source digest with `oras manifest fetch --descriptor` before any phase runs, waiting up to **10 minutes** for all of them to become readable. A timeout aborts the publish up front and logs exactly which digest lagged, instead of failing opaquely deep in a later phase.

### 2. Retry-with-backoff on registry calls (solution #1)

New `posit_bakery/retry.py` provides `RetryPolicy` + `retry_on_transient`, which retries *transient* registry errors (`not found` / `manifest unknown` / `blob unknown` / 5xx / 429 / timeouts / connection resets / EOF) with exponential backoff, while non-transient errors (e.g. `unauthorized`) still fail fast. Applied to the three calls called out in the issue:

- index creation (`OrasIndexCreateWorkflow`)
- the SOCI `oras cp --to-oci-layout` pull (`SociConvertWorkflow`)
- the destination index-copy (`OrasIndexCopyWorkflow`)

Counts and timings are configurable via `BAKERY_REGISTRY_RETRY_ATTEMPTS` (5), `BAKERY_REGISTRY_RETRY_INITIAL_BACKOFF` (2.0s), `BAKERY_REGISTRY_RETRY_MAX_BACKOFF` (32.0s), and `BAKERY_REGISTRY_RETRY_MULTIPLIER` (2.0).

## Scope note

The post-copy verify (`OrasManifestFetch`) was intentionally left without retry — the pre-flight wait already covers the read-after-write window on the source side, where every observed failure occurred. Easy to extend later if final-tag verification shows the same flakiness.

## Testing

- New `test/test_retry.py`: transient detection, retry-then-succeed, fail-fast, exhaustion, capped backoff, env config.
- `test_oras.py`: index-create/copy retry + full `OrasWaitForSourcesWorkflow` coverage (`oras.py` now 100%).
- `test_workflow.py` (soci): SOCI pull retries a transient `not found` then succeeds.
- `test_ci_publish.py`: publish invokes the wait with the right sources and proceeds; a timeout aborts before SOCI convert.
- Full suite: **1695 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)