### PR TITLE
Print Docker stderr in dgoss error output

### DIFF
--- a/posit-bakery/posit_bakery/plugins/builtin/dgoss/errors.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/dgoss/errors.py
@@ -33,7 +33,7 @@ class BakeryDGossError(BakeryToolRuntimeError):
         stdout_dump = self.dump_stdout()
         if stdout_dump:
             s += f"  - Command output:\n{textwrap.indent(stdout_dump, '      ')}\n"
-        stderr_dump = self.dump_stderr()
+        stderr_dump = self.dump_stderr(lines=50)
         if stderr_dump:
             s += f"  - Error output:\n{textwrap.indent(stderr_dump, '      ')}\n"
         s += f"  - Command executed: {' '.join(self.cmd)}\n"

--- a/posit-bakery/posit_bakery/plugins/builtin/dgoss/errors.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/dgoss/errors.py
@@ -30,7 +30,12 @@ class BakeryDGossError(BakeryToolRuntimeError):
     def __str__(self) -> str:
         s = f"{self.message}\n"
         s += f"  - Exit code: {self.exit_code}\n"
-        s += f"  - Command output: \n{textwrap.indent(self.dump_stdout(), '      ')}\n"
+        stdout_dump = self.dump_stdout()
+        if stdout_dump:
+            s += f"  - Command output:\n{textwrap.indent(stdout_dump, '      ')}\n"
+        stderr_dump = self.dump_stderr()
+        if stderr_dump:
+            s += f"  - Error output:\n{textwrap.indent(stderr_dump, '      ')}\n"
         s += f"  - Command executed: {' '.join(self.cmd)}\n"
         if self.metadata:
             s += "  - Metadata:\n"

--- a/posit-bakery/test/plugins/builtin/dgoss/test_suite.py
+++ b/posit-bakery/test/plugins/builtin/dgoss/test_suite.py
@@ -161,3 +161,27 @@ class TestDGossSuite:
         suite.run()
         assert captured["tasks"]
         assert all(t.timeout == 900 for t in captured["tasks"])  # default 900 from GossOptions
+
+
+class TestBakeryDGossError:
+    def test_str_includes_stderr_when_present(self):
+        err = BakeryDGossError(
+            message="dgoss execution failed for image 'test-image'",
+            tool_name="dgoss",
+            cmd=["dgoss", "run", "test-image"],
+            stdout=b"",
+            stderr=b"Error response from daemon: pull access denied",
+            exit_code=125,
+        )
+        assert "Error response from daemon" in str(err)
+
+    def test_str_omits_stderr_section_when_empty(self):
+        err = BakeryDGossError(
+            message="dgoss execution failed for image 'test-image'",
+            tool_name="dgoss",
+            cmd=["dgoss", "run", "test-image"],
+            stdout=b'{"summary": {}}',
+            stderr=b"",
+            exit_code=1,
+        )
+        assert "Error output" not in str(err)


### PR DESCRIPTION
When Docker fails to start a container (exit 125 — failed pull, auth error, unreachable daemon), dgoss exits immediately with empty stdout. The existing code at `suite.py:134` already caught this case and attached `stderr` to the error, but `BakeryDGossError.__str__` only printed stdout — so the Docker error message was never shown.

Three commits:

- Print stderr in `BakeryDGossError.__str__`, guarded so empty streams produce no section header
- Suppress the misleading `Failed to decode JSON output` log when stdout is empty (the parse error is still recorded; only the log is suppressed)
- Raise the stderr dump limit from 10 to 50 lines, since Docker errors are now user-visible for the first time

Tested via: https://github.com/posit-dev/images-workbench/pull/150