### PR TITLE
Supply GitHub token to TinyTeX installs in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,8 @@ jobs:
 
       - name: Run pytest
         working-directory: ./posit-bakery
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           GOSS_PATH=${GITHUB_WORKSPACE}/tools/goss \
           DGOSS_PATH=${GITHUB_WORKSPACE}/tools/dgoss \

--- a/posit-bakery/test/resources/with-macros/bakery.yaml
+++ b/posit-bakery/test/resources/with-macros/bakery.yaml
@@ -18,6 +18,9 @@ registries:
 
 images:
   - name: "test-image"
+    buildSecrets:
+      - id: github_token
+        envVar: GITHUB_TOKEN
     dependencyConstraints:
       - dependency: R
         constraint:


### PR DESCRIPTION
The test suite's Quarto/TinyTeX builds query the GitHub API to resolve the latest `rstudio/tinytex-releases` version. Unauthenticated requests from shared CI runners get rate-limited, producing flaky "Unable to determine latest release" build failures.

The shared `quarto.j2` macro already mounts an optional `github_token` secret and reads it into `GH_TOKEN`, but the token was never supplied to the pytest builds:

- `with-macros/bakery.yaml` did not declare the `github_token` build secret, so bakery never passed `--secret` for those builds.
- The "Run pytest" CI step did not export `GITHUB_TOKEN`, so even the matrix image's declared secret resolved to an unset env var and was silently skipped.

Declare the build secret for the with-macros test image (mirroring the matrix fixture and the product repos) and export `GITHUB_TOKEN` in the pytest step so both build paths authenticate TinyTeX downloads.

Related:
- https://github.com/posit-dev/images-shared/pull/643
