### PR TITLE
Set CI=true for Quarto TinyTeX install command

### DIFF
--- a/posit-bakery/posit_bakery/config/templating/macros/quarto.j2
+++ b/posit-bakery/posit_bakery/config/templating/macros/quarto.j2
@@ -48,12 +48,19 @@ backward compatibility but is ignored.
 
 {# Command to install TinyTeX using the Quarto CLI
 
+`CI=true` is set inline so Quarto's `runningInCI()` check passes inside
+container builds. When it passes, Quarto collapses its TinyTeX download
+progress bar to a single line; otherwise it renders an animated progress bar
+that, written to a non-TTY build log, emits tens of thousands of redundant
+lines (one per download tick). The variable is scoped to this command only, so
+it does not leak into the built image.
+
 :param quarto_binary: The path to the Quarto binary.
 :param update_path: Adds --update-path to the command to add TinyTeX binaries to the PATH. Defaults to False.
 :param home_path: An optional path to set the HOME environment variable for the command, which controls where TinyTeX is installed. If not provided, TinyTeX will be installed to the default location under the current user's home directory.
 #}
 {% macro install_tinytex_command(quarto_binary, update_path = False, home_path = None) -%}
-GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" {% if home_path %}HOME="{{ home_path }}" {% endif %}{{ quarto_binary }} install tinytex --no-prompt{% if update_path %} --update-path{% endif %}
+GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" {% if home_path %}HOME="{{ home_path }}" {% endif %}CI=true {{ quarto_binary }} install tinytex --no-prompt{% if update_path %} --update-path{% endif %}
 {%- endmacro %}
 
 {# Command to install a specific version of Quarto from the Posit Open

--- a/posit-bakery/test/config/templating/test_macros.py
+++ b/posit-bakery/test/config/templating/test_macros.py
@@ -1940,25 +1940,25 @@ class TestQuartoMacros:
             pytest.param(
                 True,
                 None,
-                'GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --update-path',
+                'GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" CI=true /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --update-path',
                 id="with-update-path",
             ),
             pytest.param(
                 False,
                 None,
-                'GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt',
+                'GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" CI=true /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt',
                 id="without-update-path",
             ),
             pytest.param(
                 False,
                 "/root",
-                'GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt',
+                'GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" CI=true /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt',
                 id="with-home-path",
             ),
             pytest.param(
                 True,
                 "/root",
-                'GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --update-path',
+                'GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" CI=true /opt/quarto/1.8.24/bin/quarto install tinytex --no-prompt --update-path',
                 id="with-home-path-and-update-path",
             ),
         ],
@@ -2018,7 +2018,7 @@ class TestQuartoMacros:
                     apt-mark hold quarto && \\
                     apt-get clean -yqq && \\
                     rm -rf /var/lib/apt/lists/* && \\
-                    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/bin/quarto install tinytex --no-prompt"""
+                    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" CI=true /opt/quarto/bin/quarto install tinytex --no-prompt"""
                 ),
                 id="with-tinytex",
             ),
@@ -2035,7 +2035,7 @@ class TestQuartoMacros:
                     apt-mark hold quarto && \\
                     apt-get clean -yqq && \\
                     rm -rf /var/lib/apt/lists/* && \\
-                    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path"""
+                    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" CI=true /opt/quarto/bin/quarto install tinytex --no-prompt --update-path"""
                 ),
                 id="with-tinytex-update-path",
             ),
@@ -2052,7 +2052,7 @@ class TestQuartoMacros:
                     apt-mark hold quarto && \\
                     apt-get clean -yqq && \\
                     rm -rf /var/lib/apt/lists/* && \\
-                    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/bin/quarto install tinytex --no-prompt"""
+                    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" CI=true /opt/quarto/bin/quarto install tinytex --no-prompt"""
                 ),
                 id="with-tinytex-home-path",
             ),
@@ -2069,7 +2069,7 @@ class TestQuartoMacros:
                     apt-mark hold quarto && \\
                     apt-get clean -yqq && \\
                     rm -rf /var/lib/apt/lists/* && \\
-                    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path"""
+                    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" CI=true /opt/quarto/bin/quarto install tinytex --no-prompt --update-path"""
                 ),
                 id="with-tinytex-home-path-update-path",
             ),
@@ -2122,7 +2122,7 @@ class TestQuartoMacros:
                 xz && \\
             dnf versionlock add quarto && \\
             dnf clean all -yq && \\
-            GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/bin/quarto install tinytex --no-prompt"""
+            GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" CI=true /opt/quarto/bin/quarto install tinytex --no-prompt"""
         )
         rendered = environment_with_macros.from_string(template).render()
         assert rendered == expected
@@ -2163,7 +2163,7 @@ class TestQuartoMacros:
                         apt-mark hold quarto && \\
                         apt-get clean -yqq && \\
                         rm -rf /var/lib/apt/lists/* && \\
-                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/bin/quarto install tinytex --no-prompt"""
+                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" CI=true /opt/quarto/bin/quarto install tinytex --no-prompt"""
                 ),
                 id="single-version-with-tinytex",
             ),
@@ -2178,7 +2178,7 @@ class TestQuartoMacros:
                         apt-mark hold quarto && \\
                         apt-get clean -yqq && \\
                         rm -rf /var/lib/apt/lists/* && \\
-                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path"""
+                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" CI=true /opt/quarto/bin/quarto install tinytex --no-prompt --update-path"""
                 ),
                 id="single-version-with-tinytex-update-path",
             ),
@@ -2193,7 +2193,7 @@ class TestQuartoMacros:
                         apt-mark hold quarto && \\
                         apt-get clean -yqq && \\
                         rm -rf /var/lib/apt/lists/* && \\
-                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/bin/quarto install tinytex --no-prompt"""
+                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" CI=true /opt/quarto/bin/quarto install tinytex --no-prompt"""
                 ),
                 id="single-version-with-tinytex-home-path",
             ),
@@ -2208,7 +2208,7 @@ class TestQuartoMacros:
                         apt-mark hold quarto && \\
                         apt-get clean -yqq && \\
                         rm -rf /var/lib/apt/lists/* && \\
-                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path"""
+                        GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/root" CI=true /opt/quarto/bin/quarto install tinytex --no-prompt --update-path"""
                 ),
                 id="single-version-with-tinytex-home-path-update-path",
             ),

--- a/posit-bakery/test/config/test_config.py
+++ b/posit-bakery/test/config/test_config.py
@@ -1406,7 +1406,7 @@ class TestBakeryConfig:
                 apt-mark hold quarto && \\
                 apt-get clean -yqq && \\
                 rm -rf /var/lib/apt/lists/* && \\
-                GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/bin/quarto install tinytex --no-prompt
+                GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" CI=true /opt/quarto/bin/quarto install tinytex --no-prompt
         """)
         assert (
             expected_std_containerfile

--- a/posit-bakery/test/resources/matrix/test-matrix/matrix/Containerfile.ubuntu2404
+++ b/posit-bakery/test/resources/matrix/test-matrix/matrix/Containerfile.ubuntu2404
@@ -57,4 +57,4 @@ RUN --mount=type=secret,id=github_token,required=false bash -c "$(curl -1fsSL 'h
     apt-mark hold quarto && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/* && \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/bin/quarto install tinytex --no-prompt
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" CI=true /opt/quarto/bin/quarto install tinytex --no-prompt

--- a/posit-bakery/test/resources/with-macros/test-image/1.0.0/Containerfile.ubuntu2204.std
+++ b/posit-bakery/test/resources/with-macros/test-image/1.0.0/Containerfile.ubuntu2204.std
@@ -59,4 +59,4 @@ RUN --mount=type=secret,id=github_token,required=false bash -c "$(curl -1fsSL 'h
     apt-mark hold quarto && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/* && \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" /opt/quarto/bin/quarto install tinytex --no-prompt
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" CI=true /opt/quarto/bin/quarto install tinytex --no-prompt


### PR DESCRIPTION
Quarto renders an animated TinyTeX download progress bar unless its `runningInCI()` check passes. That check only reads environment variables (`CI`, `GITHUB_ACTIONS`, etc.), none of which propagate into a `docker build` RUN step — so inside container builds Quarto thinks it is interactive and redraws the progress bar on every download tick.

In a non-TTY build log each redraw becomes its own line. One observed Workbench dev build emitted ~26,000 of them (~5 MB, 68% of the log), which slows the build and bloats CI logs.

Setting `CI=true` inline on the install command makes `runningInCI()` pass, so Quarto collapses the progress bar to a single line. Unlike re-adding `--quiet` (removed in 51c7fc66 so install errors stay visible), this keeps all error output, and the variable is scoped to the command so it does not leak into the built image.