### PR TITLE
fix(bakery): apply image_name filter in ci matrix command

### DIFF
--- a/posit-bakery/posit_bakery/cli/ci.py
+++ b/posit-bakery/posit_bakery/cli/ci.py
@@ -1,6 +1,7 @@
 import glob
 import json
 import logging
+import re
 import python_on_whales
 from enum import Enum
 from pathlib import Path
@@ -132,7 +133,7 @@ def matrix(
             dev_spec=dev_spec,  # type: ignore[arg-type]  # typer requires str annotation; parse_dev_spec callback delivers DevBuildSpec at runtime
         )
         c = BakeryConfig.from_context(context=context, settings=settings)
-        images = [i for i in c.model.images]
+        images = [i for i in c.model.images if image_name is None or re.search(image_name, i.name) is not None]
 
         data = []
         for img in images:

--- a/posit-bakery/test/cli/testdata/ci/matrix/merge-multi-image/image_name_filter.json
+++ b/posit-bakery/test/cli/testdata/ci/matrix/merge-multi-image/image_name_filter.json
@@ -1,0 +1,1 @@
+[{"image": "test-alpha", "version": "1.0.0", "dev": false, "platform": "linux/amd64"}]

--- a/posit-bakery/test/features/cli/ci/matrix.feature
+++ b/posit-bakery/test/features/cli/ci/matrix.feature
@@ -47,3 +47,12 @@ Feature: matrix
             | --image-version | 9.9.9 |
         When I execute the command
         Then The command fails
+
+    Scenario: Filtering the CI matrix by image name excludes non-matching images
+        Given I call bakery ci matrix
+        * in the merge-multi-image context
+        * with the arguments:
+            | test-alpha$ |
+        When I execute the command
+        Then The command succeeds
+        * the matrix matches testdata ci/matrix/merge-multi-image/image_name_filter.json


### PR DESCRIPTION
## Summary

- `bakery ci matrix <image_name>` was iterating `c.model.images` (the unfiltered list) instead of applying the `image_name` regex from `BakeryConfigFilter`
- Patterns like `workbench$` would match prefix-colliding image names like `workbench-session-init` because the filter was never consulted
- Fix: apply `re.search(image_name, i.name)` inline on the image list, consistent with how `generate_image_targets()` applies the same filter

## Test plan

- [ ] New BDD scenario in `matrix.feature` using the existing `merge-multi-image` context (`test-alpha` / `test-alpha-extra`) verifies that `test-alpha$` returns only `test-alpha`
- [ ] All 29 existing `test_ci.py` tests pass
- [ ] Manual: `bakery ci matrix 'workbench$'` in `images-workbench/` now returns only `workbench` entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)