### PR TITLE
fix: stop silent dgoss/build workflow failures on version filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,7 @@ jobs:
       packages: write
     uses: "./.github/workflows/bakery-build-pr.yml"
     with:
+      version: ${{ github.head_ref || github.ref_name }}
       context: "./posit-bakery/test/resources/multiplatform/"
       dev-versions: include
 

--- a/posit-bakery/posit_bakery/cli/build.py
+++ b/posit-bakery/posit_bakery/cli/build.py
@@ -6,7 +6,7 @@ from typing import Annotated, Optional
 import python_on_whales
 import typer
 
-from posit_bakery.cli.common import with_verbosity_flags, with_temporary_storage, parse_dev_spec
+from posit_bakery.cli.common import with_verbosity_flags, with_temporary_storage, parse_dev_spec, exit_if_no_targets
 from posit_bakery.config import BakeryConfig
 from posit_bakery.config.config import BakeryConfigFilter, BakerySettings
 from posit_bakery.config.image.posit_product.const import ReleaseChannelEnum
@@ -262,6 +262,8 @@ def build(
     except (ArtifactNotAvailableError, VersionSubstitutionError) as e:
         stderr_console.print(f"❌ {e}", style="error")
         raise typer.Exit(code=1)
+
+    exit_if_no_targets(config, settings)
 
     if plan:
         if strategy == ImageBuildStrategy.BUILD:

--- a/posit-bakery/posit_bakery/cli/common.py
+++ b/posit-bakery/posit_bakery/cli/common.py
@@ -4,7 +4,7 @@ import json
 import logging
 import tempfile
 from pathlib import Path
-from typing import Annotated, Optional, Any
+from typing import Annotated, Optional, Any, TYPE_CHECKING
 
 import typer
 from pydantic import ValidationError
@@ -16,10 +16,55 @@ from posit_bakery.config.dependencies import (
     DependencyVersions,
 )
 from posit_bakery.config.image.dev_version.spec import DevBuildSpec
-from posit_bakery.log import init_logging
+from posit_bakery.log import init_logging, stderr_console
 from posit_bakery.settings import SETTINGS
 
+# Runtime import would cycle (config.config indirectly imports the CLI package),
+# and these are only needed for type hints.
+if TYPE_CHECKING:
+    from posit_bakery.config.config import BakeryConfig, BakerySettings
+
 log = logging.getLogger(__name__)
+
+
+def exit_if_no_targets(config: "BakeryConfig", settings: "BakerySettings") -> None:
+    """Abort the command when the active filters resolved to zero image targets.
+
+    A ``build`` or ``dgoss run`` that matches no targets is almost always a
+    mistake — a typo'd or non-existent ``--image-version``, an over-narrow
+    combination of filters, or a ``--dev-versions``/``--matrix-versions``
+    selection that excludes everything. Exiting 0 in that case let broken CI
+    jobs pass while building/testing nothing, so fail loudly and echo the
+    active filters back to aid debugging.
+    """
+    if config.targets:
+        return
+    active = _describe_active_filters(settings)
+    detail = f" matching {active}" if active else ""
+    stderr_console.print(
+        f"❌ No image targets{detail}. Check the --image-name, --image-version, "
+        "--image-variant, --image-os, and --image-platform filters along with the "
+        "--dev-versions/--matrix-versions selection.",
+        style="error",
+    )
+    raise typer.Exit(code=1)
+
+
+def _describe_active_filters(settings: "BakerySettings") -> str:
+    """Render the set filters as a human-readable ``--flag value`` list."""
+    f = settings.filter
+    parts = [
+        f"--{name} {value!r}"
+        for name, value in (
+            ("image-name", f.image_name),
+            ("image-version", f.image_version),
+            ("image-variant", f.image_variant),
+            ("image-os", f.image_os),
+            ("image-platform", f.image_platform),
+        )
+        if value
+    ]
+    return ", ".join(parts)
 
 
 def parse_dev_spec(ctx: typer.Context, param: typer.CallbackParam, value: str | None) -> DevBuildSpec | None:

--- a/posit-bakery/posit_bakery/cli/run.py
+++ b/posit-bakery/posit_bakery/cli/run.py
@@ -6,7 +6,7 @@ from typing import Annotated, Optional
 
 import typer
 
-from posit_bakery.cli.common import with_verbosity_flags, parse_dev_spec
+from posit_bakery.cli.common import with_verbosity_flags, parse_dev_spec, exit_if_no_targets
 from posit_bakery.config import BakeryConfig
 from posit_bakery.config.config import BakeryConfigFilter, BakerySettings
 from posit_bakery.config.image.posit_product.const import ReleaseChannelEnum
@@ -196,6 +196,8 @@ def dgoss(
         clean_temporary=clean,
     )
     c = BakeryConfig.from_context(context, settings)
+
+    exit_if_no_targets(c, settings)
 
     if metadata_file:
         c.load_build_metadata_from_file(metadata_file)

--- a/posit-bakery/posit_bakery/plugins/builtin/dgoss/__init__.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/dgoss/__init__.py
@@ -6,7 +6,7 @@ from typing import Annotated, Optional
 
 import typer
 
-from posit_bakery.cli.common import with_verbosity_flags, parse_dev_spec
+from posit_bakery.cli.common import with_verbosity_flags, parse_dev_spec, exit_if_no_targets
 from posit_bakery.config.image.posit_product.const import ReleaseChannelEnum
 from posit_bakery.config.config import BakeryConfig, BakeryConfigFilter, BakerySettings
 from posit_bakery.const import DevVersionInclusionEnum, MatrixVersionInclusionEnum
@@ -209,6 +209,8 @@ class DGossPlugin(BakeryToolPlugin):
                 clean_temporary=clean,
             )
             c = BakeryConfig.from_context(context, settings)
+
+            exit_if_no_targets(c, settings)
 
             if metadata_file:
                 c.load_build_metadata_from_file(metadata_file)

--- a/posit-bakery/posit_bakery/plugins/builtin/dgoss/__init__.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/dgoss/__init__.py
@@ -1,5 +1,4 @@
 import logging
-import re
 import warnings
 from enum import Enum
 from pathlib import Path
@@ -197,7 +196,7 @@ class DGossPlugin(BakeryToolPlugin):
             settings = BakerySettings(
                 filter=BakeryConfigFilter(
                     image_name=image_name,
-                    image_version=re.escape(image_version) if image_version else None,
+                    image_version=image_version,
                     image_variant=image_variant,
                     image_os=image_os,
                     image_platform=[platform],

--- a/posit-bakery/posit_bakery/plugins/builtin/hadolint/__init__.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/hadolint/__init__.py
@@ -1,5 +1,4 @@
 import logging
-import re
 from enum import Enum
 from pathlib import Path
 from typing import Annotated, Optional
@@ -212,7 +211,7 @@ class HadolintPlugin(BakeryToolPlugin):
             settings = BakerySettings(
                 filter=BakeryConfigFilter(
                     image_name=image_name,
-                    image_version=re.escape(image_version) if image_version else None,
+                    image_version=image_version,
                     image_variant=image_variant,
                     image_os=image_os,
                     image_platform=[],

--- a/posit-bakery/posit_bakery/plugins/builtin/hadolint/__init__.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/hadolint/__init__.py
@@ -5,7 +5,7 @@ from typing import Annotated, Optional
 
 import typer
 
-from posit_bakery.cli.common import with_verbosity_flags
+from posit_bakery.cli.common import with_verbosity_flags, exit_if_no_targets
 from posit_bakery.config.config import BakeryConfig, BakeryConfigFilter, BakerySettings
 from posit_bakery.const import DevVersionInclusionEnum, MatrixVersionInclusionEnum
 from posit_bakery.error import BakeryToolRuntimeErrorGroup
@@ -221,6 +221,8 @@ class HadolintPlugin(BakeryToolPlugin):
                 latest=latest,
             )
             c = BakeryConfig.from_context(context, settings)
+
+            exit_if_no_targets(c, settings)
 
             # Build options override from CLI flags
             override_dict = {}

--- a/posit-bakery/posit_bakery/plugins/builtin/wizcli/__init__.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/wizcli/__init__.py
@@ -1,5 +1,4 @@
 import logging
-import re
 from enum import Enum
 from pathlib import Path
 from typing import Annotated, Optional
@@ -224,7 +223,7 @@ class WizCLIPlugin(BakeryToolPlugin):
             settings = BakerySettings(
                 filter=BakeryConfigFilter(
                     image_name=image_name,
-                    image_version=re.escape(image_version) if image_version else None,
+                    image_version=image_version,
                     image_variant=image_variant,
                     image_os=image_os,
                     image_platform=[platform],

--- a/posit-bakery/posit_bakery/plugins/builtin/wizcli/__init__.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/wizcli/__init__.py
@@ -5,7 +5,7 @@ from typing import Annotated, Optional
 
 import typer
 
-from posit_bakery.cli.common import with_verbosity_flags
+from posit_bakery.cli.common import with_verbosity_flags, exit_if_no_targets
 from posit_bakery.config.config import BakeryConfig, BakeryConfigFilter, BakerySettings
 from posit_bakery.const import DevVersionInclusionEnum, MatrixVersionInclusionEnum
 from posit_bakery.error import BakeryToolRuntimeErrorGroup
@@ -233,6 +233,8 @@ class WizCLIPlugin(BakeryToolPlugin):
                 latest=latest,
             )
             c = BakeryConfig.from_context(context, settings)
+
+            exit_if_no_targets(c, settings)
 
             if metadata_file:
                 c.load_build_metadata_from_file(metadata_file)

--- a/posit-bakery/test/cli/test_build.py
+++ b/posit-bakery/test/cli/test_build.py
@@ -59,6 +59,40 @@ class TestBuildErrorHandling:
         assert "Traceback" not in result.output
 
 
+class TestBuildZeroMatchGuard:
+    """A filter that matches no targets must fail the build, not silently pass."""
+
+    def test_no_targets_exits_nonzero(self):
+        with patch("posit_bakery.cli.build.BakeryConfig") as mock:
+            instance = MagicMock()
+            instance.targets = []
+            mock.from_context.return_value = instance
+            result = runner.invoke(
+                app,
+                ["build", "--context", BASIC_CONTEXT, "--image-version", "9999.99.99"],
+                catch_exceptions=False,
+            )
+        assert result.exit_code == 1
+        assert "No image targets" in result.output
+        assert "9999.99.99" in result.output
+        instance.build_targets.assert_not_called()
+
+    def test_no_targets_blocks_plan_output(self):
+        """--plan must also fail rather than emit an empty bake plan."""
+        with patch("posit_bakery.cli.build.BakeryConfig") as mock:
+            instance = MagicMock()
+            instance.targets = []
+            mock.from_context.return_value = instance
+            result = runner.invoke(
+                app,
+                ["build", "--plan", "--context", BASIC_CONTEXT, "--image-version", "9999.99.99"],
+                catch_exceptions=False,
+            )
+        assert result.exit_code == 1
+        assert "No image targets" in result.output
+        instance.bake_plan_targets.assert_not_called()
+
+
 class TestBuildLatestFlag:
     def test_latest_passed_to_settings(self, mock_build_config):
         result = runner.invoke(

--- a/posit-bakery/test/cli/test_dev_spec.py
+++ b/posit-bakery/test/cli/test_dev_spec.py
@@ -196,7 +196,8 @@ class TestDgossRunDevSpec:
         ):
             instance = MagicMock()
             instance.base_path = Path(BASIC_CONTEXT)
-            instance.targets = []
+            # Non-empty so the zero-match guard does not abort the happy-path runs.
+            instance.targets = [MagicMock()]
             mock_config.from_context.return_value = instance
             result = runner.invoke(
                 app,
@@ -264,7 +265,8 @@ class TestRunDgossDevSpec:
         ):
             instance = MagicMock()
             instance.base_path = Path(BASIC_CONTEXT)
-            instance.targets = []
+            # Non-empty so the zero-match guard does not abort the happy-path runs.
+            instance.targets = [MagicMock()]
             mock_config.from_context.return_value = instance
             mock_plugin = MagicMock()
             mock_plugin.execute.return_value = []

--- a/posit-bakery/test/cli/test_dev_stream_deprecated.py
+++ b/posit-bakery/test/cli/test_dev_stream_deprecated.py
@@ -195,7 +195,8 @@ class TestRunDgossDevStreamDeprecation:
         with patch("posit_bakery.cli.run.BakeryConfig") as mock_config:
             instance = MagicMock()
             instance.base_path = Path(BASIC_CONTEXT)
-            instance.targets = []
+            # Non-empty so the zero-match guard does not abort the happy-path runs.
+            instance.targets = [MagicMock()]
             mock_config.from_context.return_value = instance
             with patch("posit_bakery.cli.run.get_plugin") as mock_plugin:
                 mock_dgoss = MagicMock()

--- a/posit-bakery/test/cli/test_run_dgoss.py
+++ b/posit-bakery/test/cli/test_run_dgoss.py
@@ -25,7 +25,8 @@ def mocked_bakery_run_dgoss():
     with patch("posit_bakery.cli.run.BakeryConfig") as mock_config:
         instance = MagicMock()
         instance.base_path = Path(BASIC_CONTEXT)
-        instance.targets = []
+        # Non-empty so the zero-match guard does not abort the happy-path runs.
+        instance.targets = [MagicMock()]
         mock_config.from_context.return_value = instance
         with patch("posit_bakery.cli.run.get_plugin") as mock_get_plugin:
             mock_plugin = MagicMock()
@@ -75,6 +76,28 @@ class TestRunDgossDeprecationWarning:
         assert "deprecated" in combined.lower()
         assert "bakery dgoss run" in combined
         assert "removed" in combined.lower()
+
+
+class TestRunDgossZeroMatchGuard:
+    """The deprecated path must also fail loudly when no targets match."""
+
+    def test_no_targets_exits_nonzero(self):
+        with patch("posit_bakery.cli.run.BakeryConfig") as mock_config:
+            instance = MagicMock()
+            instance.base_path = Path(BASIC_CONTEXT)
+            instance.targets = []
+            mock_config.from_context.return_value = instance
+            with patch("posit_bakery.cli.run.get_plugin") as mock_get_plugin:
+                mock_plugin = MagicMock()
+                mock_get_plugin.return_value = mock_plugin
+                result = runner.invoke(
+                    app,
+                    ["run", "dgoss", "--context", BASIC_CONTEXT, "--image-version", "9999.99.99"],
+                    catch_exceptions=False,
+                )
+        assert result.exit_code == 1
+        assert "No image targets" in result.output
+        mock_plugin.execute.assert_not_called()
 
 
 class TestRunDgossLatestFlag:

--- a/posit-bakery/test/plugins/builtin/dgoss/test_init.py
+++ b/posit-bakery/test/plugins/builtin/dgoss/test_init.py
@@ -90,6 +90,28 @@ class TestDgossRunLatestFlag:
         assert settings.latest is False
 
 
+class TestDgossRunImageVersionFilter:
+    """Regression coverage: `--image-version` must reach the filter verbatim.
+
+    ``BakeryConfigFilter.image_version`` is consumed by ``version_matches()``,
+    which does segment-aware (not regex) matching, so the value must NOT be
+    regex-escaped. Escaping a calver build string like ``2026.01.2+418.pro1``
+    into ``2026\\.01\\.2\\+418\\.pro1`` made the filter match no versions, so
+    `dgoss run` silently tested nothing and the CI workflow passed."""
+
+    def test_image_version_passed_verbatim(self, mocked_dgoss_run):
+        mock_config, _ = mocked_dgoss_run
+        version = "2026.01.2+418.pro1"
+        result = runner.invoke(
+            app,
+            ["dgoss", "run", "--context", BASIC_CONTEXT, "--image-version", version],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.stdout
+        settings = mock_config.from_context.call_args[0][1]
+        assert settings.filter.image_version == version
+
+
 class TestDgossRunJobsFlag:
     """The --jobs flag is forwarded to DGossPlugin.execute()."""
 

--- a/posit-bakery/test/plugins/builtin/dgoss/test_init.py
+++ b/posit-bakery/test/plugins/builtin/dgoss/test_init.py
@@ -28,7 +28,8 @@ def mocked_dgoss_run():
     with patch("posit_bakery.plugins.builtin.dgoss.BakeryConfig") as mock_config:
         instance = MagicMock()
         instance.base_path = Path(BASIC_CONTEXT)
-        instance.targets = []
+        # Non-empty so the zero-match guard does not abort the happy-path runs.
+        instance.targets = [MagicMock()]
         mock_config.from_context.return_value = instance
         with (
             patch("posit_bakery.plugins.builtin.dgoss.DGossPlugin.execute") as mock_execute,
@@ -110,6 +111,30 @@ class TestDgossRunImageVersionFilter:
         assert result.exit_code == 0, result.stdout
         settings = mock_config.from_context.call_args[0][1]
         assert settings.filter.image_version == version
+
+
+class TestDgossRunZeroMatchGuard:
+    """A filter that matches no targets must fail loudly, not silently pass.
+
+    Before the guard, `dgoss run` with a non-matching filter exited 0 having
+    tested nothing, hiding broken CI jobs."""
+
+    def test_no_targets_exits_nonzero(self):
+        with patch("posit_bakery.plugins.builtin.dgoss.BakeryConfig") as mock_config:
+            instance = MagicMock()
+            instance.base_path = Path(BASIC_CONTEXT)
+            instance.targets = []
+            mock_config.from_context.return_value = instance
+            with patch("posit_bakery.plugins.builtin.dgoss.DGossPlugin.execute") as mock_execute:
+                result = runner.invoke(
+                    app,
+                    ["dgoss", "run", "--context", BASIC_CONTEXT, "--image-version", "9999.99.99"],
+                    catch_exceptions=False,
+                )
+        assert result.exit_code == 1
+        assert "No image targets" in result.output
+        assert "9999.99.99" in result.output
+        mock_execute.assert_not_called()
 
 
 class TestDgossRunJobsFlag:

--- a/posit-bakery/test/plugins/builtin/hadolint/test_init.py
+++ b/posit-bakery/test/plugins/builtin/hadolint/test_init.py
@@ -30,7 +30,8 @@ def mocked_hadolint_run():
     with patch("posit_bakery.plugins.builtin.hadolint.BakeryConfig") as mock_config:
         instance = MagicMock()
         instance.base_path = Path(BASIC_CONTEXT)
-        instance.targets = []
+        # Non-empty so the zero-match guard does not abort the happy-path runs.
+        instance.targets = [MagicMock()]
         mock_config.from_context.return_value = instance
         with (
             patch("posit_bakery.plugins.builtin.hadolint.HadolintPlugin.execute") as mock_execute,
@@ -38,6 +39,27 @@ def mocked_hadolint_run():
         ):
             mock_execute.return_value = []
             yield mock_config, mock_execute
+
+
+class TestHadolintRunZeroMatchGuard:
+    """A filter that matches no targets must fail loudly, not silently pass."""
+
+    def test_no_targets_exits_nonzero(self):
+        with patch("posit_bakery.plugins.builtin.hadolint.BakeryConfig") as mock_config:
+            instance = MagicMock()
+            instance.base_path = Path(BASIC_CONTEXT)
+            instance.targets = []
+            mock_config.from_context.return_value = instance
+            with patch("posit_bakery.plugins.builtin.hadolint.HadolintPlugin.execute") as mock_execute:
+                result = runner.invoke(
+                    app,
+                    ["hadolint", "run", "--context", BASIC_CONTEXT, "--image-version", "9999.99.99"],
+                    catch_exceptions=False,
+                )
+        assert result.exit_code == 1
+        assert "No image targets" in result.output
+        assert "9999.99.99" in result.output
+        mock_execute.assert_not_called()
 
 
 class TestHadolintRunLatestFlag:

--- a/posit-bakery/test/plugins/builtin/wizcli/test_init.py
+++ b/posit-bakery/test/plugins/builtin/wizcli/test_init.py
@@ -30,7 +30,8 @@ def mocked_wizcli_scan():
     with patch("posit_bakery.plugins.builtin.wizcli.BakeryConfig") as mock_config:
         instance = MagicMock()
         instance.base_path = Path(BASIC_CONTEXT)
-        instance.targets = []
+        # Non-empty so the zero-match guard does not abort the happy-path runs.
+        instance.targets = [MagicMock()]
         mock_config.from_context.return_value = instance
         with (
             patch("posit_bakery.plugins.builtin.wizcli.WizCLIPlugin.execute") as mock_execute,
@@ -38,6 +39,27 @@ def mocked_wizcli_scan():
         ):
             mock_execute.return_value = []
             yield mock_config, mock_execute
+
+
+class TestWizcliScanZeroMatchGuard:
+    """A filter that matches no targets must fail loudly, not silently pass."""
+
+    def test_no_targets_exits_nonzero(self):
+        with patch("posit_bakery.plugins.builtin.wizcli.BakeryConfig") as mock_config:
+            instance = MagicMock()
+            instance.base_path = Path(BASIC_CONTEXT)
+            instance.targets = []
+            mock_config.from_context.return_value = instance
+            with patch("posit_bakery.plugins.builtin.wizcli.WizCLIPlugin.execute") as mock_execute:
+                result = runner.invoke(
+                    app,
+                    ["wizcli", "scan", "--context", BASIC_CONTEXT, "--image-version", "9999.99.99"],
+                    catch_exceptions=False,
+                )
+        assert result.exit_code == 1
+        assert "No image targets" in result.output
+        assert "9999.99.99" in result.output
+        mock_execute.assert_not_called()
 
 
 class TestWizcliScanLatestFlag:


### PR DESCRIPTION
Fixes #611

## Summary

CI workflows were silently passing during `bakery dgoss run` while testing nothing, accompanied by warnings like:

```
WARNING  Unparseable version string: '2026\.01\.2\+418\.pro1'   parsed_version.py:84
```

This PR fixes the root cause and adds a guard so the failure can never be silent again.

### Root cause

Commit `50575feb` migrated version filtering from `re.search()` (which needed `re.escape()` on the filter) to segment-aware `version_matches()`, and updated the CLI call sites — but missed the `dgoss`, `hadolint`, and `wizcli` plugins. They still called `re.escape(image_version)`, mangling `2026.01.2+418.pro1` into `2026\.01\.2\+418\.pro1`. That failed to parse and failed the fallback comparison → zero targets matched → `dgoss run` tested nothing and exited 0.

### Changes

- **Remove `re.escape()`** from the `image_version` filter in the dgoss, hadolint, and wizcli plugins (and the now-unused `import re`), matching how the CLI commands already pass it through verbatim.
- **Add a shared `exit_if_no_targets()` guard** (`cli/common.py`) that aborts with a non-zero exit code, echoing the active filters, when filters resolve to zero image targets. Wired into `build`, `dgoss run` (+ deprecated `run dgoss`), `hadolint run`, and `wizcli scan`.

### Testing

- New regression test asserting `--image-version` reaches the filter unescaped.
- New zero-match guard tests for every affected command (exit 1, helpful message, execute/build never called).
- All affected suites pass with `-n auto`; ruff clean; verified end-to-end against the `basic` resource context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)