### PR TITLE
feat: parallelize bakery ci publish across image targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,9 +102,6 @@ jobs:
       - name: Setup ORAS CLI
         uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3  # v2.0.0
 
-      - name: Setup SOCI
-        uses: ./setup-soci
-
       - name: Add tools/ to path
         run: echo "${GITHUB_WORKSPACE}/tools" >> "$GITHUB_PATH"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,9 @@ jobs:
       - name: Setup ORAS CLI
         uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3  # v2.0.0
 
+      - name: Setup SOCI
+        uses: ./setup-soci
+
       - name: Add tools/ to path
         run: echo "${GITHUB_WORKSPACE}/tools" >> "$GITHUB_PATH"
 

--- a/posit-bakery/posit_bakery/cli/ci.py
+++ b/posit-bakery/posit_bakery/cli/ci.py
@@ -397,6 +397,16 @@ def publish(
             help="Temporary registry to use for split/merge builds.", rich_help_panel="Build Configuration & Outputs"
         ),
     ] = None,
+    jobs: Annotated[
+        Optional[int],
+        typer.Option(
+            "--jobs",
+            "-j",
+            show_default=False,
+            help="Maximum number of targets to publish concurrently. "
+            "Defaults to the BAKERY_MAX_CONCURRENCY env var or a built-in default.",
+        ),
+    ] = None,
     dry_run: Annotated[bool, typer.Option(help="If set, no images will be pushed.")] = False,
     dev_channel: Annotated[
         Optional[ReleaseChannelEnum],
@@ -459,6 +469,7 @@ def publish(
         dry_run=dry_run,
         dev_channel=dev_channel,
         dev_spec=dev_spec,
+        jobs=jobs,
     )
 
 

--- a/posit-bakery/posit_bakery/cli/ci.py
+++ b/posit-bakery/posit_bakery/cli/ci.py
@@ -402,6 +402,7 @@ def publish(
         typer.Option(
             "--jobs",
             "-j",
+            min=1,
             show_default=False,
             help="Maximum number of targets to publish concurrently. "
             "Defaults to the BAKERY_MAX_CONCURRENCY env var or a built-in default.",

--- a/posit-bakery/posit_bakery/const.py
+++ b/posit-bakery/posit_bakery/const.py
@@ -37,3 +37,8 @@ OCI_LABEL_PREFIX = "org.opencontainers.image"
 JINJA2_TEMPLATE_EXTENSIONS = {".jinja2", ".j2", ".jinja"}
 
 DEFAULT_MAX_CONCURRENCY = 4
+
+# Bounds a single tracked command (e.g. an oras/soci invocation) so a hung registry
+# call can't block a publish run forever; 30 minutes comfortably covers slow pushes
+# of large image layers without masking a truly stuck process.
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 1800.0

--- a/posit-bakery/posit_bakery/parallel/__init__.py
+++ b/posit-bakery/posit_bakery/parallel/__init__.py
@@ -1,12 +1,18 @@
 from posit_bakery.parallel.executor import (
+    CommandRunner,
+    JobResult,
     ParallelShellExecutor,
+    ShellJob,
     ShellResult,
     ShellTask,
     resolve_max_workers,
 )
 
 __all__ = [
+    "CommandRunner",
+    "JobResult",
     "ParallelShellExecutor",
+    "ShellJob",
     "ShellResult",
     "ShellTask",
     "resolve_max_workers",

--- a/posit-bakery/posit_bakery/parallel/executor.py
+++ b/posit-bakery/posit_bakery/parallel/executor.py
@@ -128,22 +128,35 @@ class ParallelShellExecutor:
             progress.start_task(task_id)
             progress.update(task_id, description=f"[bright_blue]running {task.display_label}")
 
-    def _run_one(self, task: ShellTask) -> ShellResult:
-        """Run one task as a tracked child process, enforcing task.timeout if set."""
-        start = time.monotonic()
+    def _spawn_and_communicate(
+        self,
+        cmd: list[str],
+        *,
+        env: dict[str, str] | None = None,
+        cwd: Path | None = None,
+        timeout: float | None = None,
+        on_started: Callable[[], None] | None = None,
+    ) -> tuple[int | None, bytes, bytes, bool, Exception | None]:
+        """Spawn a tracked child process and communicate with it, handling timeout and shutdown.
+
+        Spawns a subprocess in a new session (process group), registers it as active, and
+        manages its lifecycle: timeout enforcement, graceful termination on interrupt/timeout,
+        and tracking for Ctrl-C safety. Calls on_started() just before communicate() blocks.
+        Returns (returncode, stdout, stderr, timed_out, exception). exception is set on
+        spawn failure (e.g. FileNotFoundError) or on an unhandled timeout/interrupt artifact;
+        callers with raise-on-failure semantics check it themselves.
+        """
         try:
             proc = subprocess.Popen(
-                task.cmd,
-                env=task.env,
-                cwd=task.cwd,
+                cmd,
+                env=env,
+                cwd=cwd,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 start_new_session=True,
             )
         except Exception as exc:  # spawn failures (FileNotFoundError, PermissionError, ...)
-            return ShellResult(
-                task=task, returncode=None, stdout=b"", stderr=b"", duration=time.monotonic() - start, exception=exc
-            )
+            return None, b"", b"", False, exc
 
         with self._lock:
             if self._shutdown:
@@ -153,25 +166,19 @@ class ParallelShellExecutor:
                 interrupted = False
         if interrupted:
             # An interrupt began before this child was registered; stop it now so it
-            # cannot escape termination. The returned result is discarded as run() unwinds.
+            # cannot escape termination. The returned result is discarded as run()/run_jobs() unwinds.
             self._stop(proc)
             stdout, stderr = proc.communicate()
-            return ShellResult(
-                task=task,
-                returncode=proc.returncode,
-                stdout=stdout or b"",
-                stderr=stderr or b"",
-                duration=time.monotonic() - start,
-                exception=None,
-                timed_out=False,
-            )
-        self._mark_running(task)
+            return proc.returncode, stdout or b"", stderr or b"", False, None
+
+        if on_started is not None:
+            on_started()
         timed_out = False
         exception: Exception | None = None
-        timeout = task.timeout if (task.timeout is not None and task.timeout > 0) else None
+        eff_timeout = timeout if (timeout is not None and timeout > 0) else None
         try:
             try:
-                stdout, stderr = proc.communicate(timeout=timeout)
+                stdout, stderr = proc.communicate(timeout=eff_timeout)
             except subprocess.TimeoutExpired as exc:
                 timed_out = True
                 exception = exc
@@ -181,11 +188,23 @@ class ParallelShellExecutor:
             with self._lock:
                 self._active.discard(proc)
 
+        return proc.returncode, stdout or b"", stderr or b"", timed_out, exception
+
+    def _run_one(self, task: ShellTask) -> ShellResult:
+        """Run one task as a tracked child process, enforcing task.timeout if set."""
+        start = time.monotonic()
+        returncode, stdout, stderr, timed_out, exception = self._spawn_and_communicate(
+            task.cmd,
+            env=task.env,
+            cwd=task.cwd,
+            timeout=task.timeout,
+            on_started=lambda: self._mark_running(task),
+        )
         return ShellResult(
             task=task,
-            returncode=proc.returncode,
-            stdout=stdout or b"",
-            stderr=stderr or b"",
+            returncode=returncode,
+            stdout=stdout,
+            stderr=stderr,
             duration=time.monotonic() - start,
             exception=exception,
             timed_out=timed_out,

--- a/posit-bakery/posit_bakery/parallel/executor.py
+++ b/posit-bakery/posit_bakery/parallel/executor.py
@@ -14,6 +14,7 @@ from typing import Any, Callable
 from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 
+from posit_bakery.const import DEFAULT_COMMAND_TIMEOUT_SECONDS
 from posit_bakery.log import stderr_console
 from posit_bakery.settings import SETTINGS
 
@@ -415,18 +416,23 @@ class CommandRunner:
         *,
         env: dict[str, str] | None = None,
         cwd: Path | None = None,
+        timeout: float | None = DEFAULT_COMMAND_TIMEOUT_SECONDS,
     ) -> subprocess.CompletedProcess:
         """Run ``cmd`` as a tracked child process and return completed result.
 
         Does not raise on non-zero exit — callers with raise-on-failure semantics
         (e.g. ``OrasCommand.run()``) check ``returncode`` themselves, exactly as when
         calling ``subprocess.run()`` directly.
+
+        :param timeout: Seconds to allow before killing the child; defaults to
+            :data:`DEFAULT_COMMAND_TIMEOUT_SECONDS` so a hung ``oras``/``soci`` call
+            can't block a publish run forever. Pass ``None`` for no bound.
         """
         returncode, stdout, stderr, _timed_out, exception = self._executor._spawn_and_communicate(
             cmd,
             env=env,
             cwd=cwd,
-            timeout=None,
+            timeout=timeout,
             on_started=lambda: self._executor._mark_running_row(self._key, self._label),
         )
         if exception is not None:

--- a/posit-bakery/posit_bakery/parallel/executor.py
+++ b/posit-bakery/posit_bakery/parallel/executor.py
@@ -73,6 +73,41 @@ class ShellResult:
         return self.exception is None and self.returncode == 0
 
 
+@dataclass
+class ShellJob:
+    """A unit of work that runs an ordered sequence of commands.
+
+    ``run`` receives a :class:`CommandRunner` bound to this job and uses it to invoke each
+    command in order; the executor runs jobs concurrently up to the worker bound. The
+    callable's return value is surfaced on :attr:`JobResult.value`.
+    """
+
+    key: str
+    run: Callable[["CommandRunner"], Any]
+    label: str | None = None
+    payload: Any = None  # opaque caller data, passed through unchanged on JobResult.job.payload
+
+    @property
+    def display_label(self) -> str:
+        """Human-facing label for live output; falls back to job key."""
+        return self.label or self.key
+
+
+@dataclass
+class JobResult:
+    """The outcome of running a ShellJob."""
+
+    job: ShellJob
+    value: Any = None
+    exception: Exception | None = None
+    duration: float = 0.0
+
+    @property
+    def ok(self) -> bool:
+        """True when the job callable returned without raising."""
+        return self.exception is None
+
+
 def resolve_max_workers(jobs: int | None, n_tasks: int) -> int:
     """Resolve the worker count: --jobs override, else SETTINGS, clamped to [1, n_tasks].
 
@@ -114,8 +149,8 @@ class ParallelShellExecutor:
             return self._use_live
         return self.console.is_terminal and SETTINGS.log_level < logging.ERROR and n_tasks > 1
 
-    def _mark_running(self, task: ShellTask) -> None:
-        """Flip a task's live-table row from queued to running and start its timer.
+    def _mark_running_row(self, key: str, label: str) -> None:
+        """Flip a live-table row from queued to running and start its timer.
 
         Safe to call from worker threads: Rich Progress mutations are internally locked and
         are not console output. No-op when no live Progress is attached.
@@ -123,10 +158,18 @@ class ParallelShellExecutor:
         progress = self._progress
         if progress is None:
             return
-        task_id = self._progress_ids.get(task.key)
-        if task_id is not None:
-            progress.start_task(task_id)
-            progress.update(task_id, description=f"[bright_blue]running {task.display_label}")
+        row_id = self._progress_ids.get(key)
+        if row_id is not None:
+            progress.start_task(row_id)
+            progress.update(row_id, description=f"[bright_blue]running {label}")
+
+    def _mark_running(self, task: ShellTask) -> None:
+        """Flip a task's live-table row from queued to running and start its timer.
+
+        Safe to call from worker threads: Rich Progress mutations are internally locked and
+        are not console output. No-op when no live Progress is attached.
+        """
+        self._mark_running_row(task.key, task.display_label)
 
     def _spawn_and_communicate(
         self,
@@ -210,6 +253,16 @@ class ParallelShellExecutor:
             timed_out=timed_out,
         )
 
+    def _run_job(self, job: ShellJob) -> JobResult:
+        """Run one job's callable, handing it a CommandRunner bound to the job."""
+        start = time.monotonic()
+        runner = CommandRunner(self, job.key, job.display_label)
+        try:
+            value = job.run(runner)
+        except Exception as exc:  # job callable raised; surface without crashing pool
+            return JobResult(job=job, value=None, exception=exc, duration=time.monotonic() - start)
+        return JobResult(job=job, value=value, exception=None, duration=time.monotonic() - start)
+
     @staticmethod
     def _stop(proc: subprocess.Popen, grace: float = TERMINATE_GRACE_SECONDS) -> None:
         """Stop a child group gracefully: SIGTERM the group, wait up to grace, then SIGKILL it."""
@@ -246,14 +299,45 @@ class ParallelShellExecutor:
         terminates in-flight child processes before re-raising, so Ctrl-C is responsive and
         does not leave orphaned children.
         """
-        if not tasks:
+        return self._execute_pool(tasks, worker=self._run_one, on_result=on_result)
+
+    def run_jobs(
+        self,
+        jobs: list[ShellJob],
+        *,
+        on_result: Callable[[JobResult], None] | None = None,
+    ) -> list[JobResult]:
+        """Run all jobs (each an ordered command sequence) concurrently, returning results in input order.
+
+        Each job's callable runs on a worker thread with a :class:`CommandRunner` bound to it;
+        commands it spawns are tracked exactly like task runs, so timeout enforcement,
+        process-group termination, and interrupt-safety all apply. ``on_result`` fires per job
+        on the main thread (so callers can mutate shared state without locks).
+        """
+        return self._execute_pool(jobs, worker=self._run_job, on_result=on_result)
+
+    def _execute_pool(
+        self,
+        units: list,
+        *,
+        worker: Callable[[Any], Any],
+        on_result: Callable[[Any], None] | None,
+    ) -> list:
+        """Shared driver for :meth:`run` and :meth:`run_jobs`.
+
+        ``units`` each expose ``.key`` and ``.display_label``; ``worker`` maps a unit to its
+        result, and the result must expose ``.ok`` (used to render live table's check/cross mark).
+        Owns the thread pool, live-table lifecycle, interrupt handling, and input-order result
+        assembly so both call paths share identical Ctrl-C and process-group-termination semantics.
+        """
+        if not units:
             return []
 
         self._shutdown = False
         self._progress = None
         self._progress_ids = {}
-        use_live = self._resolve_use_live(len(tasks))
-        results_by_key: dict[str, ShellResult] = {}
+        use_live = self._resolve_use_live(len(units))
+        results_by_key: dict[str, Any] = {}
         progress: Progress | None = None
         progress_ids: dict[str, Any] = {}
 
@@ -270,12 +354,12 @@ class ParallelShellExecutor:
         def consume(future_map: dict) -> None:
             for future in as_completed(future_map):
                 result = future.result()
-                results_by_key[result.task.key] = result
+                results_by_key[future_map[future].key] = result
                 if progress is not None:
                     status = "[green3]✓" if result.ok else "[bright_red]✗"
                     progress.update(
-                        progress_ids[result.task.key],
-                        description=f"{status} {result.task.display_label}",
+                        progress_ids[future_map[future].key],
+                        description=f"{status} {future_map[future].display_label}",
                         completed=1,
                     )
                 if on_result is not None:
@@ -285,18 +369,18 @@ class ParallelShellExecutor:
         try:
             if progress is not None:
                 with progress:
-                    for task in tasks:
-                        progress_ids[task.key] = progress.add_task(
-                            f"[quiet]{'queued':<7} {task.display_label}", total=1, start=False
+                    for unit in units:
+                        progress_ids[unit.key] = progress.add_task(
+                            f"[quiet]{'queued':<7} {unit.display_label}", total=1, start=False
                         )
                     self._progress_ids = progress_ids
-                    future_map = {pool.submit(self._run_one, task): task for task in tasks}
+                    future_map = {pool.submit(worker, unit): unit for unit in units}
                     consume(future_map)
             else:
-                future_map = {pool.submit(self._run_one, task): task for task in tasks}
+                future_map = {pool.submit(worker, unit): unit for unit in units}
                 consume(future_map)
         except BaseException:
-            # Interrupted (e.g. Ctrl-C): stop accepting/continuing work, drop queued tasks,
+            # Interrupted (e.g. Ctrl-C): stop accepting/continuing work, drop queued units,
             # and terminate running children, then propagate.
             with self._lock:
                 self._shutdown = True
@@ -309,4 +393,42 @@ class ParallelShellExecutor:
             self._progress = None
             self._progress_ids = {}
 
-        return [results_by_key[task.key] for task in tasks]
+        return [results_by_key[unit.key] for unit in units]
+
+
+class CommandRunner:
+    """Executes commands within a ShellJob, binding subprocess lifecycle to the job's executor.
+
+    Each job receives a CommandRunner instance bound to itself; the runner's ``run()`` method
+    spawns subprocesses via the shared executor's tracked-spawn primitives, so timeout
+    enforcement, process-group termination, and interrupt-safety all apply transparently.
+    """
+
+    def __init__(self, executor: "ParallelShellExecutor", key: str, label: str | None = None) -> None:
+        self._executor = executor
+        self._key = key
+        self._label = label or key
+
+    def run(
+        self,
+        cmd: list[str],
+        *,
+        env: dict[str, str] | None = None,
+        cwd: Path | None = None,
+    ) -> subprocess.CompletedProcess:
+        """Run ``cmd`` as a tracked child process and return completed result.
+
+        Does not raise on non-zero exit — callers with raise-on-failure semantics
+        (e.g. ``OrasCommand.run()``) check ``returncode`` themselves, exactly as when
+        calling ``subprocess.run()`` directly.
+        """
+        returncode, stdout, stderr, _timed_out, exception = self._executor._spawn_and_communicate(
+            cmd,
+            env=env,
+            cwd=cwd,
+            timeout=None,
+            on_started=lambda: self._executor._mark_running_row(self._key, self._label),
+        )
+        if exception is not None:
+            raise exception
+        return subprocess.CompletedProcess(args=cmd, returncode=returncode, stdout=stdout, stderr=stderr)

--- a/posit-bakery/posit_bakery/plugins/builtin/imagetools/imagetools.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/imagetools/imagetools.py
@@ -573,6 +573,7 @@ class ImageToolsPlugin(BakeryToolPlugin):
             OrasIndexVerifyWorkflow,
             find_oras_bin,
         )
+        from posit_bakery.plugins.builtin.imagetools.soci import find_soci_bin
 
         settings = BakerySettings(
             filter=BakeryConfigFilter(image_name=image_name),
@@ -605,14 +606,6 @@ class ImageToolsPlugin(BakeryToolPlugin):
         log.debug(", ".join(loaded_targets))
 
         oras_bin = find_oras_bin(config.base_path)
-        try:
-            soci_bin = find_soci_bin(config.base_path)
-        except BakeryToolNotFoundError:
-            # A real run needs soci but cannot find it is still a hard error; a dry run
-            # executes nothing, so fall back to the bare name purely for logged commands.
-            if not dry_run:
-                raise
-            soci_bin = "soci"
 
         # Act only on targets that were actually present in the provided metadata
         # files, not every target defined in the config. Publishing a single set of
@@ -624,6 +617,16 @@ class ImageToolsPlugin(BakeryToolPlugin):
             (t for uid in loaded_targets if (t := config.get_image_target_by_uid(uid)) is not None),
             key=lambda t: t.push_sort_key,
         )
+
+        try:
+            soci_bin = find_soci_bin(config.base_path)
+        except BakeryToolNotFoundError:
+            # A dry run executes nothing, and a run where no target has SOCI enabled never
+            # touches soci_bin, so neither needs the binary to actually be installed. Only a
+            # real run with at least one SOCI-enabled target makes this a hard error.
+            if not dry_run and any(get_soci_options_for_target(t).enabled for t in targets):
+                raise
+            soci_bin = "soci"
 
         # Stage 1: wait for each target's own sources, then index-create, then soci-convert.
         # Runs concurrently across targets; one target's failure is isolated to it.

--- a/posit-bakery/posit_bakery/plugins/builtin/imagetools/imagetools.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/imagetools/imagetools.py
@@ -14,10 +14,11 @@ orchestration delegates to per target). ORAS merge is exposed via the dedicated
 publish orchestration via :meth:`publish`.
 """
 
+from dataclasses import dataclass
 import glob as glob_module
 import logging
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import typer
 
@@ -27,6 +28,9 @@ from posit_bakery.plugins.builtin.imagetools.options import SociOptions
 from posit_bakery.plugins.builtin.imagetools.oras import OrasMergeWorkflow, find_oras_bin
 from posit_bakery.plugins.builtin.imagetools.soci import SociConvertWorkflow, find_soci_bin
 from posit_bakery.plugins.protocol import BakeryToolPlugin, ToolCallResult
+
+if TYPE_CHECKING:
+    from posit_bakery.parallel import CommandRunner
 
 log = logging.getLogger(__name__)
 
@@ -65,6 +69,94 @@ def get_soci_options_for_target(target: ImageTarget) -> SociOptions:
     if variant_opts and image_opts:
         return variant_opts.update(image_opts)
     return variant_opts or image_opts or SociOptions()
+
+
+@dataclass
+class _PublishStage1Result:
+    """Outcome of running wait + index-create + (optional) soci-convert for one target."""
+
+    target: ImageTarget
+    success: bool = True
+    skipped: bool = False
+    skip_reason: str | None = None
+    temp_ref: str | None = None
+    error: str | None = None
+    failed_phase: str | None = None
+
+
+def _run_publish_stage1(
+    target: ImageTarget,
+    oras_bin: str,
+    soci_bin: str,
+    dry_run: bool,
+    *,
+    runner: "CommandRunner | None" = None,
+) -> _PublishStage1Result:
+    """Wait for a target's own sources, create its temp index, then SOCI-convert it if enabled.
+
+    Runs entirely for one target so it can be wrapped in a ``ShellJob`` and fanned out across
+    the parallel executor; one target's failure does not affect any other target. Imports the
+    oras/soci workflow classes locally (mirroring the rest of this module) so test patches on
+    the source modules are honoured at call time.
+    """
+    from posit_bakery.error import BakeryToolRuntimeError
+    from posit_bakery.plugins.builtin.imagetools.oras import OrasIndexCreateWorkflow, OrasWaitForSourcesWorkflow
+    from posit_bakery.plugins.builtin.imagetools.soci import SociConvertWorkflow
+
+    if not target.get_merge_sources():
+        return _PublishStage1Result(target=target, skipped=True, skip_reason="no merge sources")
+    if not target.settings.temp_registry:
+        return _PublishStage1Result(
+            target=target,
+            success=False,
+            failed_phase="create",
+            error=f"Cannot publish '{target}': temp_registry not configured.",
+        )
+
+    sources = sorted(set(target.get_merge_sources()))
+    try:
+        wait = OrasWaitForSourcesWorkflow(oras_bin=oras_bin, sources=sources).run(dry_run=dry_run, runner=runner)
+    except BakeryToolRuntimeError as e:
+        # Non-transient registry error (auth, bad reference, ...) while probing sources:
+        # fatal for this target and won't self-heal, but must not escape as an unhandled
+        # exception out of a worker thread.
+        return _PublishStage1Result(
+            target=target,
+            success=False,
+            failed_phase="wait",
+            error=f"Failed while waiting on source digests: {e.dump_stderr() or e}",
+        )
+    if not wait.success:
+        return _PublishStage1Result(
+            target=target,
+            success=False,
+            failed_phase="wait",
+            error=f"Source digests not available: {wait.error}",
+        )
+
+    create = OrasIndexCreateWorkflow(
+        oras_bin=oras_bin,
+        image_target=target,
+        annotations=target.labels,
+    ).run(dry_run=dry_run, runner=runner)
+    if not create.success:
+        return _PublishStage1Result(target=target, success=False, failed_phase="create", error=create.error)
+    temp_ref = create.temp_ref
+
+    soci_opts = get_soci_options_for_target(target)
+    if soci_opts.enabled:
+        soci = SociConvertWorkflow(
+            soci_bin=soci_bin,
+            oras_bin=oras_bin,
+            image_target=target,
+            options=soci_opts,
+            source_ref=temp_ref,
+        ).run(dry_run=dry_run, runner=runner)
+        if not soci.success:
+            return _PublishStage1Result(target=target, success=False, failed_phase="soci", error=soci.error)
+        temp_ref = soci.destination_ref
+
+    return _PublishStage1Result(target=target, temp_ref=temp_ref)
 
 
 class ImageToolsPlugin(BakeryToolPlugin):

--- a/posit-bakery/posit_bakery/plugins/builtin/imagetools/imagetools.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/imagetools/imagetools.py
@@ -537,34 +537,40 @@ class ImageToolsPlugin(BakeryToolPlugin):
         dry_run: bool = False,
         dev_channel: Any = None,
         dev_spec: Any = None,
+        jobs: int | None = None,
     ) -> None:
-        """Publish multi-platform images by composing oras index-create →
-        soci-convert → oras index-copy → verify.
+        """Publish multi-platform images by composing wait -> index-create -> soci-convert ->
+        index-copy -> verify.
 
-        Which targets are converted is driven by configuration: each target is
-        converted only when its resolved SOCI options have ``enabled: true``
-        (set via the ``soci`` tool options on an image or variant). Targets
-        without SOCI enabled pass through the convert phase untouched.
-        Conversion runs in standalone (no containerd) mode via oras.
+        Targets are converted into SOCI-enabled images only when their resolved SOCI options
+        have ``enabled: true`` (set via ``soci`` tool options on the image variant). Targets
+        without SOCI enabled pass through that step untouched. Conversion runs in standalone
+        (no containerd) mode via oras.
 
-        Temporary indexes are left in place and cleaned up out-of-band by the
-        clean.yml workflow (``bakery clean temp-registry``) rather than deleted
-        here.
+        Stage 1 (wait for that target's own sources, then index-create, then soci-convert)
+        runs concurrently across targets, bounded by ``jobs`` (falls back to
+        ``SETTINGS.max_concurrency``); one target's failure does not block any other target.
+        Stage 2 (index-copy, the actual registry push) is sequential and runs in
+        ``push_sort_key`` order so registries that display tags by push time (e.g. Docker
+        Hub) still show the latest version as most recent. Stage 3 (verify) is sequential and
+        read-only.
 
-        Raises ``typer.Exit(1)`` on any phase failure.
+        Temporary indexes are left in place; they are cleaned up out-of-band by the clean.yml
+        workflow (``bakery clean temp-registry``) rather than deleted here.
+
+        Raises ``typer.Exit(1)`` if any target failed Stage 1, or if any index-copy or verify
+        failed.
         """
         from posit_bakery.config import BakeryConfig
         from posit_bakery.config.config import BakeryConfigFilter, BakerySettings
         from posit_bakery.const import DevVersionInclusionEnum, MatrixVersionInclusionEnum
-        from posit_bakery.error import BakeryToolRuntimeError
+        from posit_bakery.parallel import ParallelShellExecutor, ShellJob, resolve_max_workers
 
-        # Imported here to mirror existing patterns and keep the test seams
-        # (which patch these on the source module) working at call time.
+        # Imported locally to mirror existing patterns and keep test seams (patch on the
+        # source module) working at call time.
         from posit_bakery.plugins.builtin.imagetools.oras import (
             OrasIndexCopyWorkflow,
-            OrasIndexCreateWorkflow,
             OrasIndexVerifyWorkflow,
-            OrasWaitForSourcesWorkflow,
             find_oras_bin,
         )
 
@@ -599,6 +605,14 @@ class ImageToolsPlugin(BakeryToolPlugin):
         log.debug(", ".join(loaded_targets))
 
         oras_bin = find_oras_bin(config.base_path)
+        try:
+            soci_bin = find_soci_bin(config.base_path)
+        except BakeryToolNotFoundError:
+            # A real run needs soci but cannot find it is still a hard error; a dry run
+            # executes nothing, so fall back to the bare name purely for logged commands.
+            if not dry_run:
+                raise
+            soci_bin = "soci"
 
         # Act only on targets that were actually present in the provided metadata
         # files, not every target defined in the config. Publishing a single set of
@@ -611,76 +625,44 @@ class ImageToolsPlugin(BakeryToolPlugin):
             key=lambda t: t.push_sort_key,
         )
 
-        # Pre-flight: wait for every per-platform source digest to be readable
-        # before we touch them. Those manifests are pushed by digest from separate
-        # build runners, and registries with read-after-write (eventual
-        # consistency) behaviour — notably GHCR — can briefly 404 them. Polling
-        # here turns propagation lag into condition-based waiting and logs exactly
-        # which digest lagged, rather than failing a downstream phase opaquely.
-        all_sources = sorted({s for t in targets for s in t.get_merge_sources()})
-        if all_sources:
-            log.info(f"Waiting for {len(all_sources)} source digest(s) to be readable before publishing.")
-            try:
-                wait = OrasWaitForSourcesWorkflow(
-                    oras_bin=oras_bin,
-                    sources=all_sources,
-                ).run(dry_run=dry_run)
-            except BakeryToolRuntimeError as e:
-                # A non-transient registry error (auth, bad reference, ...) while
-                # probing sources is fatal and won't self-heal — surface it cleanly
-                # rather than letting it escape as an unhandled traceback.
-                log.error(f"Failed while waiting for source digests: {e.dump_stderr() or e}")
-                raise typer.Exit(code=1)
-            if not wait.success:
-                log.error(f"Source digests not available: {wait.error}")
-                raise typer.Exit(code=1)
-            if wait.ready:
-                log.info(f"All {len(wait.ready)} source digest(s) readable after {wait.waited_seconds:.0f}s.")
+        # Stage 1: wait for each target's own sources, then index-create, then soci-convert.
+        # Runs concurrently across targets; one target's failure is isolated to it.
+        shell_jobs = [
+            ShellJob(
+                key=t.uid,
+                label=str(t),
+                run=lambda runner, t=t: _run_publish_stage1(t, oras_bin, soci_bin, dry_run, runner=runner),
+            )
+            for t in targets
+        ]
+        executor = ParallelShellExecutor(max_workers=resolve_max_workers(jobs, len(shell_jobs)))
+        job_results = executor.run_jobs(shell_jobs)
 
-        # Phase 1: index create. Failures abort.
+        stage1_failed = False
         temp_refs: dict[str, str] = {}
-        for t in targets:
-            if not t.get_merge_sources():
-                log.debug(f"Skipping target '{t}' (no merge sources).")
+        for jr in job_results:
+            if not jr.ok:
+                stage1_failed = True
+                log.error(f"publish Stage 1 crashed for '{jr.job.display_label}': {jr.exception}")
                 continue
-            if not t.settings.temp_registry:
-                log.error(f"Cannot publish '{t}': temp_registry not configured.")
-                raise typer.Exit(code=1)
-            res = OrasIndexCreateWorkflow(
-                oras_bin=oras_bin,
-                image_target=t,
-                annotations=t.labels,
-            ).run(dry_run=dry_run)
-            if not res.success:
-                log.error(f"index-create failed for '{t}': {res.error}")
-                raise typer.Exit(code=1)
-            temp_refs[t.uid] = res.temp_ref
+            stage1_result: _PublishStage1Result = jr.value
+            if stage1_result.skipped:
+                log.debug(f"Skipping target '{stage1_result.target}' ({stage1_result.skip_reason}).")
+                continue
+            if not stage1_result.success:
+                stage1_failed = True
+                log.error(
+                    f"publish Stage 1 failed for '{stage1_result.target}' "
+                    f"at phase '{stage1_result.failed_phase}': {stage1_result.error}"
+                )
+                continue
+            temp_refs[stage1_result.target.uid] = stage1_result.temp_ref
 
-        # Phase 2: SOCI convert. Driven by per-target config; targets whose
-        # resolved SOCI options have enabled=False are skipped by execute().
-        soci_results = self.execute(
-            config.base_path,
-            targets,
-            source_refs=temp_refs,
-            dry_run=dry_run,
-        )
-        soci_failed = False
-        for r in soci_results:
-            artifacts = r.artifacts or {}
-            if artifacts.get("skipped"):
-                continue
-            wf = artifacts.get("workflow_result")
-            if r.exit_code != 0:
-                soci_failed = True
-                continue
-            if wf and getattr(wf, "destination_ref", None):
-                temp_refs[r.target.uid] = wf.destination_ref
-        if soci_failed:
-            self.results(soci_results)  # raises typer.Exit(1)
-
-        # Phase 3: index copy.
+        # Stage 2: index copy. Sequential, in push_sort_key order (targets is already sorted
+        # that way) -- this is the only stage that must stay ordered, since it is the actual
+        # registry push that determines what registries display as "most recent".
         copy_failed = False
-        copied_targets: list = []
+        copied_targets: list[ImageTarget] = []
         for t in targets:
             if t.uid not in temp_refs:
                 continue
@@ -694,9 +676,8 @@ class ImageToolsPlugin(BakeryToolPlugin):
             else:
                 copied_targets.append(t)
 
-        # Phase 4: verify each final destination tag resolves. This replaces the
-        # `docker buildx imagetools inspect` check the old `bakery ci merge` ran;
-        # ORAS is faster and more reliable for the existence check.
+        # Stage 3: verify each final destination tag resolves. Read-only and order-independent,
+        # so it stays a simple sequential loop.
         verify_failed = False
         if not dry_run:
             for t in copied_targets:
@@ -710,9 +691,9 @@ class ImageToolsPlugin(BakeryToolPlugin):
                 else:
                     log.info(f"Verified '{t}' -> {', '.join(verify.verified)}")
 
-        # The temporary indexes (and any SOCI-converted variants) are intentionally
-        # left in place; they are cleaned up out-of-band by the clean.yml workflow
-        # (bakery clean temp-registry) rather than deleted here.
+        # The temporary indexes (and any SOCI-converted variants) are intentionally left in
+        # place; they are cleaned up out-of-band by the clean.yml workflow (bakery clean
+        # temp-registry) rather than deleted here.
 
-        if copy_failed or verify_failed:
+        if stage1_failed or copy_failed or verify_failed:
             raise typer.Exit(code=1)

--- a/posit-bakery/posit_bakery/plugins/builtin/imagetools/oras.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/imagetools/oras.py
@@ -5,7 +5,7 @@ import subprocess
 import time
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Annotated, Callable, Self
+from typing import TYPE_CHECKING, Annotated, Callable, Self
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -13,6 +13,9 @@ from posit_bakery.error import BakeryToolRuntimeError
 from posit_bakery.image.image_target import ImageTarget, Tag
 from posit_bakery.retry import RetryPolicy, is_transient_error, retry_on_transient
 from posit_bakery.util import find_bin
+
+if TYPE_CHECKING:
+    from posit_bakery.parallel import CommandRunner
 
 log = logging.getLogger(__name__)
 
@@ -49,10 +52,15 @@ class OrasCommand(BaseModel, ABC):
         """Return the full command to execute."""
         ...
 
-    def run(self, dry_run: bool = False) -> subprocess.CompletedProcess:
+    def run(self, dry_run: bool = False, runner: "CommandRunner | None" = None) -> subprocess.CompletedProcess:
         """Execute the oras command.
 
         :param dry_run: If True, log the command without executing it.
+        :param runner: When provided, spawn through this tracked :class:`CommandRunner`
+            instead of calling ``subprocess.run()`` directly. Used by the parallel publish
+            path so in-flight oras commands are Ctrl-C-safe and process-group-tracked like
+            every other command the parallel executor runs; standalone callers (``oras
+            merge``, ``soci convert``) omit it and keep today's direct-subprocess behavior.
         :return: The completed process result.
         :raises BakeryToolRuntimeError: If the command fails.
         """
@@ -63,11 +71,11 @@ class OrasCommand(BaseModel, ABC):
             log.info(f"[DRY RUN] Would execute: {' '.join(cmd)}")
             return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=b"", stderr=b"")
 
-        result = subprocess.run(cmd, capture_output=True)
+        result = runner.run(cmd) if runner is not None else subprocess.run(cmd, capture_output=True)
 
         if result.returncode != 0:
             raise BakeryToolRuntimeError(
-                message=f"oras command failed",
+                message="oras command failed",
                 tool_name="oras",
                 cmd=cmd,
                 stdout=result.stdout,
@@ -211,7 +219,7 @@ class OrasIndexCreateWorkflow(BaseModel):
             f"{self.image_target.temp_registry}/{self.image_target.image_name}/tmp:{self.image_target.uid}{source_hash}"
         )
 
-    def run(self, dry_run: bool = False) -> OrasIndexCreateResult:
+    def run(self, dry_run: bool = False, runner: "CommandRunner | None" = None) -> OrasIndexCreateResult:
         # Retry transient registry errors: the per-platform source manifests
         # are pushed by digest from separate runners and may not yet be
         # readable here due to registry eventual consistency.
@@ -224,7 +232,7 @@ class OrasIndexCreateWorkflow(BaseModel):
         )
         try:
             retry_on_transient(
-                lambda: cmd.run(dry_run=dry_run),
+                lambda: cmd.run(dry_run=dry_run, runner=runner),
                 policy=self.retry_policy,
                 description=f"index-create for '{self.image_target.uid}'",
             )
@@ -357,14 +365,14 @@ class OrasWaitForSourcesWorkflow(BaseModel):
     poll_interval: Annotated[float, Field(default=5.0, description="Seconds between polling sweeps.")]
     plain_http: Annotated[bool, Field(default=False)]
 
-    def _is_available(self, ref: str) -> bool:
+    def _is_available(self, ref: str, runner: "CommandRunner | None" = None) -> bool:
         try:
             OrasManifestFetch(
                 oras_bin=self.oras_bin,
                 reference=ref,
                 descriptor=True,
                 plain_http=self.plain_http,
-            ).run(dry_run=False)
+            ).run(dry_run=False, runner=runner)
             return True
         except BakeryToolRuntimeError as e:
             if is_transient_error(e):
@@ -377,6 +385,7 @@ class OrasWaitForSourcesWorkflow(BaseModel):
         *,
         sleep: Callable[[float], None] = time.sleep,
         now: Callable[[], float] = time.monotonic,
+        runner: "CommandRunner | None" = None,
     ) -> OrasSourcesReadyResult:
         """Probe each source until all resolve or ``timeout`` elapses.
 
@@ -384,6 +393,7 @@ class OrasWaitForSourcesWorkflow(BaseModel):
             registry (nothing has been pushed to wait on).
         :param sleep: Sleep function, injectable for testing.
         :param now: Monotonic clock, injectable for testing.
+        :param runner: When provided, use this tracked CommandRunner for oras commands.
         """
         unique_sources = list(dict.fromkeys(self.sources))
         if dry_run or not unique_sources:
@@ -395,7 +405,7 @@ class OrasWaitForSourcesWorkflow(BaseModel):
         while True:
             still_pending: list[str] = []
             for ref in pending:
-                if self._is_available(ref):
+                if self._is_available(ref, runner=runner):
                     ready.append(ref)
                 else:
                     still_pending.append(ref)

--- a/posit-bakery/posit_bakery/plugins/builtin/imagetools/soci.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/imagetools/soci.py
@@ -7,7 +7,7 @@ import subprocess
 import tempfile
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Annotated, Literal
+from typing import TYPE_CHECKING, Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -17,6 +17,9 @@ from posit_bakery.plugins.builtin.imagetools.oras import OrasCopy
 from posit_bakery.plugins.builtin.imagetools.options import SociOptions
 from posit_bakery.retry import RetryPolicy, retry_on_transient
 from posit_bakery.util import find_bin
+
+if TYPE_CHECKING:
+    from posit_bakery.parallel import CommandRunner
 
 log = logging.getLogger(__name__)
 
@@ -43,10 +46,13 @@ class SociCommand(BaseModel, ABC):
         """Return the full command to execute."""
         ...
 
-    def run(self, dry_run: bool = False) -> subprocess.CompletedProcess:
+    def run(self, dry_run: bool = False, runner: "CommandRunner | None" = None) -> subprocess.CompletedProcess:
         """Execute the soci command.
 
         :param dry_run: If True, log the command without executing it.
+        :param runner: When provided, spawn through this tracked :class:`CommandRunner`
+            instead of calling ``subprocess.run()`` directly. See ``OrasCommand.run()`` for
+            why this exists.
         :return: The completed process result.
         :raises BakeryToolRuntimeError: On non-zero exit.
         """
@@ -57,7 +63,7 @@ class SociCommand(BaseModel, ABC):
             log.info(f"[DRY RUN] Would execute: {' '.join(cmd)}")
             return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=b"", stderr=b"")
 
-        result = subprocess.run(cmd, capture_output=True)
+        result = runner.run(cmd) if runner is not None else subprocess.run(cmd, capture_output=True)
 
         if result.returncode != 0:
             raise BakeryToolRuntimeError(
@@ -170,7 +176,7 @@ class SociConvertWorkflow(BaseModel):
         index = json.loads((layout / "index.json").read_text())
         return index["manifests"][0]["digest"]
 
-    def run(self, dry_run: bool = False) -> SociConvertWorkflowResult:
+    def run(self, dry_run: bool = False, runner: "CommandRunner | None" = None) -> SociConvertWorkflowResult:
         """Pull the source ref into an OCI layout, convert it to SOCI with
         ``soci convert --standalone``, and push the converted layout back to
         the registry.
@@ -195,7 +201,7 @@ class SociConvertWorkflow(BaseModel):
                 to_oci_layout=True,
             )
             retry_on_transient(
-                lambda: pull.run(dry_run=dry_run),
+                lambda: pull.run(dry_run=dry_run, runner=runner),
                 policy=self.retry_policy,
                 description=f"soci pull for '{self.image_target.uid}'",
             )
@@ -206,7 +212,7 @@ class SociConvertWorkflow(BaseModel):
                 source=str(src_layout),
                 destination=str(out_layout),
                 output_format="oci-dir",
-            ).run(dry_run=dry_run)
+            ).run(dry_run=dry_run, runner=runner)
 
             # 3. push converted layout -> registry, referenced by digest since
             #    the converted layout carries no tag.
@@ -216,7 +222,7 @@ class SociConvertWorkflow(BaseModel):
                 source=f"{out_layout}@{digest}",
                 destination=self.destination_ref,
                 from_oci_layout=True,
-            ).run(dry_run=dry_run)
+            ).run(dry_run=dry_run, runner=runner)
         except BakeryToolRuntimeError as e:
             return SociConvertWorkflowResult(
                 success=False,

--- a/posit-bakery/posit_bakery/plugins/builtin/imagetools/soci.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/imagetools/soci.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 import tempfile
 from abc import ABC, abstractmethod
+from functools import cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Literal
 
@@ -24,8 +25,12 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
+@cache
 def find_soci_bin(context: Path) -> str:
     """Resolve a path or PATH-resident name for the soci binary.
+
+    Memoized so a publish run with multiple SOCI-enabled targets resolves the
+    binary once, rather than once per target.
 
     :param context: Project context to search for the binary in.
     :return: Path to the soci binary, or the bare name "soci" when it

--- a/posit-bakery/test/cli/test_ci.py
+++ b/posit-bakery/test/cli/test_ci.py
@@ -62,7 +62,7 @@ def patch_image_target_merge_method(mocker):
             self.annotations = annotations
             self.plain_http = plain_http
 
-        def run(self, dry_run=False):
+        def run(self, dry_run=False, runner=None):
             sources = self.image_target.get_merge_sources()
             calls.append((sources, dry_run))
             result = MagicMock()

--- a/posit-bakery/test/cli/test_ci_publish.py
+++ b/posit-bakery/test/cli/test_ci_publish.py
@@ -11,6 +11,7 @@ import pytest
 from typer.testing import CliRunner
 
 from posit_bakery.cli.main import app
+from posit_bakery.plugins.builtin.imagetools.oras import OrasIndexCopyWorkflow, OrasIndexCreateWorkflow
 
 pytestmark = [pytest.mark.unit]
 
@@ -42,115 +43,144 @@ def _fake_target(uid: str, merge_sources: list[str] | None = None):
     t = MagicMock()
     t.uid = uid
     t.push_sort_key = 0
-    # Default: no merge sources, which skips phase 1 (index-create) and the
-    # pre-flight source wait.
+    # Default: no merge sources, which skips Stage 1 (wait + index-create +
+    # soci-convert) entirely for this target.
     t.get_merge_sources.return_value = merge_sources or []
+    # A bare MagicMock's `.image_version.parent.options` / `.image_variant.options`
+    # iterate as empty (MagicMock auto-configures __iter__ to `iter([])`), so
+    # get_soci_options_for_target(t) resolves to a real, defaulted SociOptions
+    # (enabled=False) without any further configuration here.
     return t
 
 
-def test_publish_invokes_soci_convert_without_mode(tmp_path):
-    """`ci publish` should drive the plugin's SOCI conversion phase
-    (``ImageToolsPlugin.execute``) without threading any mode/standalone
-    selector through it."""
-    captured = {}
+def _bypass_pydantic_init(cls):
+    """Patch ``cls.__init__`` to store constructor kwargs as plain attributes.
 
-    fake_config = MagicMock()
-    fake_config.base_path = tmp_path
-    fake_config.load_build_metadata_from_file.return_value = ["uid1"]
-    fake_config.get_image_target_by_uid.return_value = _fake_target("uid1")
-
-    def fake_execute(self, base_path, targets, *, source_refs=None, dry_run=False, **kwargs):
-        captured["called"] = True
-        captured["kwargs"] = kwargs
-        return []
-
-    runner = CliRunner()
-    with (
-        patch("posit_bakery.config.BakeryConfig.from_context", return_value=fake_config),
-        patch("posit_bakery.plugins.builtin.imagetools.oras.find_oras_bin", return_value="oras"),
-        patch(
-            "posit_bakery.plugins.builtin.imagetools.imagetools.ImageToolsPlugin.execute",
-            autospec=True,
-            side_effect=fake_execute,
-        ),
-    ):
-        result = runner.invoke(
-            app,
-            ["ci", "publish", "meta.json", "--dry-run"],
-            env=_WIDE_TERM_ENV,
-        )
-
-    assert result.exit_code == 0, result.stdout
-    assert captured["called"] is True
-    # No mode/standalone selector is threaded through anymore.
-    assert "standalone" not in captured["kwargs"]
-
-
-def test_publish_waits_for_sources_then_proceeds(tmp_path):
-    """The pre-flight wait is invoked with the targets' merge-source digests.
-
-    The orchestration now lives in ``ImageToolsPlugin.publish``; its SOCI
-    convert phase (``ImageToolsPlugin.execute``) is stubbed so we can exercise
-    the path from the wait through the ORAS phases.
+    ``OrasIndexCreateWorkflow``/``OrasIndexCopyWorkflow`` are pydantic ``BaseModel``s with an
+    ``image_target: ImageTarget`` field; pydantic validates that field against the real
+    ``ImageTarget`` model even with ``arbitrary_types_allowed=True`` (that setting only
+    relaxes validation for genuinely-opaque types, not other pydantic models), so constructing
+    one with a ``MagicMock`` target raises a validation error. These tests patch the
+    workflow's ``run`` method directly (to control its result per-target), but construction
+    still happens for real in ``_run_publish_stage1``/``publish()`` -- so construction itself
+    must also be bypassed. Returns a context manager; the patched ``__init__`` only stores
+    kwargs, so the patched ``run`` (and ``self.image_target`` accesses within it) keep working.
     """
-    sources = [
-        "ghcr.io/posit-dev/test/tmp@sha256:amd64",
-        "ghcr.io/posit-dev/test/tmp@sha256:arm64",
-    ]
-    target = _fake_target("uid1", merge_sources=sources)
-    target.settings.temp_registry = "ghcr.io/posit-dev"
+
+    def fake_init(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+    return patch.object(cls, "__init__", fake_init)
+
+
+def test_publish_runs_stage1_per_target_then_copies_in_order(tmp_path):
+    """Two targets: Stage 1 (wait+create+soci) runs for both via the parallel executor, then
+    Stage 2 (index-copy) pushes them in push_sort_key order, then Stage 3 verifies both."""
+    target_a = _fake_target("uid-a", merge_sources=["ghcr.io/posit-dev/test/tmp@sha256:a"])
+    target_a.settings.temp_registry = "ghcr.io/posit-dev"
+    target_a.push_sort_key = 1  # pushed second
+    target_b = _fake_target("uid-b", merge_sources=["ghcr.io/posit-dev/test/tmp@sha256:b"])
+    target_b.settings.temp_registry = "ghcr.io/posit-dev"
+    target_b.push_sort_key = 0  # pushed first
 
     fake_config = MagicMock()
     fake_config.base_path = tmp_path
-    fake_config.load_build_metadata_from_file.return_value = ["uid1"]
-    fake_config.get_image_target_by_uid.return_value = target
+    fake_config.load_build_metadata_from_file.return_value = ["uid-a", "uid-b"]
+    fake_config.get_image_target_by_uid.side_effect = lambda uid: {"uid-a": target_a, "uid-b": target_b}[uid]
 
-    captured = {}
+    wait_result = MagicMock(success=True, ready=["x"], missing=[], waited_seconds=0.1, error=None)
+    create_result = MagicMock(success=True, temp_ref="ghcr.io/posit-dev/tmp:created")
+    copy_order = []
 
-    fake_wait_instance = MagicMock()
-    fake_wait_instance.run.return_value = MagicMock(success=True, ready=sources, missing=[], waited_seconds=3.0)
-
-    def fake_wait_ctor(**kwargs):
-        captured["wait_kwargs"] = kwargs
-        return fake_wait_instance
-
-    # Make the downstream phases succeed so we exercise the path past the wait.
-    fake_create_result = MagicMock(success=True, temp_ref="ghcr.io/posit-dev/test/tmp:created")
-    fake_copy_result = MagicMock(success=True, destinations=["ghcr.io/posit-dev/test:1.0.0"], error=None)
-    fake_verify_result = MagicMock(success=True, verified=["ghcr.io/posit-dev/test:1.0.0"], error=None)
+    def fake_copy_run(self, source, dry_run=False):
+        copy_order.append(self.image_target.uid)
+        return MagicMock(success=True, destinations=["ghcr.io/posit-dev/test:1.0.0"], error=None)
 
     runner = CliRunner()
     with (
         patch("posit_bakery.cli.ci.BakeryConfig.from_context", return_value=fake_config),
         patch("posit_bakery.plugins.builtin.imagetools.oras.find_oras_bin", return_value="oras"),
-        patch("posit_bakery.plugins.builtin.imagetools.oras.OrasWaitForSourcesWorkflow", side_effect=fake_wait_ctor),
+        patch("posit_bakery.plugins.builtin.imagetools.soci.find_soci_bin", return_value="soci"),
+        patch(
+            "posit_bakery.plugins.builtin.imagetools.oras.OrasWaitForSourcesWorkflow",
+            return_value=MagicMock(run=MagicMock(return_value=wait_result)),
+        ),
         patch(
             "posit_bakery.plugins.builtin.imagetools.oras.OrasIndexCreateWorkflow",
-            return_value=MagicMock(run=MagicMock(return_value=fake_create_result)),
+            return_value=MagicMock(run=MagicMock(return_value=create_result)),
         ),
-        patch(
-            "posit_bakery.plugins.builtin.imagetools.oras.OrasIndexCopyWorkflow",
-            return_value=MagicMock(run=MagicMock(return_value=fake_copy_result)),
-        ),
+        _bypass_pydantic_init(OrasIndexCopyWorkflow),
+        patch("posit_bakery.plugins.builtin.imagetools.oras.OrasIndexCopyWorkflow.run", fake_copy_run, create=True),
         patch(
             "posit_bakery.plugins.builtin.imagetools.oras.OrasIndexVerifyWorkflow",
-            return_value=MagicMock(run=MagicMock(return_value=fake_verify_result)),
-        ),
-        patch(
-            "posit_bakery.plugins.builtin.imagetools.imagetools.ImageToolsPlugin.execute",
-            autospec=True,
-            return_value=[],
+            return_value=MagicMock(
+                run=MagicMock(return_value=MagicMock(success=True, verified=["ghcr.io/posit-dev/test:1.0.0"]))
+            ),
         ),
     ):
         result = runner.invoke(app, ["ci", "publish", "meta.json"], env=_WIDE_TERM_ENV)
 
     assert result.exit_code == 0, result.stdout
-    fake_wait_instance.run.assert_called_once()
-    assert sorted(captured["wait_kwargs"]["sources"]) == sorted(sources)
+    # Stage 2 pushes in push_sort_key order regardless of how Stage 1 completed.
+    assert copy_order == ["uid-b", "uid-a"]
+
+
+def test_publish_isolates_one_targets_create_failure_from_others(tmp_path):
+    """One target's index-create failure must not prevent the other target from publishing,
+    and the overall command must still exit non-zero."""
+    failing = _fake_target("uid-fail", merge_sources=["ghcr.io/posit-dev/test/tmp@sha256:f"])
+    failing.settings.temp_registry = "ghcr.io/posit-dev"
+    ok = _fake_target("uid-ok", merge_sources=["ghcr.io/posit-dev/test/tmp@sha256:o"])
+    ok.settings.temp_registry = "ghcr.io/posit-dev"
+
+    fake_config = MagicMock()
+    fake_config.base_path = tmp_path
+    fake_config.load_build_metadata_from_file.return_value = ["uid-fail", "uid-ok"]
+    fake_config.get_image_target_by_uid.side_effect = lambda uid: {"uid-fail": failing, "uid-ok": ok}[uid]
+
+    wait_result = MagicMock(success=True, ready=["x"], missing=[], waited_seconds=0.1, error=None)
+
+    def fake_create_run(self, dry_run=False, runner=None):
+        if self.image_target.uid == "uid-fail":
+            return MagicMock(success=False, temp_ref=None, error="boom")
+        return MagicMock(success=True, temp_ref="ghcr.io/posit-dev/tmp:created")
+
+    copied = []
+
+    def fake_copy_run(self, source, dry_run=False):
+        copied.append(self.image_target.uid)
+        return MagicMock(success=True, destinations=["ghcr.io/posit-dev/test:1.0.0"], error=None)
+
+    runner = CliRunner()
+    with (
+        patch("posit_bakery.cli.ci.BakeryConfig.from_context", return_value=fake_config),
+        patch("posit_bakery.plugins.builtin.imagetools.oras.find_oras_bin", return_value="oras"),
+        patch("posit_bakery.plugins.builtin.imagetools.soci.find_soci_bin", return_value="soci"),
+        patch(
+            "posit_bakery.plugins.builtin.imagetools.oras.OrasWaitForSourcesWorkflow",
+            return_value=MagicMock(run=MagicMock(return_value=wait_result)),
+        ),
+        _bypass_pydantic_init(OrasIndexCreateWorkflow),
+        patch("posit_bakery.plugins.builtin.imagetools.oras.OrasIndexCreateWorkflow.run", fake_create_run, create=True),
+        _bypass_pydantic_init(OrasIndexCopyWorkflow),
+        patch("posit_bakery.plugins.builtin.imagetools.oras.OrasIndexCopyWorkflow.run", fake_copy_run, create=True),
+        patch(
+            "posit_bakery.plugins.builtin.imagetools.oras.OrasIndexVerifyWorkflow",
+            return_value=MagicMock(
+                run=MagicMock(return_value=MagicMock(success=True, verified=["ghcr.io/posit-dev/test:1.0.0"]))
+            ),
+        ),
+    ):
+        result = runner.invoke(app, ["ci", "publish", "meta.json"], env=_WIDE_TERM_ENV)
+
+    assert result.exit_code == 1
+    # The failing target never reached Stage 2; the healthy target still published.
+    assert copied == ["uid-ok"]
 
 
 def test_publish_aborts_when_sources_never_ready(tmp_path):
-    """A wait timeout aborts the publish before any phase runs."""
+    """A wait timeout for the only target fails that target (and, since it's the only
+    target, the whole run) without raising."""
     sources = ["ghcr.io/posit-dev/test/tmp@sha256:amd64"]
     target = _fake_target("uid1", merge_sources=sources)
     target.settings.temp_registry = "ghcr.io/posit-dev"
@@ -160,34 +190,29 @@ def test_publish_aborts_when_sources_never_ready(tmp_path):
     fake_config.load_build_metadata_from_file.return_value = ["uid1"]
     fake_config.get_image_target_by_uid.return_value = target
 
-    fake_wait_instance = MagicMock()
-    fake_wait_instance.run.return_value = MagicMock(
-        success=False, ready=[], missing=sources, waited_seconds=600.0, error="still unreadable"
-    )
+    wait_failure = MagicMock(success=False, ready=[], missing=sources, waited_seconds=600.0, error="still unreadable")
 
     runner = CliRunner()
     with (
         patch("posit_bakery.cli.ci.BakeryConfig.from_context", return_value=fake_config),
         patch("posit_bakery.plugins.builtin.imagetools.oras.find_oras_bin", return_value="oras"),
+        patch("posit_bakery.plugins.builtin.imagetools.soci.find_soci_bin", return_value="soci"),
         patch(
             "posit_bakery.plugins.builtin.imagetools.oras.OrasWaitForSourcesWorkflow",
-            return_value=fake_wait_instance,
+            return_value=MagicMock(run=MagicMock(return_value=wait_failure)),
         ),
-        patch(
-            "posit_bakery.plugins.builtin.imagetools.imagetools.ImageToolsPlugin.execute",
-            autospec=True,
-        ) as mock_execute,
+        patch("posit_bakery.plugins.builtin.imagetools.oras.OrasIndexCreateWorkflow") as mock_create,
     ):
         result = runner.invoke(app, ["ci", "publish", "meta.json"], env=_WIDE_TERM_ENV)
 
     assert result.exit_code == 1
-    # Aborted before SOCI convert.
-    mock_execute.assert_not_called()
+    # Stage 1 never reached index-create for this target.
+    mock_create.assert_not_called()
 
 
 def test_publish_surfaces_clean_error_on_non_transient_wait_failure(tmp_path):
-    """A non-transient registry error during the wait exits cleanly (code 1)
-    rather than escaping as an unhandled traceback."""
+    """A non-transient registry error during the wait exits cleanly (code 1) rather than
+    escaping as an unhandled traceback."""
     from posit_bakery.error import BakeryToolRuntimeError
 
     sources = ["ghcr.io/posit-dev/test/tmp@sha256:amd64"]
@@ -199,8 +224,7 @@ def test_publish_surfaces_clean_error_on_non_transient_wait_failure(tmp_path):
     fake_config.load_build_metadata_from_file.return_value = ["uid1"]
     fake_config.get_image_target_by_uid.return_value = target
 
-    fake_wait_instance = MagicMock()
-    fake_wait_instance.run.side_effect = BakeryToolRuntimeError(
+    error = BakeryToolRuntimeError(
         message="oras command failed",
         tool_name="oras",
         cmd=["oras", "manifest", "fetch"],
@@ -212,18 +236,15 @@ def test_publish_surfaces_clean_error_on_non_transient_wait_failure(tmp_path):
     with (
         patch("posit_bakery.cli.ci.BakeryConfig.from_context", return_value=fake_config),
         patch("posit_bakery.plugins.builtin.imagetools.oras.find_oras_bin", return_value="oras"),
+        patch("posit_bakery.plugins.builtin.imagetools.soci.find_soci_bin", return_value="soci"),
         patch(
             "posit_bakery.plugins.builtin.imagetools.oras.OrasWaitForSourcesWorkflow",
-            return_value=fake_wait_instance,
+            return_value=MagicMock(run=MagicMock(side_effect=error)),
         ),
-        patch(
-            "posit_bakery.plugins.builtin.imagetools.imagetools.ImageToolsPlugin.execute",
-            autospec=True,
-        ) as mock_execute,
+        patch("posit_bakery.plugins.builtin.imagetools.oras.OrasIndexCreateWorkflow") as mock_create,
     ):
         result = runner.invoke(app, ["ci", "publish", "meta.json"], env=_WIDE_TERM_ENV)
 
-    # Clean exit, not an unhandled exception.
     assert result.exit_code == 1
     assert result.exception is None or isinstance(result.exception, SystemExit)
-    mock_execute.assert_not_called()
+    mock_create.assert_not_called()

--- a/posit-bakery/test/cli/test_ci_publish.py
+++ b/posit-bakery/test/cli/test_ci_publish.py
@@ -248,3 +248,37 @@ def test_publish_surfaces_clean_error_on_non_transient_wait_failure(tmp_path):
     assert result.exit_code == 1
     assert result.exception is None or isinstance(result.exception, SystemExit)
     mock_create.assert_not_called()
+
+
+def test_publish_jobs_flag_present():
+    runner = CliRunner()
+    result = runner.invoke(app, ["ci", "publish", "--help"], env=_WIDE_TERM_ENV)
+    assert result.exit_code == 0
+    assert "--jobs" in result.stdout
+    assert "-j" in result.stdout
+
+
+def test_publish_jobs_flag_passed_through(tmp_path):
+    captured = {}
+
+    fake_config = MagicMock()
+    fake_config.base_path = tmp_path
+    fake_config.load_build_metadata_from_file.return_value = []
+    fake_config.get_image_target_by_uid.return_value = None
+
+    def fake_publish(self, *args, **kwargs):
+        captured["jobs"] = kwargs.get("jobs")
+
+    runner = CliRunner()
+    with (
+        patch("posit_bakery.cli.ci.BakeryConfig.from_context", return_value=fake_config),
+        patch(
+            "posit_bakery.plugins.builtin.imagetools.imagetools.ImageToolsPlugin.publish",
+            autospec=True,
+            side_effect=fake_publish,
+        ),
+    ):
+        result = runner.invoke(app, ["ci", "publish", "meta.json", "--jobs", "4"], env=_WIDE_TERM_ENV)
+
+    assert result.exit_code == 0, result.stdout
+    assert captured["jobs"] == 4

--- a/posit-bakery/test/parallel/test_executor.py
+++ b/posit-bakery/test/parallel/test_executor.py
@@ -348,6 +348,12 @@ class TestParallelShellExecutorJobs:
     def test_empty_jobs_returns_empty(self):
         assert self._executor(2).run_jobs([]) == []
 
+    def test_job_value_is_callable_return(self):
+        job = ShellJob(key="a", run=lambda runner: runner.run([PY, "-c", "print('hi')"]).stdout.decode().strip())
+        results = self._executor(1).run_jobs([job])
+        assert results[0].ok is True
+        assert results[0].value == "hi"
+
     def test_results_returned_in_input_order(self):
         # Sleep durations are inverted vs. input order so completion order differs.
         durations = {"a": 0.30, "b": 0.05, "c": 0.15}
@@ -392,3 +398,45 @@ class TestParallelShellExecutorJobs:
         results = self._executor(1).run_jobs([ShellJob(key="a", run=run)])
         assert results[0].ok is False
         assert isinstance(results[0].exception, (FileNotFoundError, OSError))
+
+    def test_on_result_called_once_per_job_on_main_thread(self):
+        jobs = [ShellJob(key=str(i), run=lambda runner: runner.run([PY, "-c", "pass"]).returncode) for i in range(5)]
+        seen_keys = []
+        seen_threads = set()
+
+        def on_result(result):
+            seen_keys.append(result.job.key)
+            seen_threads.add(threading.get_ident())
+
+        self._executor(3).run_jobs(jobs, on_result=on_result)
+        assert sorted(seen_keys) == sorted(j.key for j in jobs)
+        assert seen_threads == {threading.main_thread().ident}
+
+    def test_sigint_terminates_in_flight_children(self, tmp_path):
+        # Mirrors TestParallelShellExecutor.test_sigint_cancels_queued_and_terminates_running
+        # for the ShellTask path: confirms run_jobs() shares the same interrupt-safety
+        # primitive rather than re-testing every nuance of it.
+        marker = tmp_path / "started"
+        script = f"import pathlib,time; pathlib.Path({str(marker)!r}).write_text('1'); time.sleep(5)"
+
+        def run(runner):
+            runner.run([PY, "-c", script])
+
+        ex = self._executor(1)
+        result_holder = {}
+
+        def driver():
+            try:
+                result_holder["results"] = ex.run_jobs([ShellJob(key="a", run=run)])
+            except BaseException as exc:
+                result_holder["exc"] = exc
+
+        thread = threading.Thread(target=driver)
+        thread.start()
+        while not marker.exists():
+            time.sleep(0.01)
+        with ex._lock:
+            ex._shutdown = True
+        ex._terminate_active()
+        thread.join(timeout=5)
+        assert not thread.is_alive()

--- a/posit-bakery/test/parallel/test_executor.py
+++ b/posit-bakery/test/parallel/test_executor.py
@@ -414,29 +414,34 @@ class TestParallelShellExecutorJobs:
 
     def test_sigint_terminates_in_flight_children(self, tmp_path):
         # Mirrors TestParallelShellExecutor.test_sigint_cancels_queued_and_terminates_running
-        # for the ShellTask path: confirms run_jobs() shares the same interrupt-safety
-        # primitive rather than re-testing every nuance of it.
+        # for the ShellJob path, firing a real SIGINT so the full run_jobs() -> run() ->
+        # _execute_pool() interrupt-handling chain is exercised end to end, rather than
+        # calling _terminate_active() directly and skipping the KeyboardInterrupt path.
         marker = tmp_path / "started"
-        script = f"import pathlib,time; pathlib.Path({str(marker)!r}).write_text('1'); time.sleep(5)"
+        ended = tmp_path / "ended"
+        script = (
+            f"import pathlib,time; pathlib.Path({str(marker)!r}).write_text('1'); "
+            f"time.sleep(5); pathlib.Path({str(ended)!r}).write_text('1')"
+        )
 
         def run(runner):
             runner.run([PY, "-c", script])
 
+        def fire():
+            while not marker.exists():
+                time.sleep(0.01)
+            os.kill(os.getpid(), signal.SIGINT)
+
+        threading.Thread(target=fire, daemon=True).start()
         ex = self._executor(1)
-        result_holder = {}
+        start = time.monotonic()
+        interrupted = False
+        try:
+            ex.run_jobs([ShellJob(key="a", run=run)])
+        except KeyboardInterrupt:
+            interrupted = True
+        elapsed = time.monotonic() - start
 
-        def driver():
-            try:
-                result_holder["results"] = ex.run_jobs([ShellJob(key="a", run=run)])
-            except BaseException as exc:
-                result_holder["exc"] = exc
-
-        thread = threading.Thread(target=driver)
-        thread.start()
-        while not marker.exists():
-            time.sleep(0.01)
-        with ex._lock:
-            ex._shutdown = True
-        ex._terminate_active()
-        thread.join(timeout=5)
-        assert not thread.is_alive()
+        assert interrupted is True
+        assert elapsed < 5  # terminated promptly, did not wait out the 5s sleep
+        assert not ended.exists()  # child was killed, not left to finish

--- a/posit-bakery/test/parallel/test_executor.py
+++ b/posit-bakery/test/parallel/test_executor.py
@@ -12,7 +12,15 @@ from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 
 from posit_bakery.const import DEFAULT_MAX_CONCURRENCY
-from posit_bakery.parallel import ParallelShellExecutor, ShellResult, ShellTask, resolve_max_workers
+from posit_bakery.parallel import (
+    CommandRunner,
+    JobResult,
+    ParallelShellExecutor,
+    ShellJob,
+    ShellResult,
+    ShellTask,
+    resolve_max_workers,
+)
 
 PY = sys.executable
 
@@ -305,3 +313,82 @@ class TestParallelShellExecutorInterrupt:
         assert elapsed < 3  # stopped promptly, not waited out for 30s
         assert result.returncode != 0  # the child was signalled, not a clean exit
         assert ex._active == set()  # never registered (or already discarded)
+
+
+class TestShellJob:
+    def test_display_label_defaults_to_key(self):
+        job = ShellJob(key="abc", run=lambda runner: None)
+        assert job.display_label == "abc"
+
+    def test_display_label_uses_label_when_set(self):
+        job = ShellJob(key="abc", run=lambda runner: None, label="My Label")
+        assert job.display_label == "My Label"
+
+
+class TestJobResult:
+    def test_ok_true_on_no_exception(self):
+        job = ShellJob(key="a", run=lambda runner: None)
+        result = JobResult(job=job, value=42)
+        assert result.ok is True
+
+    def test_ok_false_on_exception(self):
+        job = ShellJob(key="a", run=lambda runner: None)
+        result = JobResult(job=job, value=None, exception=RuntimeError("boom"))
+        assert result.ok is False
+
+
+class TestParallelShellExecutorJobs:
+    def _executor(self, max_workers):
+        return ParallelShellExecutor(
+            max_workers=max_workers,
+            console=Console(file=io.StringIO()),
+            use_live=False,
+        )
+
+    def test_empty_jobs_returns_empty(self):
+        assert self._executor(2).run_jobs([]) == []
+
+    def test_results_returned_in_input_order(self):
+        # Sleep durations are inverted vs. input order so completion order differs.
+        durations = {"a": 0.30, "b": 0.05, "c": 0.15}
+
+        def make_run(d):
+            return lambda runner: runner.run([PY, "-c", f"import time; time.sleep({d})"]).returncode
+
+        jobs = [ShellJob(key=k, run=make_run(d)) for k, d in durations.items()]
+        results = self._executor(3).run_jobs(jobs)
+        assert [r.job.key for r in results] == ["a", "b", "c"]
+
+    def test_job_exception_isolated_others_still_run(self):
+        def boom(runner):
+            raise RuntimeError("target blew up")
+
+        def ok(runner):
+            return runner.run([PY, "-c", "pass"]).returncode
+
+        jobs = [ShellJob(key="bad", run=boom), ShellJob(key="good", run=ok)]
+        results = self._executor(2).run_jobs(jobs)
+        by_key = {r.job.key: r for r in results}
+        assert by_key["bad"].ok is False
+        assert isinstance(by_key["bad"].exception, RuntimeError)
+        assert by_key["good"].ok is True
+        assert by_key["good"].value == 0
+
+    def test_runner_run_returns_completed_process(self):
+        captured = {}
+
+        def run(runner):
+            captured["result"] = runner.run([PY, "-c", "import sys; sys.stdout.write('out'); sys.exit(3)"])
+
+        self._executor(1).run_jobs([ShellJob(key="a", run=run)])
+        result = captured["result"]
+        assert result.returncode == 3
+        assert result.stdout == b"out"
+
+    def test_runner_run_spawn_failure_raises(self):
+        def run(runner):
+            runner.run(["definitely-not-a-real-binary-zzz"])
+
+        results = self._executor(1).run_jobs([ShellJob(key="a", run=run)])
+        assert results[0].ok is False
+        assert isinstance(results[0].exception, (FileNotFoundError, OSError))

--- a/posit-bakery/test/plugins/builtin/imagetools/test_command_base.py
+++ b/posit-bakery/test/plugins/builtin/imagetools/test_command_base.py
@@ -3,7 +3,7 @@
 import os
 import subprocess
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from pydantic import Field
@@ -50,6 +50,25 @@ def test_dry_run_does_not_invoke_subprocess():
         result = cmd.run(dry_run=True)
     mock_run.assert_not_called()
     assert result.returncode == 0
+
+
+def test_run_uses_runner_when_provided():
+    cmd = _StubSociCommand(soci_bin="soci", arg="x")
+    fake_runner = MagicMock()
+    fake_runner.run.return_value = subprocess.CompletedProcess(args=cmd.command, returncode=0, stdout=b"ok", stderr=b"")
+
+    result = cmd.run(runner=fake_runner)
+
+    fake_runner.run.assert_called_once_with(cmd.command)
+    assert result.returncode == 0
+
+
+def test_run_falls_back_to_subprocess_when_runner_omitted():
+    cmd = _StubSociCommand(soci_bin="soci", arg="x")
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(args=cmd.command, returncode=0, stdout=b"", stderr=b"")
+        cmd.run()
+    mock_run.assert_called_once_with(cmd.command, capture_output=True)
 
 
 def test_find_soci_bin_uses_env_var(tmp_path, monkeypatch):

--- a/posit-bakery/test/plugins/builtin/imagetools/test_oras.py
+++ b/posit-bakery/test/plugins/builtin/imagetools/test_oras.py
@@ -44,6 +44,38 @@ def test_get_repository_from_ref(ref, expected_repo):
     assert result == expected_repo
 
 
+class TestOrasCommandRunner:
+    """Tests for OrasCommand.run()'s optional CommandRunner routing."""
+
+    def test_runner_used_when_provided(self):
+        cmd = OrasManifestFetch(oras_bin="oras", reference="ghcr.io/x/y:latest")
+        fake_runner = MagicMock()
+        fake_runner.run.return_value = subprocess.CompletedProcess(
+            args=cmd.command, returncode=0, stdout=b"ok", stderr=b""
+        )
+
+        result = cmd.run(runner=fake_runner)
+
+        fake_runner.run.assert_called_once_with(cmd.command)
+        assert result.returncode == 0
+
+    def test_subprocess_run_used_when_runner_omitted(self):
+        cmd = OrasManifestFetch(oras_bin="oras", reference="ghcr.io/x/y:latest")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(args=cmd.command, returncode=0, stdout=b"", stderr=b"")
+            cmd.run()
+        mock_run.assert_called_once_with(cmd.command, capture_output=True)
+
+    def test_runner_failure_raises_tool_error(self):
+        cmd = OrasManifestFetch(oras_bin="oras", reference="ghcr.io/x/y:latest")
+        fake_runner = MagicMock()
+        fake_runner.run.return_value = subprocess.CompletedProcess(
+            args=cmd.command, returncode=1, stdout=b"", stderr=b"nope"
+        )
+        with pytest.raises(BakeryToolRuntimeError):
+            cmd.run(runner=fake_runner)
+
+
 class TestOrasManifestIndexCreate:
     """Tests for the OrasManifestIndexCreate command."""
 
@@ -573,6 +605,15 @@ class TestOrasIndexCreateWorkflow:
         cmd = mock_run.call_args.args[0]
         assert cmd[:4] == ["oras", "manifest", "index", "create"]
 
+    def test_index_create_passes_runner_through(self, workflow):
+        fake_runner = MagicMock()
+        fake_runner.run.return_value = subprocess.CompletedProcess(args=["oras"], returncode=0, stdout=b"", stderr=b"")
+
+        result = workflow.run(runner=fake_runner)
+
+        assert result.success is True
+        fake_runner.run.assert_called_once()
+
 
 class TestOrasIndexCopyWorkflow:
     """Tests for the standalone index-copy primitive."""
@@ -986,5 +1027,15 @@ class TestOrasWaitForSourcesWorkflow:
         with patch("subprocess.run") as mock_run:
             result = wf.run()
         mock_run.assert_not_called()
+
+    def test_wait_for_sources_passes_runner_through(self):
+        wf = OrasWaitForSourcesWorkflow(oras_bin="oras", sources=["ghcr.io/posit-dev/test/tmp@sha256:a"])
+        fake_runner = MagicMock()
+        fake_runner.run.return_value = subprocess.CompletedProcess(
+            args=["oras"], returncode=0, stdout=b"{}", stderr=b""
+        )
+
+        result = wf.run(sleep=MagicMock(), now=lambda: 0.0, runner=fake_runner)
+
         assert result.success is True
-        assert result.ready == []
+        fake_runner.run.assert_called_once()

--- a/posit-bakery/test/plugins/builtin/imagetools/test_publish_stage1.py
+++ b/posit-bakery/test/plugins/builtin/imagetools/test_publish_stage1.py
@@ -1,0 +1,191 @@
+"""Tests for ImageToolsPlugin's per-target publish Stage 1 helper (wait + create + soci)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from posit_bakery.error import BakeryToolRuntimeError
+from posit_bakery.plugins.builtin.imagetools.imagetools import _PublishStage1Result, _run_publish_stage1
+
+pytestmark = [pytest.mark.unit]
+
+
+def _target(uid="uid1", merge_sources=None, temp_registry="ghcr.io/posit-dev"):
+    t = MagicMock()
+    t.uid = uid
+    t.get_merge_sources.return_value = merge_sources if merge_sources is not None else ["ghcr.io/x@sha256:a"]
+    t.settings.temp_registry = temp_registry
+    t.labels = {}
+    # No real SociOptions configured anywhere -> get_soci_options_for_target resolves to
+    # a disabled default without needing to iterate real option lists.
+    t.image_version.parent.options = []
+    t.image_variant = None
+    return t
+
+
+def _wait_ok(sources):
+    return MagicMock(success=True, ready=sources, missing=[], waited_seconds=0.1, error=None)
+
+
+def _wait_fail(sources):
+    return MagicMock(success=False, ready=[], missing=sources, waited_seconds=600.0, error="still unreadable")
+
+
+class TestRunPublishStage1:
+    def test_skips_target_with_no_merge_sources(self):
+        target = _target(merge_sources=[])
+        result = _run_publish_stage1(target, "oras", "soci", dry_run=False)
+        assert result.skipped is True
+        assert result.skip_reason == "no merge sources"
+
+    def test_fails_when_temp_registry_not_configured(self):
+        target = _target(temp_registry=None)
+        result = _run_publish_stage1(target, "oras", "soci", dry_run=False)
+        assert result.success is False
+        assert result.failed_phase == "create"
+
+    def test_success_without_soci(self):
+        target = _target()
+        with (
+            patch(
+                "posit_bakery.plugins.builtin.imagetools.oras.OrasWaitForSourcesWorkflow",
+                return_value=MagicMock(run=MagicMock(return_value=_wait_ok(target.get_merge_sources()))),
+            ),
+            patch(
+                "posit_bakery.plugins.builtin.imagetools.oras.OrasIndexCreateWorkflow",
+                return_value=MagicMock(
+                    run=MagicMock(return_value=MagicMock(success=True, temp_ref="ghcr.io/x/tmp:created"))
+                ),
+            ),
+        ):
+            result = _run_publish_stage1(target, "oras", "soci", dry_run=False)
+
+        assert result.success is True
+        assert result.skipped is False
+        assert result.temp_ref == "ghcr.io/x/tmp:created"
+
+    def test_wait_failure_marks_target_failed(self):
+        target = _target()
+        with patch(
+            "posit_bakery.plugins.builtin.imagetools.oras.OrasWaitForSourcesWorkflow",
+            return_value=MagicMock(run=MagicMock(return_value=_wait_fail(target.get_merge_sources()))),
+        ):
+            result = _run_publish_stage1(target, "oras", "soci", dry_run=False)
+
+        assert result.success is False
+        assert result.failed_phase == "wait"
+
+    def test_non_transient_wait_error_marks_target_failed_not_raised(self):
+        target = _target()
+        error = BakeryToolRuntimeError(
+            message="oras command failed",
+            tool_name="oras",
+            cmd=["oras", "manifest", "fetch"],
+            stdout=b"",
+            stderr=b"unauthorized: authentication required",
+        )
+        with patch(
+            "posit_bakery.plugins.builtin.imagetools.oras.OrasWaitForSourcesWorkflow",
+            return_value=MagicMock(run=MagicMock(side_effect=error)),
+        ):
+            result = _run_publish_stage1(target, "oras", "soci", dry_run=False)
+
+        assert result.success is False
+        assert result.failed_phase == "wait"
+
+    def test_create_failure_marks_target_failed(self):
+        target = _target()
+        with (
+            patch(
+                "posit_bakery.plugins.builtin.imagetools.oras.OrasWaitForSourcesWorkflow",
+                return_value=MagicMock(run=MagicMock(return_value=_wait_ok(target.get_merge_sources()))),
+            ),
+            patch(
+                "posit_bakery.plugins.builtin.imagetools.oras.OrasIndexCreateWorkflow",
+                return_value=MagicMock(
+                    run=MagicMock(return_value=MagicMock(success=False, temp_ref=None, error="boom"))
+                ),
+            ),
+        ):
+            result = _run_publish_stage1(target, "oras", "soci", dry_run=False)
+
+        assert result.success is False
+        assert result.failed_phase == "create"
+        assert result.error == "boom"
+
+    def test_soci_enabled_success_overwrites_temp_ref(self):
+        target = _target()
+        from posit_bakery.plugins.builtin.imagetools.options import SociOptions
+
+        target.image_version.parent.options = [SociOptions(enabled=True)]
+        with (
+            patch(
+                "posit_bakery.plugins.builtin.imagetools.oras.OrasWaitForSourcesWorkflow",
+                return_value=MagicMock(run=MagicMock(return_value=_wait_ok(target.get_merge_sources()))),
+            ),
+            patch(
+                "posit_bakery.plugins.builtin.imagetools.oras.OrasIndexCreateWorkflow",
+                return_value=MagicMock(
+                    run=MagicMock(return_value=MagicMock(success=True, temp_ref="ghcr.io/x/tmp:created"))
+                ),
+            ),
+            patch(
+                "posit_bakery.plugins.builtin.imagetools.soci.SociConvertWorkflow",
+                return_value=MagicMock(
+                    run=MagicMock(return_value=MagicMock(success=True, destination_ref="ghcr.io/x/tmp:created-soci"))
+                ),
+            ),
+        ):
+            result = _run_publish_stage1(target, "oras", "soci", dry_run=False)
+
+        assert result.success is True
+        assert result.temp_ref == "ghcr.io/x/tmp:created-soci"
+
+    def test_soci_failure_marks_target_failed(self):
+        target = _target()
+        from posit_bakery.plugins.builtin.imagetools.options import SociOptions
+
+        target.image_version.parent.options = [SociOptions(enabled=True)]
+        with (
+            patch(
+                "posit_bakery.plugins.builtin.imagetools.oras.OrasWaitForSourcesWorkflow",
+                return_value=MagicMock(run=MagicMock(return_value=_wait_ok(target.get_merge_sources()))),
+            ),
+            patch(
+                "posit_bakery.plugins.builtin.imagetools.oras.OrasIndexCreateWorkflow",
+                return_value=MagicMock(
+                    run=MagicMock(return_value=MagicMock(success=True, temp_ref="ghcr.io/x/tmp:created"))
+                ),
+            ),
+            patch(
+                "posit_bakery.plugins.builtin.imagetools.soci.SociConvertWorkflow",
+                return_value=MagicMock(
+                    run=MagicMock(return_value=MagicMock(success=False, destination_ref=None, error="soci boom"))
+                ),
+            ),
+        ):
+            result = _run_publish_stage1(target, "oras", "soci", dry_run=False)
+
+        assert result.success is False
+        assert result.failed_phase == "soci"
+        assert result.error == "soci boom"
+
+    def test_passes_runner_through_to_wait_and_create(self):
+        target = _target()
+        fake_runner = MagicMock()
+        with (
+            patch(
+                "posit_bakery.plugins.builtin.imagetools.oras.OrasWaitForSourcesWorkflow",
+                return_value=MagicMock(run=MagicMock(return_value=_wait_ok(target.get_merge_sources()))),
+            ) as wait_ctor,
+            patch(
+                "posit_bakery.plugins.builtin.imagetools.oras.OrasIndexCreateWorkflow",
+                return_value=MagicMock(
+                    run=MagicMock(return_value=MagicMock(success=True, temp_ref="ghcr.io/x/tmp:created"))
+                ),
+            ) as create_ctor,
+        ):
+            _run_publish_stage1(target, "oras", "soci", dry_run=False, runner=fake_runner)
+
+        wait_ctor.return_value.run.assert_called_once_with(dry_run=False, runner=fake_runner)
+        create_ctor.return_value.run.assert_called_once_with(dry_run=False, runner=fake_runner)

--- a/posit-bakery/test/plugins/builtin/imagetools/test_workflow.py
+++ b/posit-bakery/test/plugins/builtin/imagetools/test_workflow.py
@@ -195,3 +195,27 @@ def test_read_converted_digest_reads_index_json(workflow, tmp_path):
     layout.mkdir()
     (layout / "index.json").write_text('{"schemaVersion":2,"manifests":[{"digest":"sha256:deadbeef","size":7849}]}')
     assert workflow._read_converted_digest(layout) == "sha256:deadbeef"
+
+
+def test_runner_passed_to_pull_convert_push(workflow, tmp_path):
+    fake_runner = MagicMock()
+    captured_runners = []
+
+    def fake_oras_copy_run(self, dry_run=False, runner=None):
+        captured_runners.append(runner)
+        return subprocess.CompletedProcess(args=[], returncode=0, stdout=b"", stderr=b"")
+
+    def fake_soci_convert_run(self, dry_run=False, runner=None):
+        captured_runners.append(runner)
+        (tmp_path / "index.json").write_text('{"manifests": [{"digest": "sha256:abc"}]}')
+        return subprocess.CompletedProcess(args=[], returncode=0, stdout=b"", stderr=b"")
+
+    with (
+        patch("posit_bakery.plugins.builtin.imagetools.soci.OrasCopy.run", fake_oras_copy_run),
+        patch("posit_bakery.plugins.builtin.imagetools.soci.SociConvert.run", fake_soci_convert_run),
+        patch.object(workflow, "_read_converted_digest", return_value="sha256:abc"),
+    ):
+        result = workflow.run(runner=fake_runner)
+
+    assert result.success is True
+    assert captured_runners == [fake_runner, fake_runner, fake_runner]


### PR DESCRIPTION
## Summary

Stacked on #619 (unmerged) — targets that branch rather than `main` so this diff only shows the new work.

Parallelizes `bakery ci publish`'s per-target pipeline across image targets, while keeping each target's own operation sequence (wait-for-sources → index-create → soci-convert → index-copy → verify) strictly ordered:

- **Stage 1 (parallel):** wait-for-sources + index-create + soci-convert run concurrently, one job per target, via a new `ParallelShellExecutor.run_jobs()`/`ShellJob`/`CommandRunner` (`parallel/executor.py`) built on the same tracked-spawn/Ctrl-C-safety primitive the existing dgoss `run()` path uses. One target's failure is isolated — it no longer aborts the whole run.
- **Stage 2 (sequential, ordered):** index-copy (the actual registry push) stays serialized in `push_sort_key` order, so registries that display tags by push time (e.g. Docker Hub) still show the latest version as most recent.
- **Stage 3 (sequential):** verify, unchanged — read-only and order-independent.
- Adds `--jobs`/`-j` to `bakery ci publish`, matching the existing dgoss flag.

Out of scope (deferred to follow-up work, per the design spec): retry-with-backoff plumbing in the `parallel` module (transient registry errors are already handled independently by `posit_bakery/retry.py`), and unifying `oras merge`/`soci convert` into this same pipeline.

Design spec and implementation plan (local-only, gitignored under `docs/superpowers/`) drove this; happy to share their content in review if useful.

## Test plan

- [x] `uv run pytest test/parallel/ test/plugins/builtin/imagetools/ test/cli/test_ci_publish.py -q` — 174 passed
- [x] `uv run ruff check .` / `uv run ruff format --check .` — clean
- [x] Task-by-task review (spec compliance + code quality) during implementation; whole-branch review across the full diff — no Critical/Important findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)