### PR TITLE
Seed CDN cache from matrix job into build jobs

### DIFF
--- a/.github/workflows/bakery-build-native.yml
+++ b/.github/workflows/bakery-build-native.yml
@@ -188,6 +188,13 @@ jobs:
           echo "platform_matrix=$(echo "$result" | jq --compact-output .)" >> "$GITHUB_OUTPUT"
           echo "image_matrix=$(echo "$result" | jq --compact-output '[.[].image] | unique')" >> "$GITHUB_OUTPUT"
 
+      - name: Upload CDN cache
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: bakery-cdn-cache
+          path: /tmp/bakery_cache/
+          if-no-files-found: ignore
+
   build-test:
     name: "Build/Test ${{ matrix.img.image }}:${{ matrix.img.version }} (${{ matrix.img.platform }})"
     permissions:
@@ -294,6 +301,12 @@ jobs:
           else
             echo "dev-spec=" >> "$GITHUB_OUTPUT"
           fi
+      - name: Restore CDN cache
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: bakery-cdn-cache
+          path: /tmp/bakery_cache/
       - name: Build
         env:
           GIT_SHA: ${{ github.sha }}
@@ -473,6 +486,13 @@ jobs:
           else
             echo "dev-spec=" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Restore CDN cache
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: bakery-cdn-cache
+          path: /tmp/bakery_cache/
 
       - name: Publish
         env:

--- a/.github/workflows/bakery-build-pr.yml
+++ b/.github/workflows/bakery-build-pr.yml
@@ -121,6 +121,13 @@ jobs:
           result=$(bakery ci matrix --quiet --dev-versions "$DEV_VERSIONS" --matrix-versions "$MATRIX_VERSIONS" --exclude platform --context "$BAKERY_CONTEXT")
           echo "versions_matrix=$(echo "$result" | jq --compact-output .)" >> "$GITHUB_OUTPUT"
 
+      - name: Upload CDN cache
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: bakery-cdn-cache
+          path: /tmp/bakery_cache/
+          if-no-files-found: ignore
+
   build-test:
     name: "Build/Test ${{ matrix.img.image }}:${{ matrix.img.version }} (${{ matrix.img.platform }})"
     needs:
@@ -179,6 +186,13 @@ jobs:
         run: |
           PLATFORM=${BUILD_PLATFORM#linux/}
           echo "platform=$PLATFORM" >> "$GITHUB_OUTPUT"
+
+      - name: Restore CDN cache
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: bakery-cdn-cache
+          path: /tmp/bakery_cache/
 
       - name: Build
         env:


### PR DESCRIPTION
The matrix step resolves dev versions from the CDN and outputs them as a build matrix. Each subsequent job runs on a fresh runner and re-queries the CDN independently. If the daily CDN updates between the matrix step and a build or merge step, the resolved version changes and the `--image-version` filter no longer matches any target, producing a "no targets" failure.

Fix this by uploading the populated `requests-cache` filesystem cache (`/tmp/bakery_cache/`) as a run-scoped artifact after the matrix step, then restoring it before each `bakery build` and `bakery ci publish` invocation. The cache keys are deterministic (blake2b of the normalized request URL), so the pre-seeded responses are found by lookup without any code changes to bakery itself. The restore step uses `continue-on-error` so runs that build no dev versions (empty cache) degrade gracefully.

Closes #304