### PR TITLE
Make change-aware PR builds honor the dev and matrix flags

### DIFF
--- a/.github/workflows/bakery-build-pr.yml
+++ b/.github/workflows/bakery-build-pr.yml
@@ -105,6 +105,8 @@ jobs:
           DEV_VERSIONS: ${{ inputs.dev-versions }}
           MATRIX_VERSIONS: ${{ inputs.matrix-versions }}
           BAKERY_CONTEXT: ${{ inputs.context }}
+          # PR-only: empty on merge_group/push/scheduled, which intentionally
+          # fall back to the full matrix. Do not wire in merge_group.base_sha.
           BASE_REF: ${{ github.event.pull_request.base.sha }}
         run: |
           BASE_FLAG=()
@@ -124,6 +126,8 @@ jobs:
           DEV_VERSIONS: ${{ inputs.dev-versions }}
           MATRIX_VERSIONS: ${{ inputs.matrix-versions }}
           BAKERY_CONTEXT: ${{ inputs.context }}
+          # PR-only: empty on merge_group/push/scheduled, which intentionally
+          # fall back to the full matrix. Do not wire in merge_group.base_sha.
           BASE_REF: ${{ github.event.pull_request.base.sha }}
         run: |
           BASE_FLAG=()

--- a/posit-bakery/posit_bakery/cli/ci.py
+++ b/posit-bakery/posit_bakery/cli/ci.py
@@ -41,11 +41,20 @@ class BakeryCIMatrixFieldEnum(str, Enum):
 def _resolve_changed_files(base_ref: str | None, changed_files_from: str | None, rebase_root: Path) -> list[str] | None:
     """Return the changed-file list for change-aware filtering, or None to disable it.
 
-    ``--changed-files-from`` takes precedence over ``--base-ref``. Git paths are
-    relative to the repo root; they are rebased onto ``rebase_root`` and paths
-    outside the root are dropped.
+    ``--changed-files-from`` takes precedence over ``--base-ref``, and the two use
+    different path conventions.
+
+    - ``--base-ref`` runs ``git diff`` (paths relative to the repo root), then
+      rebases them onto ``rebase_root`` (the bakery context) and drops paths outside
+      it.
+    - ``--changed-files-from`` paths are used verbatim and must already be relative
+      to the bakery context root. They are not rebased, so do not pipe raw
+      ``git diff --name-only`` output here unless the context is the repo root. Use
+      ``--base-ref`` when you have a git checkout.
     """
     if changed_files_from is not None:
+        if base_ref is not None:
+            log.warning("--base-ref is ignored because --changed-files-from is set.")
         if changed_files_from == "-":
             raw = sys.stdin.read()
         else:
@@ -169,8 +178,8 @@ def matrix(
         typer.Option(
             "--changed-files-from",
             show_default=False,
-            help="Read changed file paths (one per line; '-' for stdin) instead of running git diff. "
-            "Overrides --base-ref.",
+            help="Read changed file paths (one per line, '-' for stdin), relative to the "
+            "bakery context root, instead of running git diff. Overrides --base-ref.",
             rich_help_panel=RichHelpPanelEnum.FILTERS,
         ),
     ] = None,

--- a/posit-bakery/posit_bakery/cli/ci.py
+++ b/posit-bakery/posit_bakery/cli/ci.py
@@ -86,11 +86,16 @@ def _resolve_changed_files(base_ref: str | None, changed_files_from: str | None,
 
 
 def _version_selected(ver: ImageVersion, cs: ImageChangeSet) -> bool:
-    """Whether a candidate version is wanted by a change set."""
-    if getattr(ver, "isDevelopmentVersion", False):
+    """Whether a candidate version was touched by the change set.
+
+    Pure narrowing predicate. Type/channel eligibility (--dev-versions,
+    --matrix-versions, --dev-channel) is enforced separately by the caller via
+    matches_dev_filter, so this only answers "did the PR touch this version?".
+    """
+    if ver.isDevelopmentVersion:
         return cs.include_dev
-    if getattr(ver, "isMatrixVersion", False):
-        return cs.include_matrix_latest and bool(getattr(ver, "latest", False))
+    if ver.isMatrixVersion:
+        return cs.include_matrix_latest and ver.latest
     # Plain release version.
     return cs.include_all_release or ver.name in cs.versions
 
@@ -238,45 +243,35 @@ def matrix(
 
             entry = {"image": img.name}
 
-            if cs is not None:
-                # Change-aware: build candidates purely from this image's change set.
-                # _version_selected() gates each candidate by type (release / dev /
-                # matrix-latest), so the list only needs to *contain* each wanted
-                # version exactly once.
-                if cs.include_dev and dev_versions == DevVersionInclusionEnum.EXCLUDE:
-                    # Dev versions are not loaded under the EXCLUDE baseline; load them
-                    # now. (Under INCLUDE/ONLY, BakeryConfig already loaded them at
-                    # config time, so loading again would duplicate entries.)
-                    img.load_dev_versions()
-                versions = list(img.versions)
-                if img.matrix is not None:
-                    versions = versions + img.matrix.to_image_versions()
-            else:
-                # Full-matrix path (no change-awareness). Preserves the matrix+dev
-                # filtering fix (commit 92c72833 / generate_image_targets): when matrix
-                # versions are included, fold the already-loaded dev versions into the
-                # matrix product per the dev_versions setting so they survive the
-                # matches_dev_filter check below.
-                versions = list(img.versions)
-                if img.matrix is None and matrix_versions == MatrixVersionInclusionEnum.ONLY:
-                    continue
-                elif img.matrix is not None:
-                    if matrix_versions != MatrixVersionInclusionEnum.EXCLUDE:
-                        if dev_versions == DevVersionInclusionEnum.ONLY:
-                            pass  # img.versions has dev versions; matrix prod versions all fail the dev filter
-                        elif dev_versions == DevVersionInclusionEnum.INCLUDE:
-                            dev_versions_loaded = [v for v in img.versions if v.isDevelopmentVersion]
-                            versions = img.matrix.to_image_versions() + dev_versions_loaded
-                        else:
-                            versions = img.matrix.to_image_versions()
+            # Candidate versions honor --dev-versions / --matrix-versions identically
+            # whether or not change-aware filtering is active. Preserves the matrix+dev
+            # filtering fix (commit 92c72833 / generate_image_targets): when matrix
+            # versions are included, fold the already-loaded dev versions into the
+            # matrix product per the dev_versions setting so they survive the
+            # matches_dev_filter check below.
+            versions = list(img.versions)
+            if img.matrix is None and matrix_versions == MatrixVersionInclusionEnum.ONLY:
+                continue
+            elif img.matrix is not None:
+                if matrix_versions != MatrixVersionInclusionEnum.EXCLUDE:
+                    if dev_versions == DevVersionInclusionEnum.ONLY:
+                        pass  # img.versions has dev versions; matrix prod versions all fail the dev filter
+                    elif dev_versions == DevVersionInclusionEnum.INCLUDE:
+                        dev_versions_loaded = [v for v in img.versions if v.isDevelopmentVersion]
+                        versions = img.matrix.to_image_versions() + dev_versions_loaded
+                    else:
+                        versions = img.matrix.to_image_versions()
 
             for ver in versions:
+                # The caller's flags decide which kinds of version are eligible
+                # (release / dev / matrix), in both full and change-aware modes.
+                included, _ = ver.matches_dev_filter(dev_versions, dev_channel)
+                if not included:
+                    continue
+                # In change-aware mode the change set then narrows to the versions
+                # the PR actually touched. It only ever removes candidates.
                 if cs is not None and not _version_selected(ver, cs):
                     continue
-                if cs is None:
-                    included, _ = ver.matches_dev_filter(dev_versions, dev_channel)
-                    if not included:
-                        continue
                 if image_version is not None and not version_matches(ver.name, image_version):
                     continue
 

--- a/posit-bakery/test/cli/test_ci.py
+++ b/posit-bakery/test/cli/test_ci.py
@@ -160,70 +160,6 @@ def check_log_metadata_targets(bakery_command, datatable, ci_patched_merge_metho
         assert expected in calls
 
 
-class TestDevVersionDedup:
-    """Regression tests for Bug 1: dev versions must not appear twice in change-aware matrix output."""
-
-    def test_no_duplicate_dev_versions_with_dev_versions_exclude(self, mocker, resource_path, tmp_path):
-        """When --dev-versions exclude (default) and a template change triggers include_dev,
-        the matrix must contain each dev version exactly once.
-
-        load_dev_versions is monkeypatched to return one deterministic fake dev ImageVersion
-        so the test remains hermetic (no external HTTP calls).
-        """
-        # Stable fake dev version with a deterministic name.
-        fake_dev = ImageVersion(
-            name="2026.01.0-dev+1-gABC",
-            isDevelopmentVersion=True,
-            subpath="dev",
-            path=tmp_path,
-        )
-
-        def _patched_load_dev_versions(self_image):
-            """Append exactly one fake dev version, mimicking the real unconditional append."""
-            self_image.versions.append(fake_dev)
-
-        mocker.patch(
-            "posit_bakery.config.image.image.Image.load_dev_versions",
-            _patched_load_dev_versions,
-        )
-
-        # A template change for `app` sets include_dev=True on the change set.
-        changed_files_path = tmp_path / "changed.txt"
-        changed_files_path.write_text("app/template/Containerfile.ubuntu2204.jinja2\n")
-
-        from typer.testing import CliRunner
-        from posit_bakery.cli.main import app as bakery_app
-
-        runner = CliRunner()
-        result = runner.invoke(
-            bakery_app,
-            [
-                "ci",
-                "matrix",
-                "--quiet",
-                "--context",
-                str(resource_path / "changeset"),
-                "--changed-files-from",
-                str(changed_files_path),
-                # Default: --dev-versions exclude; do not pass it explicitly to
-                # verify the bug regression under the default baseline.
-            ],
-            catch_exceptions=True,
-            env={"TERM": "dumb", "NO_COLOR": "true"},
-        )
-
-        assert result.exit_code == 0, f"Command failed: {result.output}"
-        matrix = json.loads(result.stdout.strip())
-
-        dev_entries = [e for e in matrix if e.get("dev") is True]
-        dev_names = [e["version"] for e in dev_entries]
-
-        # The fake dev version must appear exactly once (Bug 1 regression).
-        assert dev_names.count("2026.01.0-dev+1-gABC") == 1, (
-            f"Expected dev version to appear exactly once, got: {dev_names}"
-        )
-
-
 def test_resolve_changed_files_warns_when_base_ref_also_given(tmp_path, caplog):
     """--changed-files-from overrides --base-ref; the override must not be silent.
 
@@ -244,6 +180,70 @@ def test_resolve_changed_files_warns_when_base_ref_also_given(tmp_path, caplog):
     assert any("--base-ref" in record.message and "ignored" in record.message.lower() for record in caplog.records), (
         f"expected a warning that --base-ref is ignored, got: {[r.message for r in caplog.records]}"
     )
+
+
+class TestChangeAwareFlagIntersection:
+    """Change-aware mode must still honor --dev-versions / --matrix-versions.
+
+    The change set narrows the per-caller selection; it must not override the
+    flags. Otherwise the production, development, and content PR jobs all build
+    the same set instead of their disjoint slices.
+    """
+
+    def _run(self, resource_path, changed_files_path, *extra_args):
+        from typer.testing import CliRunner
+        from posit_bakery.cli.main import app as bakery_app
+
+        runner = CliRunner()
+        result = runner.invoke(
+            bakery_app,
+            [
+                "ci",
+                "matrix",
+                "--quiet",
+                "--context",
+                str(resource_path / "changeset"),
+                "--changed-files-from",
+                str(changed_files_path),
+                *extra_args,
+            ],
+            catch_exceptions=True,
+            env={"TERM": "dumb", "NO_COLOR": "true"},
+        )
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        return json.loads(result.stdout.strip())
+
+    def test_matrix_only_skips_non_matrix_image(self, resource_path, tmp_path):
+        """A release-dir change under --matrix-versions only must skip the non-matrix
+        image entirely, instead of building it as if the flag were absent."""
+        changed = tmp_path / "changed.txt"
+        changed.write_text("app/1.0.0/Containerfile.ubuntu2204.std\n")
+
+        matrix = self._run(resource_path, changed, "--matrix-versions", "only")
+
+        assert matrix == [], f"expected the non-matrix image to be skipped, got: {matrix}"
+
+    def test_template_change_excluded_under_dev_versions_exclude(self, mocker, resource_path, tmp_path):
+        """A template-only change under --dev-versions exclude must build nothing: no
+        release version was touched and dev versions are excluded. (The development
+        job, with --dev-versions only, is what builds the dev versions.)"""
+        fake_dev = ImageVersion(
+            name="2026.01.0-dev+1-gABC",
+            isDevelopmentVersion=True,
+            subpath="dev",
+            path=tmp_path,
+        )
+        mocker.patch(
+            "posit_bakery.config.image.image.Image.load_dev_versions",
+            lambda self_image: self_image.versions.append(fake_dev),
+        )
+
+        changed = tmp_path / "changed.txt"
+        changed.write_text("app/template/Containerfile.ubuntu2204.jinja2\n")
+
+        matrix = self._run(resource_path, changed, "--dev-versions", "exclude")
+
+        assert matrix == [], f"expected an empty matrix under --dev-versions exclude, got: {matrix}"
 
 
 class TestVersionMatches:

--- a/posit-bakery/test/cli/test_ci.py
+++ b/posit-bakery/test/cli/test_ci.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import re
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -6,6 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 from pytest_bdd import scenarios, then, parsers, given
 
+from posit_bakery.cli.ci import _resolve_changed_files
 from posit_bakery.config.config import version_matches
 from posit_bakery.config.image.version import ImageVersion
 
@@ -220,6 +222,28 @@ class TestDevVersionDedup:
         assert dev_names.count("2026.01.0-dev+1-gABC") == 1, (
             f"Expected dev version to appear exactly once, got: {dev_names}"
         )
+
+
+def test_resolve_changed_files_warns_when_base_ref_also_given(tmp_path, caplog):
+    """--changed-files-from overrides --base-ref; the override must not be silent.
+
+    When both are supplied, --changed-files-from wins (its paths are used verbatim,
+    no git is run), and a warning announces that --base-ref is ignored.
+    """
+    changes = tmp_path / "changed.txt"
+    changes.write_text("app/template/Containerfile\n")
+
+    with caplog.at_level(logging.WARNING, logger="posit_bakery.cli.ci"):
+        result = _resolve_changed_files(
+            base_ref="origin/main",
+            changed_files_from=str(changes),
+            rebase_root=tmp_path,
+        )
+
+    assert result == ["app/template/Containerfile"]
+    assert any("--base-ref" in record.message and "ignored" in record.message.lower() for record in caplog.records), (
+        f"expected a warning that --base-ref is ignored, got: {[r.message for r in caplog.records]}"
+    )
 
 
 class TestVersionMatches:


### PR DESCRIPTION
Stacked on `feat/dynamic-pr-builds`.

Change-aware `bakery ci matrix` gated emission with `_version_selected` (no flag
args) and skipped `matches_dev_filter` whenever `--base-ref` /
`--changed-files-from` was set. So the per-job flags were ignored. The
production, development, and content PR jobs all call the workflow with
`--base-ref`, so they produced identical matrices and built overlapping sets.

In change-aware mode, before this:

| Flag combo | Before | Correct |
|---|---|---|
| `--dev-versions only` | also built touched release versions | dev only |
| `--matrix-versions exclude` | still built the matrix slice | no slice |
| `--matrix-versions only` | also built non-matrix images | matrix only |
| `--dev-channel <c>` | ignored, built every channel | that channel only |

The full-matrix path is untouched, so no-flag output stays byte-for-byte
identical. The change set now only narrows what the flags already select. Also
documents that `--changed-files-from` paths are context-root-relative (unlike
`--base-ref`) and warns when both are passed.

Dev-channel centralization and hermetic dev-emission coverage stack on top
separately.

- https://github.com/posit-dev/images-shared/pull/621
