### PR TITLE
feat: retry-with-backoff for the parallel publish path

### DIFF
--- a/posit-bakery/posit_bakery/parallel/__init__.py
+++ b/posit-bakery/posit_bakery/parallel/__init__.py
@@ -1,5 +1,6 @@
 from posit_bakery.parallel.executor import (
     CommandRunner,
+    ExecutorInterrupted,
     JobResult,
     ParallelShellExecutor,
     ShellJob,
@@ -10,6 +11,7 @@ from posit_bakery.parallel.executor import (
 
 __all__ = [
     "CommandRunner",
+    "ExecutorInterrupted",
     "JobResult",
     "ParallelShellExecutor",
     "ShellJob",

--- a/posit-bakery/posit_bakery/parallel/executor.py
+++ b/posit-bakery/posit_bakery/parallel/executor.py
@@ -22,6 +22,20 @@ from posit_bakery.settings import SETTINGS
 # its container via its EXIT trap — before we escalate to SIGKILL.
 TERMINATE_GRACE_SECONDS = 10.0
 
+# Slice width for CommandRunner.sleep()'s interruptible backoff wait. Short
+# enough that a shutdown request is noticed promptly without busy-waiting.
+RETRY_SLEEP_SLICE_SECONDS = 0.5
+
+
+class ExecutorInterrupted(Exception):
+    """Raised by :meth:`CommandRunner.sleep` when the bound executor's shutdown
+    flag flips mid-wait.
+
+    Lets a job blocked in retry backoff unwind within one slice of a shutdown
+    request (e.g. Ctrl-C) instead of finishing its full sleep and blocking
+    process exit via ThreadPoolExecutor's atexit thread-join.
+    """
+
 
 def _signal_process_group(proc: subprocess.Popen, sig: int) -> None:
     """Send `sig` to the child's whole process group, so a wrapper (e.g. dgoss) and the
@@ -438,3 +452,21 @@ class CommandRunner:
         if exception is not None:
             raise exception
         return subprocess.CompletedProcess(args=cmd, returncode=returncode, stdout=stdout, stderr=stderr)
+
+    def sleep(self, seconds: float, *, slice_seconds: float = RETRY_SLEEP_SLICE_SECONDS) -> None:
+        """Sleep for ``seconds``, waking early to raise :class:`ExecutorInterrupted`
+        if the bound executor's shutdown flag flips mid-wait.
+
+        Passed as the ``sleep`` callable to
+        :func:`posit_bakery.retry.retry_on_transient` when retrying inside a
+        parallel job, so a job blocked in backoff notices a shutdown request
+        within one slice instead of blocking process exit.
+        """
+        remaining = seconds
+        while remaining > 0:
+            if self._executor._shutdown:
+                raise ExecutorInterrupted(f"shutdown requested during backoff for '{self._key}'")
+            time.sleep(min(slice_seconds, remaining))
+            remaining -= slice_seconds
+        if self._executor._shutdown:
+            raise ExecutorInterrupted(f"shutdown requested during backoff for '{self._key}'")

--- a/posit-bakery/posit_bakery/plugins/builtin/imagetools/oras.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/imagetools/oras.py
@@ -235,6 +235,7 @@ class OrasIndexCreateWorkflow(BaseModel):
                 lambda: cmd.run(dry_run=dry_run, runner=runner),
                 policy=self.retry_policy,
                 description=f"index-create for '{self.image_target.uid}'",
+                sleep=runner.sleep if runner is not None else None,
             )
             return OrasIndexCreateResult(success=True, temp_ref=self.temp_index_tag)
         except BakeryToolRuntimeError as e:

--- a/posit-bakery/posit_bakery/plugins/builtin/imagetools/oras.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/imagetools/oras.py
@@ -313,17 +313,25 @@ class OrasIndexVerifyWorkflow(BaseModel):
     oras_bin: Annotated[str, Field(description="Path to the oras binary.")]
     image_target: Annotated[ImageTarget, Field(description="Target whose destination tags to verify.")]
     plain_http: Annotated[bool, Field(default=False)]
+    retry_policy: Annotated[RetryPolicy, Field(default_factory=RetryPolicy)]
 
     def run(self, dry_run: bool = False) -> OrasIndexVerifyResult:
         verified: list[str] = []
         try:
             for ref in self.image_target.tags.as_strings():
-                OrasManifestFetch(
+                fetch = OrasManifestFetch(
                     oras_bin=self.oras_bin,
                     reference=ref,
                     descriptor=True,
                     plain_http=self.plain_http,
-                ).run(dry_run=dry_run)
+                )
+                # Retry transient registry errors: the copy phase's write may
+                # still be propagating when this verify fetch first reads it.
+                retry_on_transient(
+                    lambda f=fetch: f.run(dry_run=dry_run),
+                    policy=self.retry_policy,
+                    description=f"index-verify for '{self.image_target.uid}' -> {ref}",
+                )
                 verified.append(ref)
             return OrasIndexVerifyResult(success=True, verified=verified)
         except BakeryToolRuntimeError as e:

--- a/posit-bakery/posit_bakery/plugins/builtin/imagetools/soci.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/imagetools/soci.py
@@ -209,6 +209,7 @@ class SociConvertWorkflow(BaseModel):
                 lambda: pull.run(dry_run=dry_run, runner=runner),
                 policy=self.retry_policy,
                 description=f"soci pull for '{self.image_target.uid}'",
+                sleep=runner.sleep if runner is not None else None,
             )
 
             # 2. convert local layout -> local layout (directory so we can read

--- a/posit-bakery/posit_bakery/retry.py
+++ b/posit-bakery/posit_bakery/retry.py
@@ -127,6 +127,7 @@ def retry_on_transient(
     *,
     policy: RetryPolicy | None = None,
     description: str = "registry operation",
+    sleep: Callable[[float], None] | None = None,
 ) -> T:
     """Call ``func`` retrying transient :class:`BakeryToolRuntimeError`s.
 
@@ -139,11 +140,19 @@ def retry_on_transient(
     :param policy: Retry configuration; a default (env-tunable) policy is used
         when omitted.
     :param description: Human-readable label for log messages.
+    :param sleep: Sleep function used between retry attempts. When omitted
+        (``None``), ``time.sleep`` is looked up fresh on each call rather than
+        bound as a parameter default, so tests that
+        ``patch("posit_bakery.retry.time.sleep")`` keep working. Pass
+        ``CommandRunner.sleep`` when retrying inside a parallel job so backoff
+        waits notice a shutdown request promptly instead of blocking process
+        exit.
     :return: Whatever ``func`` returns on success.
     :raises BakeryToolRuntimeError: The last error if all attempts fail or the
         first non-transient error encountered.
     """
     policy = policy or RetryPolicy()
+    effective_sleep = sleep if sleep is not None else time.sleep
     backoff = policy.initial_backoff
     for attempt in range(1, policy.max_attempts + 1):
         try:
@@ -161,7 +170,7 @@ def retry_on_transient(
                 f"(attempt {attempt}/{policy.max_attempts}); retrying in {backoff:.1f}s. "
                 f"Error: {e.dump_stderr() or e}"
             )
-            time.sleep(backoff)
+            effective_sleep(backoff)
             backoff = min(backoff * policy.multiplier, policy.max_backoff)
     # Unreachable: the loop either returns or raises on the final attempt.
     raise AssertionError("retry_on_transient exhausted its loop without returning or raising")

--- a/posit-bakery/test/parallel/test_executor.py
+++ b/posit-bakery/test/parallel/test_executor.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 import threading
 import time
+from unittest.mock import patch
 
 import pytest
 from rich.console import Console
@@ -14,6 +15,7 @@ from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 from posit_bakery.const import DEFAULT_MAX_CONCURRENCY
 from posit_bakery.parallel import (
     CommandRunner,
+    ExecutorInterrupted,
     JobResult,
     ParallelShellExecutor,
     ShellJob,
@@ -335,6 +337,43 @@ class TestJobResult:
         job = ShellJob(key="a", run=lambda runner: None)
         result = JobResult(job=job, value=None, exception=RuntimeError("boom"))
         assert result.ok is False
+
+
+class TestCommandRunnerSleep:
+    def _runner(self):
+        executor = ParallelShellExecutor(max_workers=1, console=Console(file=io.StringIO()), use_live=False)
+        return executor, CommandRunner(executor, "key", "label")
+
+    def test_sleeps_full_duration_in_slices_when_no_shutdown(self):
+        _executor, runner = self._runner()
+
+        with patch("posit_bakery.parallel.executor.time.sleep") as mock_sleep:
+            runner.sleep(1.2, slice_seconds=0.5)
+
+        assert mock_sleep.call_count == 3
+        assert sum(c.args[0] for c in mock_sleep.call_args_list) == pytest.approx(1.2)
+
+    def test_raises_executor_interrupted_when_shutdown_flips_mid_sleep(self):
+        executor, runner = self._runner()
+
+        def fake_sleep(seconds):
+            executor._shutdown = True
+
+        with patch("posit_bakery.parallel.executor.time.sleep", side_effect=fake_sleep) as mock_sleep:
+            with pytest.raises(ExecutorInterrupted):
+                runner.sleep(10.0, slice_seconds=0.5)
+
+        mock_sleep.assert_called_once()
+
+    def test_raises_immediately_when_shutdown_already_set(self):
+        executor, runner = self._runner()
+        executor._shutdown = True
+
+        with patch("posit_bakery.parallel.executor.time.sleep") as mock_sleep:
+            with pytest.raises(ExecutorInterrupted):
+                runner.sleep(5.0)
+
+        mock_sleep.assert_not_called()
 
 
 class TestParallelShellExecutorJobs:

--- a/posit-bakery/test/plugins/builtin/imagetools/test_oras.py
+++ b/posit-bakery/test/plugins/builtin/imagetools/test_oras.py
@@ -740,7 +740,9 @@ class TestOrasIndexVerifyWorkflow:
         with patch("subprocess.run") as mock_run:
             mock_run.side_effect = [
                 subprocess.CompletedProcess(args=[], returncode=0, stdout=b"{}", stderr=b""),
-                subprocess.CompletedProcess(args=[], returncode=1, stdout=b"", stderr=b"not found"),
+                subprocess.CompletedProcess(
+                    args=[], returncode=1, stdout=b"", stderr=b"unauthorized: authentication required"
+                ),
             ]
             result = workflow.run()
 
@@ -758,6 +760,54 @@ class TestOrasIndexVerifyWorkflow:
 
         mock_run.assert_not_called()
         assert result.success is True
+
+
+class TestOrasIndexVerifyWorkflowRetry:
+    """The index-verify primitive retries transient registry errors."""
+
+    def test_retries_transient_not_found_then_succeeds(self, mock_image_target_factory):
+        target = mock_image_target_factory()
+        workflow = OrasIndexVerifyWorkflow(
+            oras_bin="oras",
+            image_target=target,
+            retry_policy=RetryPolicy(max_attempts=5, initial_backoff=1.0),
+        )
+
+        attempts = {"n": 0}
+
+        def side_effect(cmd, capture_output):
+            attempts["n"] += 1
+            if attempts["n"] < 2:
+                return subprocess.CompletedProcess(args=cmd, returncode=1, stdout=b"", stderr=b"manifest unknown")
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=b"{}", stderr=b"")
+
+        with patch("subprocess.run", side_effect=side_effect), patch("posit_bakery.retry.time.sleep") as sleep:
+            result = workflow.run()
+
+        assert result.success is True
+        assert attempts["n"] == 2
+        sleep.assert_called_once()
+
+    def test_non_transient_error_fails_without_retry(self, mock_image_target_factory):
+        target = mock_image_target_factory()
+        workflow = OrasIndexVerifyWorkflow(
+            oras_bin="oras",
+            image_target=target,
+            retry_policy=RetryPolicy(max_attempts=5, initial_backoff=1.0),
+        )
+
+        with (
+            patch("subprocess.run") as mock_run,
+            patch("posit_bakery.retry.time.sleep") as sleep,
+        ):
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=1, stdout=b"", stderr=b"unauthorized: authentication required"
+            )
+            result = workflow.run()
+
+        assert result.success is False
+        assert mock_run.call_count == 1
+        sleep.assert_not_called()
 
 
 @pytest.mark.slow

--- a/posit-bakery/test/plugins/builtin/imagetools/test_oras.py
+++ b/posit-bakery/test/plugins/builtin/imagetools/test_oras.py
@@ -877,6 +877,25 @@ class TestOrasIndexCreateWorkflowRetry:
         assert mock_run.call_count == 1
         sleep.assert_not_called()
 
+    def test_uses_runner_sleep_for_backoff_when_runner_provided(self, mock_image_target_factory):
+        target = mock_image_target_factory()
+        workflow = OrasIndexCreateWorkflow(oras_bin="oras", image_target=target, annotations={"k": "v"})
+        runner = MagicMock()
+
+        with patch("posit_bakery.plugins.builtin.imagetools.oras.retry_on_transient", return_value=None) as mock_retry:
+            workflow.run(runner=runner)
+
+        assert mock_retry.call_args.kwargs["sleep"] is runner.sleep
+
+    def test_sleep_is_none_without_runner(self, mock_image_target_factory):
+        target = mock_image_target_factory()
+        workflow = OrasIndexCreateWorkflow(oras_bin="oras", image_target=target, annotations={"k": "v"})
+
+        with patch("posit_bakery.plugins.builtin.imagetools.oras.retry_on_transient", return_value=None) as mock_retry:
+            workflow.run()
+
+        assert mock_retry.call_args.kwargs["sleep"] is None
+
 
 class TestOrasIndexCopyWorkflowRetry:
     """The index-copy primitive retries transient registry errors."""

--- a/posit-bakery/test/plugins/builtin/imagetools/test_workflow.py
+++ b/posit-bakery/test/plugins/builtin/imagetools/test_workflow.py
@@ -190,6 +190,41 @@ def test_pull_retries_transient_then_succeeds(mock_target):
     sleep.assert_called_once()
 
 
+def test_pull_retry_uses_runner_sleep_when_runner_provided(mock_target):
+    workflow = SociConvertWorkflow(
+        soci_bin="soci",
+        oras_bin="oras",
+        image_target=mock_target,
+        options=SociOptions(enabled=True),
+        source_ref="ghcr.io/posit-dev/test-image/tmp:merged",
+    )
+    runner = MagicMock()
+
+    with patch("posit_bakery.plugins.builtin.imagetools.soci.retry_on_transient", return_value=None) as mock_retry:
+        with patch("subprocess.run", side_effect=lambda cmd, capture_output: _ok_proc(cmd)):
+            with patch.object(SociConvertWorkflow, "_read_converted_digest", return_value="sha256:abc123"):
+                workflow.run(runner=runner)
+
+    assert mock_retry.call_args.kwargs["sleep"] is runner.sleep
+
+
+def test_pull_retry_sleep_is_none_without_runner(mock_target):
+    workflow = SociConvertWorkflow(
+        soci_bin="soci",
+        oras_bin="oras",
+        image_target=mock_target,
+        options=SociOptions(enabled=True),
+        source_ref="ghcr.io/posit-dev/test-image/tmp:merged",
+    )
+
+    with patch("posit_bakery.plugins.builtin.imagetools.soci.retry_on_transient", return_value=None) as mock_retry:
+        with patch("subprocess.run", side_effect=lambda cmd, capture_output: _ok_proc(cmd)):
+            with patch.object(SociConvertWorkflow, "_read_converted_digest", return_value="sha256:abc123"):
+                workflow.run()
+
+    assert mock_retry.call_args.kwargs["sleep"] is None
+
+
 def test_read_converted_digest_reads_index_json(workflow, tmp_path):
     layout = tmp_path / "out"
     layout.mkdir()

--- a/posit-bakery/test/test_retry.py
+++ b/posit-bakery/test/test_retry.py
@@ -133,6 +133,41 @@ class TestRetryOnTransient:
         # 10, then 100->capped 20, then 20, then 20.
         assert [c.args[0] for c in sleep.call_args_list] == [10.0, 20.0, 20.0, 20.0]
 
+    def test_uses_provided_sleep_callable_instead_of_time_sleep(self):
+        attempts = {"n": 0}
+        sleep_calls = []
+
+        def fn():
+            attempts["n"] += 1
+            if attempts["n"] < 2:
+                raise _tool_error(stderr=b"sha256:deadbeef: not found")
+            return "ok"
+
+        def fake_sleep(seconds):
+            sleep_calls.append(seconds)
+
+        with patch("posit_bakery.retry.time.sleep") as real_sleep:
+            result = retry_on_transient(fn, policy=RetryPolicy(max_attempts=5, initial_backoff=2.0), sleep=fake_sleep)
+
+        assert result == "ok"
+        assert sleep_calls == [2.0]
+        real_sleep.assert_not_called()
+
+    def test_none_sleep_falls_back_to_time_sleep(self):
+        attempts = {"n": 0}
+
+        def fn():
+            attempts["n"] += 1
+            if attempts["n"] < 2:
+                raise _tool_error(stderr=b"sha256:deadbeef: not found")
+            return "ok"
+
+        with patch("posit_bakery.retry.time.sleep") as real_sleep:
+            result = retry_on_transient(fn, policy=RetryPolicy(max_attempts=5, initial_backoff=2.0), sleep=None)
+
+        assert result == "ok"
+        real_sleep.assert_called_once_with(2.0)
+
 
 class TestRetryPolicyEnv:
     def test_reads_defaults_from_env(self, monkeypatch):


### PR DESCRIPTION
Stacked on #641. Part of splitting #599 (parallelize + retry + unify oras/soci into `imagetools`) into smaller, independently-reviewable pieces.

## What & why

Retry-with-backoff for transient registry errors (`RetryPolicy`/`retry_on_transient` in `posit_bakery/retry.py`) already covered the riskiest phases of the parallel publish path introduced in #641 — index-create and the SOCI pull step, both carried forward from a pre-existing GHCR-flakiness fix. Two gaps remained:

- **Stage 3 (verify) had no retry.** `OrasIndexVerifyWorkflow` did a bare `oras manifest fetch` — a transient read-after-write blip failed the whole publish with zero backoff, even though every phase before it was protected.
- **Retry backoff wasn't interruptible.** `retry_on_transient` slept via plain `time.sleep`. A Stage-1 job (running on a `ParallelShellExecutor` worker thread) blocked mid-backoff wouldn't notice Ctrl-C — the executor's interrupt handling returns immediately on the main thread, but `ThreadPoolExecutor` registers an atexit hook that joins every thread it ever spawned, so the process wouldn't actually exit until that sleep (and any remaining retry attempts) finished, up to ~62s per stuck job with default settings.

## Changes

- `retry_on_transient()` gains an injectable `sleep` callable (defaults to `time.sleep`, looked up fresh per call so existing `patch("posit_bakery.retry.time.sleep")` tests keep working unmodified).
- `CommandRunner.sleep()` (new, in the `parallel` module): sleeps in short slices, checking the bound executor's shutdown flag between slices, raising a new `ExecutorInterrupted` as soon as shutdown is observed — so a mid-backoff job unwinds within about one slice interval of Ctrl-C instead of blocking process exit.
- `OrasIndexCreateWorkflow` and `SociConvertWorkflow`'s pull-step retries (the only retries reachable from a Stage-1 `ShellJob` worker thread) now pass `sleep=runner.sleep` when a runner is available.
- `OrasIndexVerifyWorkflow` gains a `retry_policy` field and now retries transient errors on the final tag-resolution check, mirroring the existing Create/Copy pattern. No `runner`/interrupt plumbing there — it runs on the main thread, not inside the executor, so there's no process-exit-blocking risk to fix.

Explicitly out of scope (see design doc): unifying `OrasWaitForSourcesWorkflow`'s poll loop onto `RetryPolicy` (different, already-correct mechanism), adding jitter, changing `RetryPolicy` defaults.

## Verification

- `just test` — 1947 passed; `ruff check` + `ruff format --check` clean.
- Each commit individually reviewed (spec compliance + code quality) before merge into this branch; a final whole-branch review confirmed the cross-task composition (retry → `CommandRunner.sleep` → `ExecutorInterrupted` propagation through `_run_job`) is correct end to end and all stated non-goals were honored.
- Known follow-up (not blocking): `OrasWaitForSourcesWorkflow`'s own poll sleep is the one Stage-1 wait left non-interruptible (~5s Ctrl-C latency bound vs. the ~62s this PR fixes for retry backoff) — same one-line fix pattern would close it if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)