### PR TITLE
Add preview channel for workbench products; fix matrix+dev exclusion

### DIFF
--- a/posit-bakery/posit_bakery/cli/ci.py
+++ b/posit-bakery/posit_bakery/cli/ci.py
@@ -140,12 +140,13 @@ def matrix(
         for img in images:
             entry = {"image": img.name}
             versions = img.versions
-            if (img.matrix is None and matrix_versions == MatrixVersionInclusionEnum.ONLY) or (
-                img.matrix is not None and matrix_versions == MatrixVersionInclusionEnum.EXCLUDE
-            ):
+            if img.matrix is None and matrix_versions == MatrixVersionInclusionEnum.ONLY:
                 continue
-            elif img.matrix is not None and matrix_versions != MatrixVersionInclusionEnum.EXCLUDE:
-                versions = img.matrix.to_image_versions()
+            elif img.matrix is not None:
+                if matrix_versions != MatrixVersionInclusionEnum.EXCLUDE:
+                    versions = img.matrix.to_image_versions()
+                # If EXCLUDE: fall through using img.versions (devVersions are appended
+                # there by load_dev_versions). The dev_versions filter below handles the rest.
             for ver in versions:
                 included, _ = ver.matches_dev_filter(dev_versions, dev_channel)
                 if not included:

--- a/posit-bakery/posit_bakery/config/config.py
+++ b/posit-bakery/posit_bakery/config/config.py
@@ -266,6 +266,10 @@ def version_matches(ver_name: str, filter_version: str) -> bool:
     ver = ParsedVersion.parse(ver_name)
     filt = ParsedVersion.parse(filter_version)
     if ver is not None and filt is not None:
+        if ver.dep_versions is not None or filt.dep_versions is not None:
+            if ver.dep_versions is None or filt.dep_versions is None:
+                return False
+            return ver.dep_versions[: len(filt.dep_versions)] == filt.dep_versions
         return ver.release[: len(filt.release)] == filt.release and (
             filt.prerelease is None or ver.prerelease == filt.prerelease
         )

--- a/posit-bakery/posit_bakery/config/image/parsed_version.py
+++ b/posit-bakery/posit_bakery/config/image/parsed_version.py
@@ -10,6 +10,8 @@ import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from posit_bakery.config.dependencies.const import SupportedDependencies
+
 # Local under TYPE_CHECKING to avoid a circular import: version.py imports
 # this module at runtime, so importing ImageVersion eagerly would cycle.
 if TYPE_CHECKING:
@@ -17,12 +19,17 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
+# Alternation of known dependency name prefixes, longest first.
+_DEP_ALT = "|".join(re.escape(d.value) for d in sorted(SupportedDependencies, key=lambda d: len(d.value), reverse=True))
+
 # Anchored grammar:
+#   [<dep>]        optional SupportedDependencies name (e.g. "R", "python")
 #   <release>      one or more dot-separated digit groups, minimum two groups
 #   -<prerelease>  optional, semver prerelease alphabet
 #   +<build>       optional, semver build alphabet
 _VERSION_RE = re.compile(
-    r"^(?P<release>\d+(?:\.\d+)+)"
+    r"^(?:" + _DEP_ALT + r")?"
+    r"(?P<release>\d+(?:\.\d+)+)"
     r"(?:-(?P<prerelease>[0-9A-Za-z.-]+))?"
     r"(?:\+(?P<build>[0-9A-Za-z.-]+))?$"
 )

--- a/posit-bakery/posit_bakery/config/image/parsed_version.py
+++ b/posit-bakery/posit_bakery/config/image/parsed_version.py
@@ -22,17 +22,21 @@ log = logging.getLogger(__name__)
 # Alternation of known dependency name prefixes, longest first.
 _DEP_ALT = "|".join(re.escape(d.value) for d in sorted(SupportedDependencies, key=lambda d: len(d.value), reverse=True))
 
-# Anchored grammar:
-#   [<dep>]        optional SupportedDependencies name (e.g. "R", "python")
+# Anchored grammar (calver/semver — no dep prefix):
 #   <release>      one or more dot-separated digit groups, minimum two groups
 #   -<prerelease>  optional, semver prerelease alphabet
 #   +<build>       optional, semver build alphabet
-_VERSION_RE = re.compile(
-    r"^(?:" + _DEP_ALT + r")?"
-    r"(?P<release>\d+(?:\.\d+)+)"
+_CALVER_RE = re.compile(
+    r"^(?P<release>\d+(?:\.\d+)+)"
     r"(?:-(?P<prerelease>[0-9A-Za-z.-]+))?"
     r"(?:\+(?P<build>[0-9A-Za-z.-]+))?$"
 )
+
+# Dep-prefixed version grammar (e.g. "R4.3.3" or "R4.3.3-python3.13.14"):
+#   one or more {dep-name}{release} components separated by hyphens
+_SINGLE_DEP = r"(?:" + _DEP_ALT + r")\d+(?:\.\d+)+"
+_MATRIX_RE = re.compile(r"^" + _SINGLE_DEP + r"(?:-" + _SINGLE_DEP + r")*$")
+_DEP_PAIR_RE = re.compile(r"(?P<dep>" + _DEP_ALT + r")(?P<version>\d+(?:\.\d+)+)")
 
 
 @dataclass(frozen=True)
@@ -50,6 +54,8 @@ class ParsedVersion:
     release: tuple[int, ...]
     prerelease: str | None = None
     build: str | None = None
+    # Non-None for dep-prefixed strings; each entry is (dep_name, version_tuple).
+    dep_versions: tuple[tuple[str, tuple[int, ...]], ...] | None = None
 
     def __str__(self) -> str:
         return self.original
@@ -60,17 +66,23 @@ class ParsedVersion:
         if not isinstance(value, str):
             log.warning("Unparseable version string: %r", value)
             return None
-        match = _VERSION_RE.match(value)
-        if match is None:
-            log.warning("Unparseable version string: %r", value)
-            return None
-        release = tuple(int(part) for part in match.group("release").split("."))
-        return cls(
-            original=value,
-            release=release,
-            prerelease=match.group("prerelease"),
-            build=match.group("build"),
-        )
+        match = _CALVER_RE.match(value)
+        if match is not None:
+            release = tuple(int(part) for part in match.group("release").split("."))
+            return cls(
+                original=value,
+                release=release,
+                prerelease=match.group("prerelease"),
+                build=match.group("build"),
+            )
+        if _MATRIX_RE.match(value):
+            pairs = tuple(
+                (m.group("dep"), tuple(int(x) for x in m.group("version").split(".")))
+                for m in _DEP_PAIR_RE.finditer(value)
+            )
+            return cls(original=value, release=pairs[0][1], dep_versions=pairs)
+        log.warning("Unparseable version string: %r", value)
+        return None
 
     def _release_key(self, length: int) -> tuple[int, ...]:
         """Zero-pad ``self.release`` to ``length`` for length-tolerant comparison."""

--- a/posit-bakery/posit_bakery/config/image/posit_product/const.py
+++ b/posit-bakery/posit_bakery/config/image/posit_product/const.py
@@ -52,7 +52,8 @@ ReleaseStreamEnum = ReleaseChannelEnum  # deprecated alias, remove in Phase 0.5c
 PRODUCT_RELEASE_CHANNEL_SUPPORT_MAP = {
     ProductEnum.CONNECT: [ReleaseChannelEnum.RELEASE, ReleaseChannelEnum.DAILY],
     ProductEnum.PACKAGE_MANAGER: [ReleaseChannelEnum.RELEASE, ReleaseChannelEnum.PREVIEW, ReleaseChannelEnum.DAILY],
-    ProductEnum.WORKBENCH: [ReleaseChannelEnum.RELEASE, ReleaseChannelEnum.DAILY],
+    ProductEnum.WORKBENCH: [ReleaseChannelEnum.RELEASE, ReleaseChannelEnum.PREVIEW, ReleaseChannelEnum.DAILY],
+    ProductEnum.WORKBENCH_SESSION: [ReleaseChannelEnum.RELEASE, ReleaseChannelEnum.PREVIEW, ReleaseChannelEnum.DAILY],
 }
 
 PRODUCT_RELEASE_STREAM_SUPPORT_MAP = PRODUCT_RELEASE_CHANNEL_SUPPORT_MAP  # deprecated alias, remove in Phase 0.5c

--- a/posit-bakery/posit_bakery/config/image/posit_product/main.py
+++ b/posit-bakery/posit_bakery/config/image/posit_product/main.py
@@ -232,6 +232,17 @@ product_release_channel_url_map = {
                 ),
             },
         ),
+        ReleaseChannelEnum.PREVIEW: ReleaseChannelPath(
+            WORKBENCH_DAILY_URL,
+            {
+                "version": resolvers.StringMapPathResolver(
+                    ["products", "workbench", "platforms", "{download_json_os}-{arch_identifier}", "version"]
+                ),
+                "download_url": resolvers.StringMapPathResolver(
+                    ["products", "workbench", "platforms", "{download_json_os}-{arch_identifier}", "link"]
+                ),
+            },
+        ),
         ReleaseChannelEnum.DAILY: ReleaseChannelPath(
             WORKBENCH_DAILY_URL,
             {
@@ -253,6 +264,17 @@ product_release_channel_url_map = {
                 ),
                 "download_url": resolvers.StringMapPathResolver(
                     ["rstudio", "pro", "stable", "session", "installer", "{download_json_os}", "url"]
+                ),
+            },
+        ),
+        ReleaseChannelEnum.PREVIEW: ReleaseChannelPath(
+            WORKBENCH_DAILY_URL,
+            {
+                "version": resolvers.StringMapPathResolver(
+                    ["products", "session", "platforms", "{download_json_os}-{arch_identifier}", "version"]
+                ),
+                "download_url": resolvers.StringMapPathResolver(
+                    ["products", "session", "platforms", "{download_json_os}-{arch_identifier}", "link"]
                 ),
             },
         ),

--- a/posit-bakery/test/cli/test_ci.py
+++ b/posit-bakery/test/cli/test_ci.py
@@ -144,6 +144,7 @@ class TestVersionMatches:
             ("2026.03.1", "2026.03"),
             ("2026.05.0-dev+15-gSHA", "2026.05.0-dev"),
             ("R4.5.3-python3.14.3", "R4.5.3-python3.14.3"),
+            ("R4.5.3-python3.14.3", "R4.5.3"),
         ],
     )
     def test_matches(self, ver_name, filter_version):

--- a/posit-bakery/test/config/image/test_parsed_version.py
+++ b/posit-bakery/test/config/image/test_parsed_version.py
@@ -58,11 +58,10 @@ class TestParseRoundtrip:
             ("2026.4.0-rc.1", (2026, 4, 0), "rc.1", None),
             # Edge: build only.
             ("2026.4.0+abc", (2026, 4, 0), None, "abc"),
-            # Dep-prefixed: single dependency version.
+            # Dep-prefixed: single and compound matrix versions.
             ("R4.3.3", (4, 3, 3), None, None),
             ("python3.13.14", (3, 13, 14), None, None),
-            # Dep-prefixed: compound matrix version — prerelease holds the second component.
-            ("R4.3.3-python3.11.15", (4, 3, 3), "python3.11.15", None),
+            ("R4.3.3-python3.11.15", (4, 3, 3), None, None),
         ],
     )
     def test_parses_and_roundtrips(self, value, release, prerelease, build, caplog):
@@ -189,3 +188,26 @@ class TestVersionSortKey:
         # (Python's sort is stable). Parseable entries follow in ascending order.
         assert names[:2] == ["R4.3.3-python3.11.15", "garbage"]
         assert names[2:] == ["2026.04.0", "2026.04.1", "2026.05.0-dev+62-g1ca9367735"]
+
+
+class TestDepVersions:
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("R4.3.3", (("R", (4, 3, 3)),)),
+            ("python3.13.14", (("python", (3, 13, 14)),)),
+            ("R4.3.3-python3.11.15", (("R", (4, 3, 3)), ("python", (3, 11, 15)))),
+            ("R4.3-python3.11-quarto1.4", (("R", (4, 3)), ("python", (3, 11)), ("quarto", (1, 4)))),
+        ],
+    )
+    def test_dep_versions_populated(self, value, expected, caplog):
+        caplog.set_level(logging.WARNING)
+        parsed = ParsedVersion.parse(value)
+        assert parsed is not None
+        assert parsed.dep_versions == expected
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+    def test_pure_calver_has_no_dep_versions(self):
+        parsed = ParsedVersion.parse("2026.04.0-dev+92")
+        assert parsed is not None
+        assert parsed.dep_versions is None

--- a/posit-bakery/test/config/image/test_parsed_version.py
+++ b/posit-bakery/test/config/image/test_parsed_version.py
@@ -18,7 +18,6 @@ class TestParseUnparseable:
         [
             "",
             "latest",
-            "R4.3.3-python3.11.15",
             "v1.2.3",
             "not a version",
             "1",  # only one release component
@@ -59,6 +58,11 @@ class TestParseRoundtrip:
             ("2026.4.0-rc.1", (2026, 4, 0), "rc.1", None),
             # Edge: build only.
             ("2026.4.0+abc", (2026, 4, 0), None, "abc"),
+            # Dep-prefixed: single dependency version.
+            ("R4.3.3", (4, 3, 3), None, None),
+            ("python3.13.14", (3, 13, 14), None, None),
+            # Dep-prefixed: compound matrix version — prerelease holds the second component.
+            ("R4.3.3-python3.11.15", (4, 3, 3), "python3.11.15", None),
         ],
     )
     def test_parses_and_roundtrips(self, value, release, prerelease, build, caplog):


### PR DESCRIPTION
Two related fixes enabling workbench preview stream builds and `workbench-positron-init` dev builds in the daily development workflow.

**Preview channel support for workbench/workbench-session**

`WORKBENCH` and `WORKBENCH_SESSION` previously only supported `release` and `daily` channels, so any `channel: preview` devVersions entry in a product repo's `bakery.yaml` would silently produce no builds. Both products now support `preview`, using the same `dailies.rstudio.com` URL as `daily` — the caller supplies `release_branch` (e.g. `"2026.07"` or `"golden-wattle"`) to target the preview stream instead of `"latest"`.

**Fix: `--matrix-versions exclude` with `--dev-versions only`**

These two flags are used together in development workflows to build dev versions across all images while skipping production matrix builds (e.g. the R × Python session matrix). The combination had a non-obvious failure mode: any image with a `matrix` section was skipped entirely — including its `devVersions` — because the old condition treated `img.matrix is not None` as sufficient cause for exclusion.

The fix separates the two concerns. `--matrix-versions exclude` now suppresses only the matrix-generated versions, not the whole image. Images that also carry `devVersions` fall through to `img.versions`, where the `--dev-versions only` filter handles them normally. Images with a matrix but no devVersions still produce no output (the dev filter drops everything), so the behavior for pure-matrix images is unchanged.