### PR TITLE
Switch issue automation to client-id

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.POSIT_PLATFORM_APP_ID }}
+          client-id: ${{ secrets.POSIT_PLATFORM_CLIENT_ID }}
           private-key: ${{ secrets.POSIT_PLATFORM_PEM }}
 
       - name: Add to Platform Carbon Project


### PR DESCRIPTION
Use `client-id` (preferred over deprecated `app-id`) for the GitHub App token in issue automation.