### PR TITLE
Improve bakery ci publish logging

### DIFF
--- a/posit-bakery/posit_bakery/parallel/executor.py
+++ b/posit-bakery/posit_bakery/parallel/executor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+import queue
 import signal
 import subprocess
 import threading
@@ -25,6 +26,38 @@ TERMINATE_GRACE_SECONDS = 10.0
 # Slice width for CommandRunner.sleep()'s interruptible backoff wait. Short
 # enough that a shutdown request is noticed promptly without busy-waiting.
 RETRY_SLEEP_SLICE_SECONDS = 0.5
+
+log = logging.getLogger(__name__)
+
+# Holds the current worker slot number (1..max_workers) for whichever pool thread is
+# running a task/job, so log records emitted deep inside that call (e.g. from oras.py,
+# soci.py) can be traced back to the operation that produced them.
+_worker_slot = threading.local()
+
+
+class _WorkerTagFilter(logging.Filter):
+    """Prefixes log records with the emitting thread's worker slot, when it has one."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        slot = getattr(_worker_slot, "value", None)
+        if slot is not None:
+            # No square brackets: RichHandler is configured with markup=True, which parses
+            # "[...]" as style tags and silently swallows unrecognized ones.
+            record.msg = f"w{slot} | {record.msg}"
+        return True
+
+
+def _ensure_worker_tag_filter() -> None:
+    """Attach :class:`_WorkerTagFilter` to every root logging handler, once.
+
+    Record-emitting loggers (e.g. in ``oras.py``, ``soci.py``) only run *their own*
+    filters before propagating; a filter must sit on the handler itself to see records
+    from every logger. Deferred until a pool actually runs (rather than at import time)
+    so it always runs after :func:`posit_bakery.log.init_logging` has installed handlers.
+    """
+    for handler in logging.getLogger().handlers:
+        if not any(isinstance(f, _WorkerTagFilter) for f in handler.filters):
+            handler.addFilter(_WorkerTagFilter())
 
 
 class ExecutorInterrupted(Exception):
@@ -331,6 +364,19 @@ class ParallelShellExecutor:
         """
         return self._execute_pool(jobs, worker=self._run_job, on_result=on_result)
 
+    @staticmethod
+    def _run_with_slot(worker: Callable[[Any], Any], unit: Any, slot_queue: "queue.SimpleQueue[int]") -> Any:
+        """Run ``worker(unit)`` with a worker slot number bound to this thread for the
+        duration of the call, so nested log records get tagged by :class:`_WorkerTagFilter`.
+        """
+        slot = slot_queue.get()
+        _worker_slot.value = slot
+        try:
+            return worker(unit)
+        finally:
+            del _worker_slot.value
+            slot_queue.put(slot)
+
     def _execute_pool(
         self,
         units: list,
@@ -347,6 +393,9 @@ class ParallelShellExecutor:
         """
         if not units:
             return []
+
+        log.info(f"Using {self.max_workers} worker(s) for {len(units)} concurrent operation(s)")
+        _ensure_worker_tag_filter()
 
         self._shutdown = False
         self._progress = None
@@ -380,6 +429,10 @@ class ParallelShellExecutor:
                 if on_result is not None:
                     on_result(result)
 
+        slot_queue: queue.SimpleQueue[int] = queue.SimpleQueue()
+        for slot in range(1, self.max_workers + 1):
+            slot_queue.put(slot)
+
         pool = ThreadPoolExecutor(max_workers=self.max_workers)
         try:
             if progress is not None:
@@ -389,10 +442,10 @@ class ParallelShellExecutor:
                             f"[quiet]{'queued':<7} {unit.display_label}", total=1, start=False
                         )
                     self._progress_ids = progress_ids
-                    future_map = {pool.submit(worker, unit): unit for unit in units}
+                    future_map = {pool.submit(self._run_with_slot, worker, unit, slot_queue): unit for unit in units}
                     consume(future_map)
             else:
-                future_map = {pool.submit(worker, unit): unit for unit in units}
+                future_map = {pool.submit(self._run_with_slot, worker, unit, slot_queue): unit for unit in units}
                 consume(future_map)
         except BaseException:
             # Interrupted (e.g. Ctrl-C): stop accepting/continuing work, drop queued units,

--- a/posit-bakery/posit_bakery/plugins/builtin/imagetools/imagetools.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/imagetools/imagetools.py
@@ -641,12 +641,18 @@ class ImageToolsPlugin(BakeryToolPlugin):
         executor = ParallelShellExecutor(max_workers=resolve_max_workers(jobs, len(shell_jobs)))
         job_results = executor.run_jobs(shell_jobs)
 
+        # (target, operation, error) for every failure across all stages, reprinted as a
+        # summary at the end so a failed run doesn't require scrolling back through
+        # possibly-interleaved concurrent log output to find what broke.
+        failures: list[tuple[str, str, str]] = []
+
         stage1_failed = False
         temp_refs: dict[str, str] = {}
         for jr in job_results:
             if not jr.ok:
                 stage1_failed = True
                 log.error(f"publish Stage 1 crashed for '{jr.job.display_label}': {jr.exception}")
+                failures.append((jr.job.display_label, "stage1-crash", str(jr.exception)))
                 continue
             stage1_result: _PublishStage1Result = jr.value
             if stage1_result.skipped:
@@ -657,6 +663,9 @@ class ImageToolsPlugin(BakeryToolPlugin):
                 log.error(
                     f"publish Stage 1 failed for '{stage1_result.target}' "
                     f"at phase '{stage1_result.failed_phase}': {stage1_result.error}"
+                )
+                failures.append(
+                    (str(stage1_result.target), f"stage1:{stage1_result.failed_phase}", str(stage1_result.error))
                 )
                 continue
             temp_refs[stage1_result.target.uid] = stage1_result.temp_ref
@@ -675,6 +684,7 @@ class ImageToolsPlugin(BakeryToolPlugin):
             ).run(source=temp_refs[t.uid], dry_run=dry_run)
             if not copy.success:
                 log.error(f"index-copy failed for '{t}': {copy.error}")
+                failures.append((str(t), "index-copy", str(copy.error)))
                 copy_failed = True
             else:
                 copied_targets.append(t)
@@ -690,6 +700,7 @@ class ImageToolsPlugin(BakeryToolPlugin):
                 ).run(dry_run=dry_run)
                 if not verify.success:
                     log.error(f"verification failed for '{t}': {verify.error}")
+                    failures.append((str(t), "verify", str(verify.error)))
                     verify_failed = True
                 else:
                     log.info(f"Verified '{t}' -> {', '.join(verify.verified)}")
@@ -699,4 +710,7 @@ class ImageToolsPlugin(BakeryToolPlugin):
         # temp-registry) rather than deleted here.
 
         if stage1_failed or copy_failed or verify_failed:
+            log.error(f"publish failed ({len(failures)} target/operation failure(s)):")
+            for target, operation, error in failures:
+                log.error(f"  - {target} [{operation}]: {error}")
             raise typer.Exit(code=1)


### PR DESCRIPTION
## Summary
- Logs the resolved worker count before a parallel pool run starts (`ParallelShellExecutor._execute_pool`).
- Tags log records emitted during a pool run with their worker slot (`w1 | ...`, `w2 | ...`), so interleaved concurrent output can be traced back to the operation that produced it.
- `bakery ci publish` now reprints a summary of every failed target/operation at the end of a failed run, so failures don't require scrolling back through the log.

## Test plan
- [x] `uv run pytest test/parallel test/cli/test_ci_publish.py test/plugins/builtin/imagetools -q -n auto` (183 passed)
- [x] `ruff check` / `ruff format --check` on changed files
- [x] Manual smoke test confirming worker-tag prefixes render correctly through `RichHandler` (markup-safe delimiter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)