### PR TITLE
Add reusable checks.yml (pre-commit, zizmor, lychee)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,23 +3,18 @@ name: Checks
 on:
   workflow_call:
     inputs:
-      pre-commit-run:
-        description: "Run the pre-commit job"
-        default: true
+      lychee-args:
+        description: "Arguments passed to lychee. The default **/*.*md glob matches both Markdown (.md) and Quarto (.qmd) files."
+        default: "--cache --no-progress --max-cache-age 1d **/*.*md"
         required: false
-        type: boolean
+        type: string
       lychee-run:
         description: "Run the lychee link-check job"
         default: true
         required: false
         type: boolean
-      zizmor-advanced-security:
-        description: "Upload zizmor results to GitHub Advanced Security. Requires security-events: write on the caller. Set to false for repos without GHAS."
-        default: true
-        required: false
-        type: boolean
-      zizmor-run:
-        description: "Run the zizmor job"
+      pre-commit-run:
+        description: "Run the pre-commit job"
         default: true
         required: false
         type: boolean
@@ -33,11 +28,16 @@ on:
         default: ""
         required: false
         type: string
-      lychee-args:
-        description: "Arguments passed to lychee. The default **/*.*md glob matches both Markdown (.md) and Quarto (.qmd) files."
-        default: "--cache --no-progress --max-cache-age 1d **/*.*md"
+      zizmor-advanced-security:
+        description: "Upload zizmor results to GitHub Advanced Security. Requires security-events: write on the caller. Set to false for repos without GHAS."
+        default: true
         required: false
-        type: string
+        type: boolean
+      zizmor-run:
+        description: "Run the zizmor job"
+        default: true
+        required: false
+        type: boolean
 
 defaults:
   run:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -74,7 +74,15 @@ jobs:
         with:
           python-version-file: ${{ inputs.python-version-file }}
 
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+
+      - name: Run pre-commit
+        run: |
+          pip install pre-commit
+          pre-commit run --show-diff-on-failure --color=always --all-files
         env:
           SKIP: no-commit-to-branch
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,6 +13,11 @@ on:
         default: true
         required: false
         type: boolean
+      zizmor-advanced-security:
+        description: "Upload zizmor results to GitHub Advanced Security. Requires security-events: write on the caller. Set to false for repos without GHAS."
+        default: true
+        required: false
+        type: boolean
       run-lychee:
         description: "Run the lychee link-check job"
         default: true
@@ -86,6 +91,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d  # v0.5.6
+        with:
+          advanced-security: ${{ inputs.zizmor-advanced-security }}
 
   lychee:
     name: Lychee

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -29,8 +29,8 @@ on:
         required: false
         type: string
       lychee-args:
-        description: "Arguments passed to lychee"
-        default: "--cache --no-progress --max-cache-age 1d **/*.md"
+        description: "Arguments passed to lychee. The default **/*.*md glob matches both Markdown (.md) and Quarto (.qmd) files."
+        default: "--cache --no-progress --max-cache-age 1d **/*.*md"
         required: false
         type: string
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,115 @@
+name: Checks
+
+on:
+  workflow_call:
+    inputs:
+      run-pre-commit:
+        description: "Run the pre-commit job"
+        default: true
+        required: false
+        type: boolean
+      run-zizmor:
+        description: "Run the zizmor job"
+        default: true
+        required: false
+        type: boolean
+      run-lychee:
+        description: "Run the lychee link-check job"
+        default: true
+        required: false
+        type: boolean
+      python-version:
+        description: "Python version for pre-commit (used when python-version-file is empty)"
+        default: "3.x"
+        required: false
+        type: string
+      python-version-file:
+        description: "Path to a file specifying the Python version (takes precedence over python-version)"
+        default: ""
+        required: false
+        type: string
+      lychee-args:
+        description: "Arguments passed to lychee"
+        default: "--cache --no-progress --max-cache-age 1d **/*.md"
+        required: false
+        type: string
+
+defaults:
+  run:
+    shell: bash
+
+# Security policy: No ${{ }} expressions in `run:` blocks. All expression values
+# are assigned to `env:` and referenced as shell variables. This keeps the rule
+# enforceable by zizmor without per-expression exceptions.
+
+jobs:
+  pre-commit:
+    name: Pre-commit
+    if: inputs.run-pre-commit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      # Two conditional setup-python steps avoid the python-version vs
+      # python-version-file precedence ambiguity: pass exactly one input.
+      - name: Set up Python (version)
+        if: inputs.python-version-file == ''
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Set up Python (version file)
+        if: inputs.python-version-file != ''
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version-file: ${{ inputs.python-version-file }}
+
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
+        env:
+          SKIP: no-commit-to-branch
+
+  zizmor:
+    name: Zizmor
+    if: inputs.run-zizmor
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d  # v0.5.6
+
+  lychee:
+    name: Lychee
+    if: inputs.run-lychee
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Restore lychee cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ github.sha }}
+          restore-keys: cache-lychee-
+
+      - name: Check links
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411  # v2.8.0
+        with:
+          args: ${{ inputs.lychee-args }}
+          fail: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -74,15 +74,17 @@ jobs:
         with:
           python-version-file: ${{ inputs.python-version-file }}
 
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          enable-cache: false
+
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
 
       - name: Run pre-commit
-        run: |
-          pip install pre-commit
-          pre-commit run --show-diff-on-failure --color=always --all-files
+        run: uvx pre-commit run --show-diff-on-failure --color=always --all-files
         env:
           SKIP: no-commit-to-branch
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,13 +3,13 @@ name: Checks
 on:
   workflow_call:
     inputs:
-      run-pre-commit:
+      pre-commit-run:
         description: "Run the pre-commit job"
         default: true
         required: false
         type: boolean
-      run-zizmor:
-        description: "Run the zizmor job"
+      lychee-run:
+        description: "Run the lychee link-check job"
         default: true
         required: false
         type: boolean
@@ -18,8 +18,8 @@ on:
         default: true
         required: false
         type: boolean
-      run-lychee:
-        description: "Run the lychee link-check job"
+      zizmor-run:
+        description: "Run the zizmor job"
         default: true
         required: false
         type: boolean
@@ -50,7 +50,7 @@ defaults:
 jobs:
   pre-commit:
     name: Pre-commit
-    if: inputs.run-pre-commit
+    if: inputs.pre-commit-run
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -80,7 +80,7 @@ jobs:
 
   zizmor:
     name: Zizmor
-    if: inputs.run-zizmor
+    if: inputs.zizmor-run
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -96,7 +96,7 @@ jobs:
 
   lychee:
     name: Lychee
-    if: inputs.run-lychee
+    if: inputs.lychee-run
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,38 +25,29 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs:
-      - lint
+      - checks
       - test
       - bakery
       - bakery-native
       - bakery-pr
       - release
       - pypi-publish
-      - zizmor
 
     steps:
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe  # v1.2.2
         with:
-          allowed-skips: bakery-pr, lint, pypi-publish
+          allowed-skips: bakery-pr, checks, pypi-publish
           jobs: ${{ toJSON(needs) }}
 
-  lint:
-    name: Lint
+  checks:
+    name: Checks
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
     permissions:
       contents: read
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version-file: posit-bakery/pyproject.toml
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
-        env:
-          SKIP: no-commit-to-branch
+      security-events: write
+    uses: ./.github/workflows/checks.yml
+    with:
+      python-version-file: posit-bakery/pyproject.toml
 
   test:
     name: Test
@@ -179,18 +170,6 @@ jobs:
       version: ${{ github.head_ref || github.ref_name }}
       context: "./posit-bakery/test/resources/multiplatform/"
       dev-versions: include
-
-  zizmor:
-    name: Zizmor
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      security-events: write
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
-      - uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d  # v0.5.6
 
   with-macros-clean-caches:
     name: Clean Caches (with-macros suite)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
     uses: ./.github/workflows/checks.yml
     with:
       python-version-file: posit-bakery/pyproject.toml
+      # Check Markdown and Quarto docs; presentations are dated decks, not maintained docs.
+      lychee-args: "--cache --no-progress --max-cache-age 1d --exclude-path presentations **/*.*md"
 
   test:
     name: Test

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -6,6 +6,9 @@ https://packagemanager.posit.co
 https://p3m.dev
 https://twitter.com
 
+# Bare directory paths that 404 (no index served)
+https://dl.posit.co/public/open/
+
 # Private Posit/RStudio source repos (return 404 to unauthenticated link checks)
 https://github.com/posit-dev/connect/
 https://github.com/rstudio/package-manager/

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,12 @@
+# Hosts that rate-limit, require auth, or otherwise false-positive.
+# One regex per line (matched against each URL). Extend as real failures surface.
+https://example.com
+https://support.posit.co
+https://packagemanager.posit.co
+https://p3m.dev
+https://twitter.com
+
+# Private Posit/RStudio source repos (return 404 to unauthenticated link checks)
+https://github.com/posit-dev/connect/
+https://github.com/rstudio/package-manager/
+https://github.com/rstudio/rstudio-pro/

--- a/justfile
+++ b/justfile
@@ -33,4 +33,4 @@ _setup-pre-commit:
 # Check links in markdown with lychee
 check-links:
     docker run --rm -w /input -v "{{ CWD }}":/input:ro \
-      lycheeverse/lychee --no-progress '**/*.md'
+      lycheeverse/lychee --no-progress --exclude-path presentations '**/*.*md'

--- a/justfile
+++ b/justfile
@@ -26,3 +26,11 @@ _python-executable executable:
 _setup-pre-commit:
     pre-commit --version || just _python-executable pre-commit
     pre-commit install --install-hooks
+
+################
+# Linting
+
+# Check links in markdown with lychee
+check-links:
+    docker run --rm -w /input -v "{{ CWD }}":/input:ro \
+      lycheeverse/lychee --no-progress '**/*.md'


### PR DESCRIPTION
Extracts the inline `lint` and `zizmor` jobs from `ci.yml` into a new
reusable `checks.yml` workflow, adds lychee link checking, and wires
`ci.yml` up as the first caller.

Sibling repos can adopt `checks.yml` to get pre-commit, zizmor, and
link checking without duplicating the job definitions.

## What changed

- `checks.yml` — new reusable workflow with three independently
  toggleable jobs: `pre-commit`, `zizmor`, `lychee`. All inputs follow
  the `{tool}-{option}` naming convention (`lychee-args`, `lychee-run`,
  `zizmor-advanced-security`, `zizmor-run`, `pre-commit-run`,
  `python-version`, `python-version-file`).
- `ci.yml` — replaces the inline `lint` + `zizmor` jobs with a single
  `checks` caller.
- `.lycheeignore` — excludes rate-limited, auth-gated, and private hosts
  from link checks.
- `justfile` — adds a `check-links` recipe for local use.

## Notes

- `pre-commit/action` is replaced with a direct `uvx pre-commit` invocation.
  The composite action internally uses `actions/cache@v4` (floating tag),
  which fails the org's transitive SHA-pin policy.
- `zizmor-advanced-security` defaults to `true`. Repos without GitHub
  Advanced Security should set it to `false` and omit
  `security-events: write` from their caller permissions.
- Lychee runs only on `pull_request` and `merge_group` events (same as
  pre-commit). Link checks on push-to-main would be redundant.