### PR TITLE
fix: default `metadata_file` to None for serial builds

### DIFF
--- a/posit-bakery/posit_bakery/config/config.py
+++ b/posit-bakery/posit_bakery/config/config.py
@@ -1179,7 +1179,7 @@ class BakeryConfig:
                             pull=pull,
                             cache=cache,
                             platforms=platforms,
-                            metadata_file=True if metadata_file else False,
+                            metadata_file=True if metadata_file else None,
                         ),
                         retry=retry,
                         label=str(target),


### PR DESCRIPTION
Fixes an issue where build metadata on `--strategy build` would automatically be automatically written to a file named "False".