### PR TITLE
Add Docker Hub README length check

### DIFF
--- a/.github/workflows/bakery-build-pr.yml
+++ b/.github/workflows/bakery-build-pr.yml
@@ -137,6 +137,32 @@ jobs:
           result=$(bakery ci matrix --quiet --dev-versions "$DEV_VERSIONS" --matrix-versions "$MATRIX_VERSIONS" "${BASE_FLAG[@]}" --exclude platform --context "$BAKERY_CONTEXT")
           echo "versions_matrix=$(echo "$result" | jq --compact-output .)" >> "$GITHUB_OUTPUT"
 
+  readme-check:
+    name: README Length Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Install
+        uses: "posit-dev/images-shared/setup-bakery@main"
+        with:
+          version: ${{ inputs.version }}
+
+      - name: Check README length
+        env:
+          DEV_VERSIONS: ${{ inputs.dev-versions }}
+          MATRIX_VERSIONS: ${{ inputs.matrix-versions }}
+          BAKERY_CONTEXT: ${{ inputs.context }}
+        run: |
+          bakery ci readme --check \
+            --dev-versions "$DEV_VERSIONS" \
+            --matrix-versions "$MATRIX_VERSIONS" \
+            --context "$BAKERY_CONTEXT"
+
   build-test:
     name: "Build/Test ${{ matrix.img.image }}:${{ matrix.img.version }} (${{ matrix.img.platform }})"
     needs:

--- a/.github/workflows/bakery-build-pr.yml
+++ b/.github/workflows/bakery-build-pr.yml
@@ -146,6 +146,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install
         uses: "posit-dev/images-shared/setup-bakery@main"

--- a/posit-bakery/posit_bakery/cli/ci.py
+++ b/posit-bakery/posit_bakery/cli/ci.py
@@ -17,7 +17,7 @@ from posit_bakery.config.image.posit_product.const import ReleaseChannelEnum
 from posit_bakery.config.image.version import ImageVersion
 from posit_bakery.const import DevVersionInclusionEnum, MatrixVersionInclusionEnum
 from posit_bakery.log import stderr_console, stdout_console
-from posit_bakery.registry_management.dockerhub.readme import push_readmes
+from posit_bakery.registry_management.dockerhub.readme import find_oversized_readmes, push_readmes
 from posit_bakery.util import auto_path
 
 app = typer.Typer(no_args_is_help=True)
@@ -519,6 +519,13 @@ def readme(
             rich_help_panel=RichHelpPanelEnum.FILTERS,
         ),
     ] = MatrixVersionInclusionEnum.INCLUDE,
+    check: Annotated[
+        bool,
+        typer.Option(
+            "--check",
+            help="Validate README length against Docker Hub's limit, without authenticating or pushing.",
+        ),
+    ] = False,
 ) -> None:
     """Push image READMEs to Docker Hub.
 
@@ -529,6 +536,10 @@ def readme(
     Requires DOCKER_HUB_README_USERNAME and DOCKER_HUB_README_PASSWORD environment
     variables to be set with a Personal Access Token (PAT). Organization Access Tokens
     cannot update repository descriptions.
+
+    With --check, only validates that eligible READMEs are within Docker Hub's
+    25,000-byte full_description limit. Requires no credentials and makes no network
+    calls, so it is safe to run in fork PR CI.
     """
     if dev_stream is not None:
         log.warning("--dev-stream is deprecated, use --dev-channel instead.")
@@ -540,6 +551,15 @@ def readme(
         matrix_versions=matrix_versions,
     )
     config: BakeryConfig = BakeryConfig.from_context(context, settings)
+
+    if check:
+        violations = find_oversized_readmes(config.targets)
+        if violations:
+            for violation in violations:
+                stderr_console.print(f"❌ {violation}", style="error")
+            raise typer.Exit(code=1)
+        stderr_console.print("✅ All READMEs are within Docker Hub's length limit", style="success")
+        return
 
     try:
         count = push_readmes(config.targets)

--- a/posit-bakery/posit_bakery/registry_management/dockerhub/readme.py
+++ b/posit-bakery/posit_bakery/registry_management/dockerhub/readme.py
@@ -14,6 +14,11 @@ DOCKER_HUB_README_PASSWORD_ENV = "DOCKER_HUB_README_PASSWORD"
 # DockerhubClient.update_full_description). Exceeding it makes Docker Hub return a
 # raw HTTP 400; the checks below let callers fail with a clear message instead,
 # without needing Docker Hub credentials.
+#
+# Not documented by Docker; confirmed by community reports and by our own
+# incident (posit-dev/images-workbench#164, which failed at 25,069 bytes):
+# https://github.com/docker/hub-feedback/issues/2320
+# https://github.com/docker/roadmap/issues/475
 DOCKER_HUB_README_MAX_BYTES = 25_000
 
 

--- a/posit-bakery/posit_bakery/registry_management/dockerhub/readme.py
+++ b/posit-bakery/posit_bakery/registry_management/dockerhub/readme.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from pathlib import Path
 
 from posit_bakery.image.image_target import ImageTarget
 from posit_bakery.registry_management.dockerhub.api import DockerhubClient
@@ -9,6 +10,12 @@ log = logging.getLogger(__name__)
 DOCKER_HUB_README_USERNAME_ENV = "DOCKER_HUB_README_USERNAME"
 DOCKER_HUB_README_PASSWORD_ENV = "DOCKER_HUB_README_PASSWORD"
 
+# Docker Hub hard-caps the `full_description` field at this many bytes (see
+# DockerhubClient.update_full_description). Exceeding it makes Docker Hub return a
+# raw HTTP 400; the checks below let callers fail with a clear message instead,
+# without needing Docker Hub credentials.
+DOCKER_HUB_README_MAX_BYTES = 25_000
+
 
 def _get_dockerhub_repos(target: ImageTarget) -> set[tuple[str, str]]:
     """Extract unique Docker Hub namespace/repository pairs from an image target's tags."""
@@ -17,6 +24,85 @@ def _get_dockerhub_repos(target: ImageTarget) -> set[tuple[str, str]]:
         if tag.registry and tag.registry.host == "docker.io" and tag.registry.namespace:
             repos.add((tag.registry.namespace, tag.repository))
     return repos
+
+
+def _eligible_targets(targets: list[ImageTarget]) -> list[tuple[ImageTarget, set[tuple[str, str]]]]:
+    """Filter to targets eligible for a Docker Hub README push or length check.
+
+    Eligible targets are non-development versions that are either marked latest
+    or a matrix version, and have at least one Docker Hub registry tag.
+    """
+    eligible: list[tuple[ImageTarget, set[tuple[str, str]]]] = []
+    for target in targets:
+        if target.image_version.isDevelopmentVersion:
+            continue
+        if not target.image_version.isMatrixVersion and not target.is_latest:
+            continue
+        repos = _get_dockerhub_repos(target)
+        if not repos:
+            continue
+        eligible.append((target, repos))
+    return eligible
+
+
+def check_readme_length(content: str, max_bytes: int = DOCKER_HUB_README_MAX_BYTES) -> int:
+    """Check README content against Docker Hub's `full_description` byte limit.
+
+    Docker Hub counts the UTF-8 encoded size of the field, not the character count,
+    so multi-byte characters can push a README over the limit sooner than a naive
+    ``len(content)`` would suggest.
+
+    :param content: The README content to measure.
+    :param max_bytes: Maximum allowed size in bytes.
+    :return: The number of bytes by which ``content`` exceeds ``max_bytes``, or 0 if
+        it is within the limit.
+    """
+    size = len(content.encode("utf-8"))
+    return max(0, size - max_bytes)
+
+
+def _find_oversized_readmes(
+    eligible: list[tuple[ImageTarget, set[tuple[str, str]]]],
+    max_bytes: int = DOCKER_HUB_README_MAX_BYTES,
+) -> list[str]:
+    """Check each eligible target's README.md against Docker Hub's length limit.
+
+    Reads only local files already present in the checkout -- no Docker Hub
+    credentials or network access required.
+
+    :return: Human-readable error messages, one per oversized README. Empty if none.
+    """
+    checked: set[Path] = set()
+    violations: list[str] = []
+    for target, _repos in eligible:
+        readme_path = target.context.image_path / "README.md"
+        if readme_path in checked or not readme_path.is_file():
+            continue
+        checked.add(readme_path)
+
+        over_by = check_readme_length(readme_path.read_text(), max_bytes)
+        if over_by:
+            size = max_bytes + over_by
+            violations.append(
+                f"{readme_path} is {size:,} bytes, exceeding Docker Hub's {max_bytes:,}-byte "
+                f"README limit by {over_by:,} bytes"
+            )
+    return violations
+
+
+def find_oversized_readmes(targets: list[ImageTarget], max_bytes: int = DOCKER_HUB_README_MAX_BYTES) -> list[str]:
+    """Check all Docker-Hub-eligible targets' README.md files against the length limit.
+
+    This is a pure, local check: it requires no Docker Hub credentials and makes no
+    network calls, so it is safe to run in fork PR CI where secrets are not available
+    (see ``bakery ci readme --check``).
+
+    :param targets: List of image targets to evaluate.
+    :param max_bytes: Maximum allowed size in bytes (Docker Hub hard limit: 25,000).
+    :return: Human-readable error messages, one per oversized README. Empty if all
+        eligible READMEs are within the limit.
+    """
+    return _find_oversized_readmes(_eligible_targets(targets), max_bytes)
 
 
 def push_readmes(targets: list[ImageTarget]) -> int:
@@ -37,22 +123,18 @@ def push_readmes(targets: list[ImageTarget]) -> int:
 
     :param targets: List of image targets to evaluate.
     :return: Number of READMEs pushed.
+    :raises ValueError: If one or more eligible READMEs exceed Docker Hub's length limit.
     :raises RuntimeError: If one or more README pushes fail.
     """
-    eligible: list[tuple[ImageTarget, set[tuple[str, str]]]] = []
-    for target in targets:
-        if target.image_version.isDevelopmentVersion:
-            continue
-        if not target.image_version.isMatrixVersion and not target.is_latest:
-            continue
-        repos = _get_dockerhub_repos(target)
-        if not repos:
-            continue
-        eligible.append((target, repos))
+    eligible = _eligible_targets(targets)
 
     if not eligible:
         log.info("No eligible targets for Docker Hub README push.")
         return 0
+
+    violations = _find_oversized_readmes(eligible)
+    if violations:
+        raise ValueError("README(s) exceed Docker Hub's length limit:\n- " + "\n- ".join(violations))
 
     username = os.getenv(DOCKER_HUB_README_USERNAME_ENV)
     password = os.getenv(DOCKER_HUB_README_PASSWORD_ENV)

--- a/posit-bakery/test/cli/test_ci_readme_check.py
+++ b/posit-bakery/test/cli/test_ci_readme_check.py
@@ -1,0 +1,97 @@
+"""Tests for the `bakery ci readme --check` flag.
+
+--check validates README length against Docker Hub's limit without
+authenticating or pushing, so it can run in fork PR CI where Docker Hub
+credentials are not available (see .github/workflows/bakery-build-pr.yml).
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from posit_bakery.cli.main import app
+
+pytestmark = [pytest.mark.unit]
+
+runner = CliRunner()
+BASIC_CONTEXT = str(Path(__file__).parent.parent / "resources" / "basic")
+_ENV = {"TERM": "dumb", "NO_COLOR": "true", "COLUMNS": "200"}
+
+
+@pytest.fixture
+def mock_config():
+    with patch("posit_bakery.cli.ci.BakeryConfig") as mock_config_cls:
+        instance = MagicMock()
+        instance.targets = []
+        mock_config_cls.from_context.return_value = instance
+        yield mock_config_cls
+
+
+class TestReadmeCheckFlag:
+    def test_passes_with_no_violations(self, mock_config):
+        with patch("posit_bakery.cli.ci.find_oversized_readmes", return_value=[]) as mock_find:
+            with patch("posit_bakery.cli.ci.push_readmes") as mock_push:
+                result = runner.invoke(
+                    app,
+                    ["ci", "readme", "--check", "--context", BASIC_CONTEXT],
+                    catch_exceptions=False,
+                    env=_ENV,
+                )
+
+        assert result.exit_code == 0, result.stdout + result.stderr
+        mock_find.assert_called_once_with(mock_config.from_context.return_value.targets)
+        mock_push.assert_not_called()
+
+    def test_fails_with_violations(self, mock_config):
+        violation = (
+            "/repo/workbench/README.md is 25,069 bytes, exceeding Docker Hub's "
+            "25,000-byte README limit by 69 bytes"
+        )
+        with patch("posit_bakery.cli.ci.find_oversized_readmes", return_value=[violation]):
+            with patch("posit_bakery.cli.ci.push_readmes") as mock_push:
+                result = runner.invoke(
+                    app,
+                    ["ci", "readme", "--check", "--context", BASIC_CONTEXT],
+                    catch_exceptions=False,
+                    env=_ENV,
+                )
+
+        assert result.exit_code == 1
+        assert violation in result.stderr
+        mock_push.assert_not_called()
+
+    def test_reports_all_violations(self, mock_config):
+        violations = ["README A is oversized", "README B is oversized"]
+        with patch("posit_bakery.cli.ci.find_oversized_readmes", return_value=violations):
+            with patch("posit_bakery.cli.ci.push_readmes"):
+                result = runner.invoke(
+                    app,
+                    ["ci", "readme", "--check", "--context", BASIC_CONTEXT],
+                    catch_exceptions=False,
+                    env=_ENV,
+                )
+
+        assert result.exit_code == 1
+        assert "README A is oversized" in result.stderr
+        assert "README B is oversized" in result.stderr
+
+    def test_without_check_does_not_call_find(self, mock_config):
+        with patch("posit_bakery.cli.ci.find_oversized_readmes") as mock_find:
+            with patch("posit_bakery.cli.ci.push_readmes", return_value=0) as mock_push:
+                result = runner.invoke(
+                    app,
+                    ["ci", "readme", "--context", BASIC_CONTEXT],
+                    catch_exceptions=False,
+                    env=_ENV,
+                )
+
+        assert result.exit_code == 0
+        mock_find.assert_not_called()
+        mock_push.assert_called_once()
+
+    def test_help_lists_check_flag(self):
+        result = runner.invoke(app, ["ci", "readme", "--help"], env=_ENV)
+        assert result.exit_code == 0
+        assert "--check" in result.stdout

--- a/posit-bakery/test/cli/test_ci_readme_check.py
+++ b/posit-bakery/test/cli/test_ci_readme_check.py
@@ -46,8 +46,7 @@ class TestReadmeCheckFlag:
 
     def test_fails_with_violations(self, mock_config):
         violation = (
-            "/repo/workbench/README.md is 25,069 bytes, exceeding Docker Hub's "
-            "25,000-byte README limit by 69 bytes"
+            "/repo/workbench/README.md is 25,069 bytes, exceeding Docker Hub's 25,000-byte README limit by 69 bytes"
         )
         with patch("posit_bakery.cli.ci.find_oversized_readmes", return_value=[violation]):
             with patch("posit_bakery.cli.ci.push_readmes") as mock_push:

--- a/posit-bakery/test/cli/test_ci_readme_check.py
+++ b/posit-bakery/test/cli/test_ci_readme_check.py
@@ -59,7 +59,7 @@ class TestReadmeCheckFlag:
                 )
 
         assert result.exit_code == 1
-        assert violation in result.stderr
+        assert violation in " ".join(result.stderr.split())
         mock_push.assert_not_called()
 
     def test_reports_all_violations(self, mock_config):
@@ -74,8 +74,9 @@ class TestReadmeCheckFlag:
                 )
 
         assert result.exit_code == 1
-        assert "README A is oversized" in result.stderr
-        assert "README B is oversized" in result.stderr
+        normalized_stderr = " ".join(result.stderr.split())
+        assert "README A is oversized" in normalized_stderr
+        assert "README B is oversized" in normalized_stderr
 
     def test_without_check_does_not_call_find(self, mock_config):
         with patch("posit_bakery.cli.ci.find_oversized_readmes") as mock_find:

--- a/posit-bakery/test/registry_management/dockerhub/test_readme.py
+++ b/posit-bakery/test/registry_management/dockerhub/test_readme.py
@@ -4,7 +4,10 @@ import pytest
 
 from posit_bakery.registry_management.dockerhub.readme import (
     _get_dockerhub_repos,
+    check_readme_length,
+    find_oversized_readmes,
     push_readmes,
+    DOCKER_HUB_README_MAX_BYTES,
     DOCKER_HUB_README_USERNAME_ENV,
     DOCKER_HUB_README_PASSWORD_ENV,
 )
@@ -39,6 +42,86 @@ class TestGetDockerhubRepos:
         repos = _get_dockerhub_repos(target)
         for namespace, repo in repos:
             assert namespace != "posit-dev"
+
+
+class TestCheckReadmeLength:
+    def test_within_limit_returns_zero(self):
+        assert check_readme_length("a" * 100, max_bytes=1000) == 0
+
+    def test_at_limit_returns_zero(self):
+        assert check_readme_length("a" * 1000, max_bytes=1000) == 0
+
+    def test_over_limit_returns_overage(self):
+        assert check_readme_length("a" * 1010, max_bytes=1000) == 10
+
+    def test_counts_utf8_bytes_not_characters(self):
+        # Each "e" with an acute accent is 1 character but 2 bytes in UTF-8, so
+        # byte length diverges from len(content) well before the character count
+        # would suggest a violation.
+        content = "é" * 600  # 600 chars, 1200 bytes
+        assert check_readme_length(content, max_bytes=1000) == 200
+
+    def test_default_max_bytes_matches_dockerhub_limit(self):
+        assert check_readme_length("a" * DOCKER_HUB_README_MAX_BYTES) == 0
+        assert check_readme_length("a" * (DOCKER_HUB_README_MAX_BYTES + 1)) == 1
+
+
+class TestFindOversizedReadmes:
+    def test_no_violations_when_within_limit(self, tmp_targets, readme_env):
+        for target in tmp_targets:
+            readme_path = target.context.image_path / "README.md"
+            readme_path.parent.mkdir(parents=True, exist_ok=True)
+            readme_path.write_text("# Fine")
+
+        assert find_oversized_readmes(tmp_targets) == []
+
+    def test_reports_oversized_readme(self, tmp_targets, readme_env):
+        oversized = "a" * (DOCKER_HUB_README_MAX_BYTES + 69)
+        for target in tmp_targets:
+            readme_path = target.context.image_path / "README.md"
+            readme_path.parent.mkdir(parents=True, exist_ok=True)
+            readme_path.write_text(oversized)
+
+        violations = find_oversized_readmes(tmp_targets)
+        assert len(violations) == 1
+        assert "README.md" in violations[0]
+        assert "69 bytes" in violations[0]
+
+    def test_deduplicates_shared_readme(self, tmp_targets, readme_env):
+        # Both Standard and Minimal variants share the same README.md; it should
+        # only be reported once.
+        oversized = "a" * (DOCKER_HUB_README_MAX_BYTES + 1)
+        for target in tmp_targets:
+            readme_path = target.context.image_path / "README.md"
+            readme_path.parent.mkdir(parents=True, exist_ok=True)
+            readme_path.write_text(oversized)
+
+        assert len(find_oversized_readmes(tmp_targets)) == 1
+
+    def test_ignores_non_eligible_targets(self, tmp_targets):
+        for target in tmp_targets:
+            target.image_version.latest = False
+            target.image_version.isMatrixVersion = False
+            readme_path = target.context.image_path / "README.md"
+            readme_path.parent.mkdir(parents=True, exist_ok=True)
+            readme_path.write_text("a" * (DOCKER_HUB_README_MAX_BYTES + 1))
+
+        assert find_oversized_readmes(tmp_targets) == []
+
+    def test_requires_no_credentials(self, tmp_targets, monkeypatch):
+        monkeypatch.delenv(DOCKER_HUB_README_USERNAME_ENV, raising=False)
+        monkeypatch.delenv(DOCKER_HUB_README_PASSWORD_ENV, raising=False)
+        oversized = "a" * (DOCKER_HUB_README_MAX_BYTES + 1)
+        for target in tmp_targets:
+            readme_path = target.context.image_path / "README.md"
+            readme_path.parent.mkdir(parents=True, exist_ok=True)
+            readme_path.write_text(oversized)
+
+        with patch("posit_bakery.registry_management.dockerhub.readme.DockerhubClient") as mock_client_cls:
+            violations = find_oversized_readmes(tmp_targets)
+            mock_client_cls.assert_not_called()
+
+        assert len(violations) == 1
 
 
 class TestPushReadmes:
@@ -148,3 +231,33 @@ class TestPushReadmes:
         ):
             with pytest.raises(Exception, match="Auth failed"):
                 push_readmes(basic_targets)
+
+    def test_raises_on_oversized_readme_without_credentials(self, tmp_targets, monkeypatch):
+        """The length check must fire before the credential check, so it also
+        works in fork PR CI where no Docker Hub credentials are configured."""
+        monkeypatch.delenv(DOCKER_HUB_README_USERNAME_ENV, raising=False)
+        monkeypatch.delenv(DOCKER_HUB_README_PASSWORD_ENV, raising=False)
+        oversized = "a" * (DOCKER_HUB_README_MAX_BYTES + 1)
+        for target in tmp_targets:
+            readme_path = target.context.image_path / "README.md"
+            readme_path.parent.mkdir(parents=True, exist_ok=True)
+            readme_path.write_text(oversized)
+
+        with patch("posit_bakery.registry_management.dockerhub.readme.DockerhubClient") as mock_client_cls:
+            with pytest.raises(ValueError, match="exceed Docker Hub's length limit"):
+                push_readmes(tmp_targets)
+            mock_client_cls.assert_not_called()
+
+    def test_raises_on_oversized_readme_before_pushing(self, tmp_targets, readme_env):
+        """Even with valid credentials, an oversized README must fail with a clear
+        error instead of reaching Docker Hub's API and surfacing a raw HTTP 400."""
+        oversized = "a" * (DOCKER_HUB_README_MAX_BYTES + 1)
+        for target in tmp_targets:
+            readme_path = target.context.image_path / "README.md"
+            readme_path.parent.mkdir(parents=True, exist_ok=True)
+            readme_path.write_text(oversized)
+
+        with patch("posit_bakery.registry_management.dockerhub.readme.DockerhubClient") as mock_client_cls:
+            with pytest.raises(ValueError, match="exceed Docker Hub's length limit"):
+                push_readmes(tmp_targets)
+            mock_client_cls.assert_not_called()


### PR DESCRIPTION
Docker Hub hard-caps full_description at 25,000 bytes. push_readmes()
never checked this, so an oversized README broke production CI with
a raw 400 only after merge, not during review.

Adds a length check and a --check flag, wired into PR CI. Validated
end-to-end against the real incident.

https://github.com/posit-dev/images-workbench/issues/164
https://github.com/posit-dev/images-workbench/pull/166

Closes https://github.com/posit-dev/images-shared/issues/658