### PR TITLE
Centralize effective_dev_channel for matrix and build paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,12 @@ only be used when there is a legitimate reason, such as:
 When a local import is used, add a comment explaining why it is local rather than at the
 top of the file.
 
+### Tests
+
+Build multi-line string literals in tests (e.g. inline `bakery.yaml` fixtures) with
+`textwrap.dedent("""\ ... """)`, not `"line\n" "line\n"` concatenation. Dedent is the
+established pattern across `test/`.
+
 ## CI/CD Architecture
 
 This repo provides shared reusable GitHub Actions workflows that all product image repos call:

--- a/posit-bakery/posit_bakery/cli/ci.py
+++ b/posit-bakery/posit_bakery/cli/ci.py
@@ -235,14 +235,6 @@ def matrix(
                     {name: vars(cs) for name, cs in selection.images.items()} or "no affected images",
                 )
 
-        # A --dev-spec carrying a channel implies the matrix should be filtered to that
-        # channel. The shared CI workflow folds the dispatched channel into the dev-spec
-        # and stops passing --dev-channel, so without this the other channels' dev versions
-        # would still be emitted (only the matching one gets its version pinned).
-        effective_dev_channel = settings.dev_channel
-        if effective_dev_channel is None and settings.dev_spec is not None:
-            effective_dev_channel = settings.dev_spec.channel
-
         data = []
         for img in images:
             if selection is not None and img.name not in selection.images:
@@ -272,8 +264,10 @@ def matrix(
 
             for ver in versions:
                 # The caller's flags decide which kinds of version are eligible
-                # (release / dev / matrix), in both full and change-aware modes.
-                included, _ = ver.matches_dev_filter(dev_versions, effective_dev_channel)
+                # (release / dev / matrix), in both full and change-aware modes. The
+                # channel comes from effective_dev_channel (honors --dev-channel and
+                # falls back to --dev-spec's channel).
+                included, _ = ver.matches_dev_filter(dev_versions, settings.effective_dev_channel)
                 if not included:
                     continue
                 # In change-aware mode the change set then narrows to the versions

--- a/posit-bakery/posit_bakery/config/config.py
+++ b/posit-bakery/posit_bakery/config/config.py
@@ -361,6 +361,23 @@ class BakerySettings(BaseModel):
         )
         return self.dev_channel
 
+    @property
+    def effective_dev_channel(self) -> ReleaseChannelEnum | None:
+        """Channel used to filter dev versions, honoring both --dev-channel and --dev-spec.
+
+        A --dev-spec carrying a channel implies dev versions should be filtered to
+        that channel. The shared CI workflow folds the dispatched channel into the
+        dev-spec and stops passing --dev-channel, so without this derivation the
+        other channels' dev versions leak through both the matrix output and the
+        build target list. --dev-channel wins when explicitly set; _apply_dev_spec
+        validates that the two never conflict.
+        """
+        if self.dev_channel is not None:
+            return self.dev_channel
+        if self.dev_spec is not None:
+            return self.dev_spec.channel
+        return None
+
     matrix_versions: Annotated[
         MatrixVersionInclusionEnum,
         Field(

--- a/posit-bakery/posit_bakery/config/config.py
+++ b/posit-bakery/posit_bakery/config/config.py
@@ -435,7 +435,10 @@ def _apply_dev_spec(image: Image, settings: BakerySettings) -> None:
             f"Either omit 'channel' from --dev-spec or ensure they match."
         )
 
-    target_channel = settings.dev_spec.channel or settings.dev_channel
+    # The conflict check above guarantees dev_spec.channel and dev_channel agree
+    # when both are set, so effective_dev_channel (the value the matrix and build
+    # filters use) resolves to the same target channel here.
+    target_channel = settings.effective_dev_channel
     candidates = [
         dv
         for dv in image.devVersions

--- a/posit-bakery/posit_bakery/config/config.py
+++ b/posit-bakery/posit_bakery/config/config.py
@@ -985,7 +985,7 @@ class BakeryConfig:
                 version_filter_matched = settings.filter.image_version is not None and version_matches(
                     version.name, settings.filter.image_version
                 )
-                included, reason = version.matches_dev_filter(settings.dev_versions, settings.dev_channel)
+                included, reason = version.matches_dev_filter(settings.dev_versions, settings.effective_dev_channel)
                 if not included:
                     if version_filter_matched:
                         log.warning(

--- a/posit-bakery/test/cli/test_ci.py
+++ b/posit-bakery/test/cli/test_ci.py
@@ -260,6 +260,12 @@ class TestVersionMatches:
             ("2026.05.0-dev+15-gSHA", "2026.05.0-dev"),
             ("R4.5.3-python3.14.3", "R4.5.3-python3.14.3"),
             ("R4.5.3-python3.14.3", "R4.5.3"),
+            # Build metadata (+...) is intentionally ignored per semver §10, so two
+            # dev versions that differ only in +build match the same --image-version
+            # filter. This is why --image-version cannot disambiguate same-build dev
+            # versions across channels (Bug 3); effective_dev_channel does that.
+            ("2026.06.0+240.pro3", "2026.06.0+240.pro1"),
+            ("2026.06.0+240.daily", "2026.06.0+240.preview"),
         ],
     )
     def test_matches(self, ver_name, filter_version):

--- a/posit-bakery/test/config/test_config.py
+++ b/posit-bakery/test/config/test_config.py
@@ -566,6 +566,48 @@ class TestBakeryConfig:
             assert len(pinned) == 1
             assert pinned[0].version_override == "2026.05.0-dev+999-gSHA"
 
+        def test_build_targets_filter_to_dev_spec_channel(self, tmp_path, patch_requests_get):
+            """generate_image_targets must drop the off-channel dev version when only
+            --dev-spec carries the channel (Bug 3). The build path used the raw
+            dev_channel (None here) and built both daily and preview; it must use
+            effective_dev_channel instead."""
+            from posit_bakery.config.image.dev_version.spec import DevBuildSpec
+
+            bakery_yaml = tmp_path / "bakery.yaml"
+            bakery_yaml.write_text(
+                textwrap.dedent("""\
+                    repository:
+                      url: https://github.com/posit-dev/test
+                    images:
+                      - name: test-image
+                        devVersions:
+                          - sourceType: stream
+                            product: package-manager
+                            channel: daily
+                            os:
+                              - name: Ubuntu 24.04
+                                primary: true
+                          - sourceType: stream
+                            product: package-manager
+                            channel: preview
+                            os:
+                              - name: Ubuntu 24.04
+                                primary: true
+                    """)
+            )
+            settings = BakerySettings(
+                dev_versions=DevVersionInclusionEnum.ONLY,
+                dev_spec=DevBuildSpec(version="2026.05.0-dev+999-gSHA", channel=ReleaseChannelEnum.PREVIEW),
+            )
+            with patch.object(posit_bakery.config.image.Image, "render_ephemeral_version_files"):
+                with patch.object(posit_bakery.config.image.Image, "remove_ephemeral_version_files"):
+                    config = BakeryConfig(bakery_yaml, settings=settings)
+
+            channels = {t.image_version.metadata.get("release_channel") for t in config.targets}
+            assert config.targets, "expected at least one preview target"
+            assert ReleaseChannelEnum.PREVIEW in channels
+            assert ReleaseChannelEnum.DAILY not in channels
+
     @pytest.mark.parametrize(
         "include_matrix_versions,expected_uids",
         [

--- a/posit-bakery/test/config/test_config.py
+++ b/posit-bakery/test/config/test_config.py
@@ -483,23 +483,25 @@ class TestBakeryConfig:
 
             bakery_yaml = tmp_path / "bakery.yaml"
             bakery_yaml.write_text(
-                "repository:\n"
-                "  url: https://github.com/posit-dev/test\n"
-                "images:\n"
-                "  - name: test-image\n"
-                "    devVersions:\n"
-                "      - sourceType: stream\n"
-                "        product: package-manager\n"
-                "        channel: daily\n"
-                "        os:\n"
-                "          - name: Ubuntu 24.04\n"
-                "            primary: true\n"
-                "      - sourceType: stream\n"
-                "        product: package-manager\n"
-                "        channel: preview\n"
-                "        os:\n"
-                "          - name: Ubuntu 24.04\n"
-                "            primary: true\n"
+                textwrap.dedent("""\
+                    repository:
+                      url: https://github.com/posit-dev/test
+                    images:
+                      - name: test-image
+                        devVersions:
+                          - sourceType: stream
+                            product: package-manager
+                            channel: daily
+                            os:
+                              - name: Ubuntu 24.04
+                                primary: true
+                          - sourceType: stream
+                            product: package-manager
+                            channel: preview
+                            os:
+                              - name: Ubuntu 24.04
+                                primary: true
+                    """)
             )
             spec = DevBuildSpec(version="2026.05.0-dev+999-gSHA")
             settings = BakerySettings(dev_versions=DevVersionInclusionEnum.ONLY, dev_spec=spec)
@@ -512,17 +514,19 @@ class TestBakeryConfig:
 
             bakery_yaml = tmp_path / "bakery.yaml"
             bakery_yaml.write_text(
-                "repository:\n"
-                "  url: https://github.com/posit-dev/test\n"
-                "images:\n"
-                "  - name: test-image\n"
-                "    devVersions:\n"
-                "      - sourceType: stream\n"
-                "        product: package-manager\n"
-                "        channel: daily\n"
-                "        os:\n"
-                "          - name: Ubuntu 24.04\n"
-                "            primary: true\n"
+                textwrap.dedent("""\
+                    repository:
+                      url: https://github.com/posit-dev/test
+                    images:
+                      - name: test-image
+                        devVersions:
+                          - sourceType: stream
+                            product: package-manager
+                            channel: daily
+                            os:
+                              - name: Ubuntu 24.04
+                                primary: true
+                    """)
             )
             spec = DevBuildSpec(version="2026.05.0-dev+999-gSHA", channel=ReleaseChannelEnum.DAILY)
             settings = BakerySettings(
@@ -540,17 +544,19 @@ class TestBakeryConfig:
 
             bakery_yaml = tmp_path / "bakery.yaml"
             bakery_yaml.write_text(
-                "repository:\n"
-                "  url: https://github.com/posit-dev/test\n"
-                "images:\n"
-                "  - name: test-image\n"
-                "    devVersions:\n"
-                "      - sourceType: stream\n"
-                "        product: package-manager\n"
-                "        channel: daily\n"
-                "        os:\n"
-                "          - name: Ubuntu 24.04\n"
-                "            primary: true\n"
+                textwrap.dedent("""\
+                    repository:
+                      url: https://github.com/posit-dev/test
+                    images:
+                      - name: test-image
+                        devVersions:
+                          - sourceType: stream
+                            product: package-manager
+                            channel: daily
+                            os:
+                              - name: Ubuntu 24.04
+                                primary: true
+                    """)
             )
             spec = DevBuildSpec(version="2026.05.0-dev+999-gSHA")
             settings = BakerySettings(dev_versions=DevVersionInclusionEnum.ONLY, dev_spec=spec)

--- a/posit-bakery/test/config/test_config.py
+++ b/posit-bakery/test/config/test_config.py
@@ -406,6 +406,41 @@ class TestBakeryConfig:
         assert settings.dev_channel == ReleaseChannelEnum.DAILY
         assert any(issubclass(warning.category, DeprecationWarning) for warning in w)
 
+    class TestEffectiveDevChannel:
+        """effective_dev_channel centralizes the dev-channel derivation so the
+        matrix path (cli/ci.py) and the build path (generate_image_targets)
+        filter dev versions by the same channel."""
+
+        def test_returns_dev_channel_when_set(self):
+            settings = BakerySettings(dev_channel=ReleaseChannelEnum.DAILY)
+            assert settings.effective_dev_channel == ReleaseChannelEnum.DAILY
+
+        def test_derives_channel_from_dev_spec_when_dev_channel_absent(self):
+            from posit_bakery.config.image.dev_version.spec import DevBuildSpec
+
+            settings = BakerySettings(
+                dev_spec=DevBuildSpec(version="2026.06.0+240", channel=ReleaseChannelEnum.PREVIEW),
+            )
+            assert settings.effective_dev_channel == ReleaseChannelEnum.PREVIEW
+
+        def test_none_when_dev_spec_is_branch_only(self):
+            from posit_bakery.config.image.dev_version.spec import DevBuildSpec
+
+            settings = BakerySettings(dev_spec=DevBuildSpec(release_branch="2026.06"))
+            assert settings.effective_dev_channel is None
+
+        def test_none_when_no_channel_and_no_spec(self):
+            assert BakerySettings().effective_dev_channel is None
+
+        def test_dev_channel_takes_precedence_over_matching_spec(self):
+            from posit_bakery.config.image.dev_version.spec import DevBuildSpec
+
+            settings = BakerySettings(
+                dev_channel=ReleaseChannelEnum.PREVIEW,
+                dev_spec=DevBuildSpec(version="2026.06.0+240", channel=ReleaseChannelEnum.PREVIEW),
+            )
+            assert settings.effective_dev_channel == ReleaseChannelEnum.PREVIEW
+
     class TestDevBuildSpecApplication:
         def test_inert_when_no_spec(self, testdata_path, patch_requests_get):
             """No dev_spec: config loads normally, no version_override set on channel devVersions."""


### PR DESCRIPTION
## Why

Dev-channel derivation was duplicated, and the two copies drifted.
`bakery ci matrix` derived the channel from `--dev-spec` when
`--dev-channel` was unset (PR #624), but the build path
(`generate_image_targets`) still read the raw `settings.dev_channel`. So
when the CI workflow folds the dispatched channel into `--dev-spec` and
drops `--dev-channel`, the build path skipped its channel guard and built
an off-channel daily dev version next to the pinned preview one.

Centralizing onto one `BakerySettings.effective_dev_channel` property
makes the matrix and build paths filter by the same channel, and stops
them drifting again.
