### PR TITLE
Add 7-day Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       - "/setup-*"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     groups:
       actions:
         patterns:


### PR DESCRIPTION
Add a 7-day cooldown to the Dependabot GitHub Actions update config. This prevents Dependabot from immediately pulling newly released dependency versions, reducing supply-chain risk from opportunistic package compromises and stability risk from regressions in new releases.