### PR TITLE
feat(ci): add image-name filter input to bakery build workflows

### DIFF
--- a/.github/workflows/bakery-build-native.yml
+++ b/.github/workflows/bakery-build-native.yml
@@ -156,7 +156,7 @@ jobs:
           IMAGE_VERSION="${IMAGE_VERSION#v}"
           ARGS=(--quiet --dev-versions "$DEV_VERSIONS" --matrix-versions "$MATRIX_VERSIONS" --context "$CONTEXT")
           [[ -n "$IMAGE_VERSION" ]] && ARGS+=(--image-version "$IMAGE_VERSION")
-          [[ -n "$IMAGE_NAME_FILTER" ]] && ARGS+=("$IMAGE_NAME_FILTER")
+          [[ -n "$IMAGE_NAME_FILTER" ]] && ARGS+=(-- "$IMAGE_NAME_FILTER")
           if [[ -n "$DEV_SPEC" ]]; then
             ARGS+=(--dev-spec "$DEV_SPEC")
           elif [[ -n "$DEV_VERSION" || -n "$RELEASE_BRANCH" ]]; then

--- a/.github/workflows/bakery-build-native.yml
+++ b/.github/workflows/bakery-build-native.yml
@@ -27,6 +27,11 @@ on:
         default: "exclude"
         required: false
         type: string
+      image-name:
+        description: "Filter to a specific image name or pattern (e.g., 'workbench', '^workbench$')"
+        default: ""
+        required: false
+        type: string
       image-version:
         description: "Filter to a specific image version. A leading 'v' is stripped automatically."
         default: ""
@@ -140,6 +145,7 @@ jobs:
         env:
           DEV_VERSIONS: ${{ inputs.dev-versions }}
           MATRIX_VERSIONS: ${{ inputs.matrix-versions }}
+          IMAGE_NAME_FILTER: ${{ inputs.image-name }}
           IMAGE_VERSION: ${{ inputs.image-version }}
           DEV_CHANNEL: ${{ inputs.dev-channel || inputs.dev-stream }}
           DEV_VERSION: ${{ inputs.dev-version }}
@@ -150,6 +156,7 @@ jobs:
           IMAGE_VERSION="${IMAGE_VERSION#v}"
           ARGS=(--quiet --dev-versions "$DEV_VERSIONS" --matrix-versions "$MATRIX_VERSIONS" --context "$CONTEXT")
           [[ -n "$IMAGE_VERSION" ]] && ARGS+=(--image-version "$IMAGE_VERSION")
+          [[ -n "$IMAGE_NAME_FILTER" ]] && ARGS+=("$IMAGE_NAME_FILTER")
           if [[ -n "$DEV_SPEC" ]]; then
             ARGS+=(--dev-spec "$DEV_SPEC")
           elif [[ -n "$DEV_VERSION" || -n "$RELEASE_BRANCH" ]]; then

--- a/.github/workflows/bakery-build.yml
+++ b/.github/workflows/bakery-build.yml
@@ -34,6 +34,11 @@ on:
         default: "exclude"
         required: false
         type: string
+      image-name:
+        description: "Filter to a specific image name or pattern (e.g., 'workbench', '^workbench$')"
+        default: ""
+        required: false
+        type: string
       image-version:
         description: "Filter to a specific image version. A leading 'v' is stripped automatically."
         default: ""
@@ -131,6 +136,7 @@ jobs:
         env:
           DEV_VERSIONS: ${{ inputs.dev-versions }}
           MATRIX_VERSIONS: ${{ inputs.matrix-versions }}
+          IMAGE_NAME_FILTER: ${{ inputs.image-name }}
           IMAGE_VERSION: ${{ inputs.image-version }}
           DEV_CHANNEL: ${{ inputs.dev-channel || inputs.dev-stream }}
           DEV_VERSION: ${{ inputs.dev-version }}
@@ -140,6 +146,7 @@ jobs:
           IMAGE_VERSION="${IMAGE_VERSION#v}"
           ARGS=(--quiet --dev-versions "$DEV_VERSIONS" --matrix-versions "$MATRIX_VERSIONS" --context "$CONTEXT")
           [[ -n "$IMAGE_VERSION" ]] && ARGS+=(--image-version "$IMAGE_VERSION")
+          [[ -n "$IMAGE_NAME_FILTER" ]] && ARGS+=("$IMAGE_NAME_FILTER")
           if [[ -n "$DEV_SPEC" ]]; then
             ARGS+=(--dev-spec "$DEV_SPEC")
           elif [[ -n "$DEV_VERSION" ]]; then

--- a/.github/workflows/bakery-build.yml
+++ b/.github/workflows/bakery-build.yml
@@ -146,7 +146,7 @@ jobs:
           IMAGE_VERSION="${IMAGE_VERSION#v}"
           ARGS=(--quiet --dev-versions "$DEV_VERSIONS" --matrix-versions "$MATRIX_VERSIONS" --context "$CONTEXT")
           [[ -n "$IMAGE_VERSION" ]] && ARGS+=(--image-version "$IMAGE_VERSION")
-          [[ -n "$IMAGE_NAME_FILTER" ]] && ARGS+=("$IMAGE_NAME_FILTER")
+          [[ -n "$IMAGE_NAME_FILTER" ]] && ARGS+=(-- "$IMAGE_NAME_FILTER")
           if [[ -n "$DEV_SPEC" ]]; then
             ARGS+=(--dev-spec "$DEV_SPEC")
           elif [[ -n "$DEV_VERSION" ]]; then


### PR DESCRIPTION
## Summary

- Adds `image-name` input to both `bakery-build-native.yml` and `bakery-build.yml` reusable workflows
- The input is passed as a positional argument to `bakery ci matrix`, allowing callers to filter the matrix to a specific image name or pattern (e.g., `workbench`, `^workbench$`)
- Value is routed through an `IMAGE_NAME_FILTER` env var to safely handle special regex characters without shell interpretation

## Test plan

- [ ] Verify workflows with no `image-name` input behave identically to before (argument is omitted when empty)
- [ ] Verify passing an image name filters the matrix as expected in a calling workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)