### PR TITLE
Fix dependency version parsing

### DIFF
--- a/posit-bakery/posit_bakery/config/image/parsed_version.py
+++ b/posit-bakery/posit_bakery/config/image/parsed_version.py
@@ -10,6 +10,8 @@ import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from posit_bakery.config.dependencies.const import SupportedDependencies
+
 # Local under TYPE_CHECKING to avoid a circular import: version.py imports
 # this module at runtime, so importing ImageVersion eagerly would cycle.
 if TYPE_CHECKING:
@@ -17,12 +19,17 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
+# Alternation of known dependency name prefixes, longest first.
+_DEP_ALT = "|".join(re.escape(d.value) for d in sorted(SupportedDependencies, key=lambda d: len(d.value), reverse=True))
+
 # Anchored grammar:
+#   [<dep>]        optional SupportedDependencies name (e.g. "R", "python")
 #   <release>      one or more dot-separated digit groups, minimum two groups
 #   -<prerelease>  optional, semver prerelease alphabet
 #   +<build>       optional, semver build alphabet
 _VERSION_RE = re.compile(
-    r"^(?P<release>\d+(?:\.\d+)+)"
+    r"^(?:" + _DEP_ALT + r")?"
+    r"(?P<release>\d+(?:\.\d+)+)"
     r"(?:-(?P<prerelease>[0-9A-Za-z.-]+))?"
     r"(?:\+(?P<build>[0-9A-Za-z.-]+))?$"
 )

--- a/posit-bakery/posit_bakery/config/image/parsed_version.py
+++ b/posit-bakery/posit_bakery/config/image/parsed_version.py
@@ -22,17 +22,21 @@ log = logging.getLogger(__name__)
 # Alternation of known dependency name prefixes, longest first.
 _DEP_ALT = "|".join(re.escape(d.value) for d in sorted(SupportedDependencies, key=lambda d: len(d.value), reverse=True))
 
-# Anchored grammar:
-#   [<dep>]        optional SupportedDependencies name (e.g. "R", "python")
+# Anchored grammar (calver/semver — no dep prefix):
 #   <release>      one or more dot-separated digit groups, minimum two groups
 #   -<prerelease>  optional, semver prerelease alphabet
 #   +<build>       optional, semver build alphabet
-_VERSION_RE = re.compile(
-    r"^(?:" + _DEP_ALT + r")?"
-    r"(?P<release>\d+(?:\.\d+)+)"
+_CALVER_RE = re.compile(
+    r"^(?P<release>\d+(?:\.\d+)+)"
     r"(?:-(?P<prerelease>[0-9A-Za-z.-]+))?"
     r"(?:\+(?P<build>[0-9A-Za-z.-]+))?$"
 )
+
+# Dep-prefixed version grammar (e.g. "R4.3.3" or "R4.3.3-python3.13.14"):
+#   one or more {dep-name}{release} components separated by hyphens
+_SINGLE_DEP = r"(?:" + _DEP_ALT + r")\d+(?:\.\d+)+"
+_MATRIX_RE = re.compile(r"^" + _SINGLE_DEP + r"(?:-" + _SINGLE_DEP + r")*$")
+_DEP_PAIR_RE = re.compile(r"(?P<dep>" + _DEP_ALT + r")(?P<version>\d+(?:\.\d+)+)")
 
 
 @dataclass(frozen=True)
@@ -50,6 +54,8 @@ class ParsedVersion:
     release: tuple[int, ...]
     prerelease: str | None = None
     build: str | None = None
+    # Non-None for dep-prefixed strings; each entry is (dep_name, version_tuple).
+    dep_versions: tuple[tuple[str, tuple[int, ...]], ...] | None = None
 
     def __str__(self) -> str:
         return self.original
@@ -60,17 +66,23 @@ class ParsedVersion:
         if not isinstance(value, str):
             log.warning("Unparseable version string: %r", value)
             return None
-        match = _VERSION_RE.match(value)
-        if match is None:
-            log.warning("Unparseable version string: %r", value)
-            return None
-        release = tuple(int(part) for part in match.group("release").split("."))
-        return cls(
-            original=value,
-            release=release,
-            prerelease=match.group("prerelease"),
-            build=match.group("build"),
-        )
+        match = _CALVER_RE.match(value)
+        if match is not None:
+            release = tuple(int(part) for part in match.group("release").split("."))
+            return cls(
+                original=value,
+                release=release,
+                prerelease=match.group("prerelease"),
+                build=match.group("build"),
+            )
+        if _MATRIX_RE.match(value):
+            pairs = tuple(
+                (m.group("dep"), tuple(int(x) for x in m.group("version").split(".")))
+                for m in _DEP_PAIR_RE.finditer(value)
+            )
+            return cls(original=value, release=pairs[0][1], dep_versions=pairs)
+        log.warning("Unparseable version string: %r", value)
+        return None
 
     def _release_key(self, length: int) -> tuple[int, ...]:
         """Zero-pad ``self.release`` to ``length`` for length-tolerant comparison."""

--- a/posit-bakery/test/config/image/test_parsed_version.py
+++ b/posit-bakery/test/config/image/test_parsed_version.py
@@ -58,11 +58,10 @@ class TestParseRoundtrip:
             ("2026.4.0-rc.1", (2026, 4, 0), "rc.1", None),
             # Edge: build only.
             ("2026.4.0+abc", (2026, 4, 0), None, "abc"),
-            # Dep-prefixed: single dependency version.
+            # Dep-prefixed: single and compound matrix versions.
             ("R4.3.3", (4, 3, 3), None, None),
             ("python3.13.14", (3, 13, 14), None, None),
-            # Dep-prefixed: compound matrix version — prerelease holds the second component.
-            ("R4.3.3-python3.11.15", (4, 3, 3), "python3.11.15", None),
+            ("R4.3.3-python3.11.15", (4, 3, 3), None, None),
         ],
     )
     def test_parses_and_roundtrips(self, value, release, prerelease, build, caplog):
@@ -189,3 +188,26 @@ class TestVersionSortKey:
         # (Python's sort is stable). Parseable entries follow in ascending order.
         assert names[:2] == ["R4.3.3-python3.11.15", "garbage"]
         assert names[2:] == ["2026.04.0", "2026.04.1", "2026.05.0-dev+62-g1ca9367735"]
+
+
+class TestDepVersions:
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("R4.3.3", (("R", (4, 3, 3)),)),
+            ("python3.13.14", (("python", (3, 13, 14)),)),
+            ("R4.3.3-python3.11.15", (("R", (4, 3, 3)), ("python", (3, 11, 15)))),
+            ("R4.3-python3.11-quarto1.4", (("R", (4, 3)), ("python", (3, 11)), ("quarto", (1, 4)))),
+        ],
+    )
+    def test_dep_versions_populated(self, value, expected, caplog):
+        caplog.set_level(logging.WARNING)
+        parsed = ParsedVersion.parse(value)
+        assert parsed is not None
+        assert parsed.dep_versions == expected
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+    def test_pure_calver_has_no_dep_versions(self):
+        parsed = ParsedVersion.parse("2026.04.0-dev+92")
+        assert parsed is not None
+        assert parsed.dep_versions is None

--- a/posit-bakery/test/config/image/test_parsed_version.py
+++ b/posit-bakery/test/config/image/test_parsed_version.py
@@ -18,7 +18,6 @@ class TestParseUnparseable:
         [
             "",
             "latest",
-            "R4.3.3-python3.11.15",
             "v1.2.3",
             "not a version",
             "1",  # only one release component
@@ -59,6 +58,11 @@ class TestParseRoundtrip:
             ("2026.4.0-rc.1", (2026, 4, 0), "rc.1", None),
             # Edge: build only.
             ("2026.4.0+abc", (2026, 4, 0), None, "abc"),
+            # Dep-prefixed: single dependency version.
+            ("R4.3.3", (4, 3, 3), None, None),
+            ("python3.13.14", (3, 13, 14), None, None),
+            # Dep-prefixed: compound matrix version — prerelease holds the second component.
+            ("R4.3.3-python3.11.15", (4, 3, 3), "python3.11.15", None),
         ],
     )
     def test_parses_and_roundtrips(self, value, release, prerelease, build, caplog):


### PR DESCRIPTION
Fixes the warning we see:

```
           WARNING  Unparseable version string:             parsed_version.py:58
                    'R4.6.0-python3.14.6'
```

- **Recognize dep-prefixed versions in ParsedVersion**
- **Parse dep-prefixed versions into separate components**
