### PR TITLE
Make push-to-main builds change-aware

### DIFF
--- a/.github/workflows/bakery-build-native.yml
+++ b/.github/workflows/bakery-build-native.yml
@@ -134,6 +134,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 0
 
       - name: Install
         uses: "posit-dev/images-shared/setup-bakery@main"
@@ -174,10 +176,16 @@ jobs:
           DEV_CHANNEL: ${{ inputs.dev-channel || inputs.dev-stream }}
           DEV_SPEC_RESOLVED: ${{ steps.resolve-dev-spec.outputs.dev-spec }}
           CONTEXT: ${{ inputs.context }}
+          # Only set on push (github.event.before); empty on schedule/
+          # workflow_dispatch, which intentionally always build the full matrix.
+          # A bad or all-zero ref (e.g. a branch's first push) is caught by
+          # bakery's git-diff fail-safe, which falls back to a full build.
+          BASE_REF: ${{ github.event.before }}
         run: |
           IMAGE_VERSION="${IMAGE_VERSION#v}"
           ARGS=(--quiet --dev-versions "$DEV_VERSIONS" --matrix-versions "$MATRIX_VERSIONS" --context "$CONTEXT")
           [[ -n "$IMAGE_VERSION" ]] && ARGS+=(--image-version "$IMAGE_VERSION")
+          [[ -n "$BASE_REF" ]] && ARGS+=(--base-ref "$BASE_REF")
           if [[ -n "$DEV_SPEC_RESOLVED" ]]; then
             ARGS+=(--dev-spec "$DEV_SPEC_RESOLVED")
           elif [[ -n "$DEV_CHANNEL" ]]; then

--- a/.github/workflows/bakery-build-native.yml
+++ b/.github/workflows/bakery-build-native.yml
@@ -514,6 +514,10 @@ jobs:
     name: Push READMEs
     permissions:
       contents: read
+    # No explicit skip-if-merge-skipped check needed: a bare `if:` that doesn't
+    # call a status function implicitly gets success() prepended, and GitHub
+    # Actions treats a skipped `needs` job as failing success() — so this
+    # already skips when merge is skipped (e.g. an empty change-aware matrix).
     if: ${{ inputs.push }}
     needs:
       - merge

--- a/.github/workflows/bakery-build-native.yml
+++ b/.github/workflows/bakery-build-native.yml
@@ -202,6 +202,10 @@ jobs:
       contents: read
       packages: write
     needs: matrix
+    # GitHub Actions fails (not skips) a matrix job when the matrix evaluates to [].
+    # Guard here so an empty change-aware matrix (a push with nothing to build)
+    # produces 'skipped' instead of 'failure'.
+    if: ${{ needs.matrix.outputs.platform-matrix != '[]' }}
     strategy:
       fail-fast: false
       matrix:
@@ -377,6 +381,10 @@ jobs:
       contents: read
       packages: write
     needs: [matrix, build-test]
+    # GitHub Actions fails (not skips) a matrix job when the matrix evaluates to [].
+    # Guard here so an empty change-aware matrix (a push with nothing to build)
+    # produces 'skipped' instead of 'failure'.
+    if: ${{ needs.matrix.outputs.image-matrix != '[]' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/bakery-build.yml
+++ b/.github/workflows/bakery-build.yml
@@ -195,8 +195,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-        with:
-          fetch-depth: 0
 
       - name: Setup bakery
         uses: "posit-dev/images-shared/setup-bakery@main"

--- a/.github/workflows/bakery-build.yml
+++ b/.github/workflows/bakery-build.yml
@@ -352,6 +352,10 @@ jobs:
     name: Push READMEs
     permissions:
       contents: read
+    # No explicit skip-if-build-skipped check needed: a bare `if:` that doesn't
+    # call a status function implicitly gets success() prepended, and GitHub
+    # Actions treats a skipped `needs` job as failing success() — so this
+    # already skips when build is skipped (e.g. an empty change-aware matrix).
     if: ${{ inputs.push }}
     needs:
       - build

--- a/.github/workflows/bakery-build.yml
+++ b/.github/workflows/bakery-build.yml
@@ -186,6 +186,10 @@ jobs:
       contents: read
       packages: write
     needs: matrix
+    # GitHub Actions fails (not skips) a matrix job when the matrix evaluates to [].
+    # Guard here so an empty change-aware matrix (a push with nothing to build)
+    # produces 'skipped' instead of 'failure'.
+    if: ${{ needs.matrix.outputs.matrix != '[]' }}
     runs-on: ${{ inputs.runs-on }}
     strategy:
       fail-fast: false

--- a/.github/workflows/bakery-build.yml
+++ b/.github/workflows/bakery-build.yml
@@ -125,6 +125,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 0
 
       - name: Install
         uses: "posit-dev/images-shared/setup-bakery@main"
@@ -159,10 +161,16 @@ jobs:
           DEV_CHANNEL: ${{ inputs.dev-channel || inputs.dev-stream }}
           DEV_SPEC_RESOLVED: ${{ steps.resolve-dev-spec.outputs.dev-spec }}
           CONTEXT: ${{ inputs.context }}
+          # Only set on push (github.event.before); empty on schedule/
+          # workflow_dispatch, which intentionally always build the full matrix.
+          # A bad or all-zero ref (e.g. a branch's first push) is caught by
+          # bakery's git-diff fail-safe, which falls back to a full build.
+          BASE_REF: ${{ github.event.before }}
         run: |
           IMAGE_VERSION="${IMAGE_VERSION#v}"
           ARGS=(--quiet --dev-versions "$DEV_VERSIONS" --matrix-versions "$MATRIX_VERSIONS" --context "$CONTEXT")
           [[ -n "$IMAGE_VERSION" ]] && ARGS+=(--image-version "$IMAGE_VERSION")
+          [[ -n "$BASE_REF" ]] && ARGS+=(--base-ref "$BASE_REF")
           if [[ -n "$DEV_SPEC_RESOLVED" ]]; then
             ARGS+=(--dev-spec "$DEV_SPEC_RESOLVED")
           elif [[ -n "$DEV_CHANNEL" ]]; then
@@ -187,6 +195,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 0
 
       - name: Setup bakery
         uses: "posit-dev/images-shared/setup-bakery@main"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,11 @@ all-zero SHA GitHub sends as `github.event.before` on a branch's first-ever push
 `bakery ci matrix` logs a warning and falls back to a full build rather than failing
 the run.
 
+Conversely, a push whose change set resolves to nothing buildable (e.g. a docs-only
+merge to `main`) now builds and publishes nothing rather than building the full
+matrix — the build and merge jobs are skipped, mirroring how an empty change-aware
+PR matrix already behaves.
+
 ### Classification rules
 
 After ignoring Markdown (`*.md`) paths, changed files are classified as follows:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,7 +134,8 @@ After ignoring Markdown (`*.md`) paths, changed files are classified as follows:
 
 | Changed path | What builds |
 |---|---|
-| `bakery.yaml` / `bakery.yml` or `.github/workflows/**` | Full matrix (fail-safe) |
+| `bakery.yaml` / `bakery.yml` | Semantically diffed vs the base ref — narrows to affected image(s)/version(s); full matrix if old content is unavailable, unparseable, malformed, or the change is outside `images[]` |
+| `.github/workflows/**` | Full matrix (fail-safe) |
 | `<image>/template/**` | That image's dev versions (if any are declared) |
 | `<image>/<version-subpath>/**` | That release version only |
 | An image-root file or unrecognized subdir under an image | That image's release versions (fail-safe) |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,8 +125,8 @@ the run.
 
 Conversely, a push whose change set resolves to nothing buildable (e.g. a docs-only
 merge to `main`) now builds and publishes nothing rather than building the full
-matrix — the build and merge jobs are skipped, mirroring how an empty change-aware
-PR matrix already behaves.
+matrix — the downstream build/publish jobs are skipped, mirroring how an empty
+change-aware PR matrix already behaves.
 
 ### Classification rules
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,15 +99,29 @@ Do not backport cosmetic changes, new feature additions, or non-security depende
 
 - **Version format mismatch.** Product repos dispatch with raw git-describe versions (e.g., `v2026.03.0-473-g072bb6fd1f`). Bakery normalizes these to semver-with-metadata (e.g., `2026.03.0-dev+473-g072bb6fd1f`). If `bakery ci matrix` produces an empty matrix after a dispatch, the formats did not align. The shared workflows strip a leading `v` automatically. Check the rest of the version string against bakery's normalization.
 
-## Change-aware PR builds
+## Change-aware builds
 
 `bakery ci matrix` supports `--base-ref <ref>` and `--changed-files-from <file|->` to emit
-only the matrix entries affected by a PR's changed files. This keeps PR CI fast: a template
+only the matrix entries affected by a set of changed files. This keeps builds fast: a template
 change builds only the images whose templates changed; a version-directory change builds only
 that version.
 
-**This filtering applies to PR builds only.** Push-to-main, scheduled, and release builds
-call `bakery ci matrix` without `--base-ref`, so they always build the full matrix.
+This applies to both PR builds and push-to-main builds:
+
+- **PR builds** diff against the PR's base commit (`github.event.pull_request.base.sha`).
+- **Push-to-main builds** diff against the commit before the push
+  (`github.event.before`), so a release merge only rebuilds the version(s) it touched
+  instead of the full matrix.
+
+**Scheduled and manually-dispatched builds always build the full matrix.** `schedule` and
+`workflow_dispatch` triggers have no `github.event.before` to diff against, so they
+intentionally skip change-aware filtering — this is how the weekly rebuild catches
+upstream base-image drift with no repository diff to detect it.
+
+If the diff against `--base-ref` fails for any reason (an unreachable ref, or the
+all-zero SHA GitHub sends as `github.event.before` on a branch's first-ever push),
+`bakery ci matrix` logs a warning and falls back to a full build rather than failing
+the run.
 
 ### Classification rules
 

--- a/posit-bakery/posit_bakery/cli/ci.py
+++ b/posit-bakery/posit_bakery/cli/ci.py
@@ -44,7 +44,9 @@ def _resolve_changed_files(base_ref: str | None, changed_files_from: str | None,
 
     - ``--base-ref`` runs ``git diff`` (paths relative to the repo root), then
       rebases them onto ``rebase_root`` (the bakery context) and drops paths outside
-      it.
+      it. If the diff against ``base_ref`` fails for any reason (unreachable ref,
+      all-zero SHA, unrelated histories), logs a warning and returns ``None``
+      (disabling filtering) rather than raising.
     - ``--changed-files-from`` paths are used verbatim and must already be relative
       to the bakery context root. They are not rebased, so do not pipe raw
       ``git diff --name-only`` output here unless the context is the repo root. Use
@@ -72,8 +74,22 @@ def _resolve_changed_files(base_ref: str | None, changed_files_from: str | None,
         text=True,
     ).stdout.strip()
     repo_root = Path(toplevel)
+
+    try:
+        changed = git_changed_files(repo_root, base_ref)
+    except subprocess.CalledProcessError as e:
+        # base_ref may not diff cleanly (e.g. github.event.before is the all-zero SHA
+        # on a branch's first push, or an unreachable ref after a force-push). Fail
+        # safe to a full build rather than crashing the CI run.
+        log.warning(
+            "Could not diff against base-ref %r (%s); falling back to a full build.",
+            base_ref,
+            e,
+        )
+        return None
+
     rebased: list[str] = []
-    for rel in git_changed_files(repo_root, base_ref):
+    for rel in changed:
         abs_path = repo_root / rel
         try:
             rebased.append((abs_path.relative_to(rebase_root)).as_posix())

--- a/posit-bakery/posit_bakery/cli/ci.py
+++ b/posit-bakery/posit_bakery/cli/ci.py
@@ -71,13 +71,7 @@ def _resolve_changed_files(base_ref: str | None, changed_files_from: str | None,
     # isn't a git checkout at all, a more fundamental misconfiguration than a
     # base_ref that doesn't diff cleanly, and should surface loudly rather than
     # silently fall back to a full build.
-    toplevel = subprocess.run(
-        ["git", "-C", str(rebase_root), "rev-parse", "--show-toplevel"],
-        check=True,
-        capture_output=True,
-        text=True,
-    ).stdout.strip()
-    repo_root = Path(toplevel)
+    repo_root = _git_repo_root(rebase_root)
 
     try:
         changed = git_changed_files(repo_root, base_ref)
@@ -101,6 +95,54 @@ def _resolve_changed_files(base_ref: str | None, changed_files_from: str | None,
             # Changed file lives outside this bakery context (monorepo) -> not our concern.
             continue
     return rebased
+
+
+def _git_repo_root(rebase_root: Path) -> Path:
+    """Return the git repository root containing ``rebase_root``.
+
+    Failing here means ``rebase_root`` isn't a git checkout at all — a more
+    fundamental misconfiguration than anything downstream should silently
+    paper over, so this is not wrapped in a fail-safe.
+    """
+    toplevel = subprocess.run(
+        ["git", "-C", str(rebase_root), "rev-parse", "--show-toplevel"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    return Path(toplevel)
+
+
+def _resolve_base_bakery_yaml(
+    base_ref: str | None, changed_files: list[str] | None, config_file: Path
+) -> str | None:
+    """Return bakery.yaml's text content at ``base_ref``, or None to skip semantic diffing.
+
+    Returns None (no git call made) when there's no base_ref, no changed-files
+    list, or bakery.yaml isn't actually one of the changed files. Otherwise
+    attempts to read it at base_ref; any failure (unreachable ref, path didn't
+    exist at that ref, etc.) logs a warning and returns None rather than
+    raising — the caller treats None as "compare unavailable, fail safe to a
+    full build," the same shape as _resolve_changed_files' own fail-safe.
+    """
+    if base_ref is None or changed_files is None or config_file.name not in changed_files:
+        return None
+
+    # Local import: git I/O is only needed on this rarely-used code path.
+    from posit_bakery.config.changeset import git_show_file
+
+    repo_root = _git_repo_root(config_file.parent)
+    rel_path = config_file.relative_to(repo_root).as_posix()
+
+    try:
+        return git_show_file(repo_root, base_ref, rel_path)
+    except subprocess.CalledProcessError as e:
+        log.warning(
+            "Could not read bakery.yaml at base-ref %r (%s); disabling semantic bakery.yaml diffing for this run.",
+            base_ref,
+            e.stderr.strip() if e.stderr else e,
+        )
+        return None
 
 
 def _version_selected(ver: ImageVersion, cs: ImageChangeSet) -> bool:

--- a/posit-bakery/posit_bakery/cli/ci.py
+++ b/posit-bakery/posit_bakery/cli/ci.py
@@ -11,7 +11,7 @@ import typer
 
 from posit_bakery.cli.common import with_verbosity_flags, parse_dev_spec
 from posit_bakery.config import BakeryConfig
-from posit_bakery.config.changeset import classify_changes, ImageChangeSet, MatrixSelection
+from posit_bakery.config.changeset import classify_changes, classify_bakery_yaml_diff, ImageChangeSet, MatrixSelection
 from posit_bakery.config.config import BakerySettings, BakeryConfigFilter, version_matches
 from posit_bakery.config.image.posit_product.const import ReleaseChannelEnum
 from posit_bakery.config.image.version import ImageVersion
@@ -113,9 +113,7 @@ def _git_repo_root(rebase_root: Path) -> Path:
     return Path(toplevel)
 
 
-def _resolve_base_bakery_yaml(
-    base_ref: str | None, changed_files: list[str] | None, config_file: Path
-) -> str | None:
+def _resolve_base_bakery_yaml(base_ref: str | None, changed_files: list[str] | None, config_file: Path) -> str | None:
     """Return bakery.yaml's text content at ``base_ref``, or None to skip semantic diffing.
 
     Returns None (no git call made) when there's no base_ref, no changed-files
@@ -290,7 +288,13 @@ def matrix(
         selection: MatrixSelection | None = None
         changed = _resolve_changed_files(base_ref, changed_files_from, c.base_path)
         if changed is not None:
-            selection = classify_changes(c, changed)
+            old_bakery_yaml = _resolve_base_bakery_yaml(base_ref, changed, c.config_file)
+            bakery_yaml_selection = (
+                classify_bakery_yaml_diff(old_bakery_yaml, c.config_file.read_text())
+                if old_bakery_yaml is not None
+                else None
+            )
+            selection = classify_changes(c, changed, bakery_yaml_selection=bakery_yaml_selection)
             if selection.full:
                 # Fail-safe / repo-wide change: behave exactly as a full matrix.
                 selection = None

--- a/posit-bakery/posit_bakery/cli/ci.py
+++ b/posit-bakery/posit_bakery/cli/ci.py
@@ -288,7 +288,12 @@ def matrix(
         selection: MatrixSelection | None = None
         changed = _resolve_changed_files(base_ref, changed_files_from, c.base_path)
         if changed is not None:
-            old_bakery_yaml = _resolve_base_bakery_yaml(base_ref, changed, c.config_file)
+            # --changed-files-from overrides --base-ref entirely (see _resolve_changed_files),
+            # so the historical bakery.yaml lookup must not fall back to running git against
+            # base_ref either -- otherwise a caller with no reliable history for base_ref (the
+            # exact case --changed-files-from exists for) still gets a git call here.
+            yaml_base_ref = base_ref if changed_files_from is None else None
+            old_bakery_yaml = _resolve_base_bakery_yaml(yaml_base_ref, changed, c.config_file)
             bakery_yaml_selection = (
                 classify_bakery_yaml_diff(old_bakery_yaml, c.config_file.read_text())
                 if old_bakery_yaml is not None

--- a/posit-bakery/posit_bakery/cli/ci.py
+++ b/posit-bakery/posit_bakery/cli/ci.py
@@ -67,6 +67,10 @@ def _resolve_changed_files(base_ref: str | None, changed_files_from: str | None,
     # Local import: git diff is only needed on this rarely-used code path.
     from posit_bakery.config.changeset import git_changed_files
 
+    # Not wrapped in the fail-safe below: failing here means rebase_root itself
+    # isn't a git checkout at all, a more fundamental misconfiguration than a
+    # base_ref that doesn't diff cleanly, and should surface loudly rather than
+    # silently fall back to a full build.
     toplevel = subprocess.run(
         ["git", "-C", str(rebase_root), "rev-parse", "--show-toplevel"],
         check=True,
@@ -84,7 +88,7 @@ def _resolve_changed_files(base_ref: str | None, changed_files_from: str | None,
         log.warning(
             "Could not diff against base-ref %r (%s); falling back to a full build.",
             base_ref,
-            e,
+            e.stderr.strip() if e.stderr else e,
         )
         return None
 

--- a/posit-bakery/posit_bakery/cli/ci.py
+++ b/posit-bakery/posit_bakery/cli/ci.py
@@ -131,16 +131,21 @@ def _resolve_base_bakery_yaml(
     # Local import: git I/O is only needed on this rarely-used code path.
     from posit_bakery.config.changeset import git_show_file
 
-    repo_root = _git_repo_root(config_file.parent)
-    rel_path = config_file.relative_to(repo_root).as_posix()
-
     try:
+        repo_root = _git_repo_root(config_file.parent)
+        rel_path = config_file.relative_to(repo_root).as_posix()
         return git_show_file(repo_root, base_ref, rel_path)
-    except subprocess.CalledProcessError as e:
+    except (subprocess.CalledProcessError, ValueError) as e:
+        # CalledProcessError: config_file.parent isn't a git checkout, or
+        # git_show_file couldn't read it at base_ref. ValueError: config_file
+        # isn't actually under repo_root (relative_to failure). Either way,
+        # this is the same "compare unavailable" fail-safe as the rest of the
+        # module -- --changed-files-from callers in particular may point
+        # config_file at a directory with no git available at all.
         log.warning(
             "Could not read bakery.yaml at base-ref %r (%s); disabling semantic bakery.yaml diffing for this run.",
             base_ref,
-            e.stderr.strip() if e.stderr else e,
+            e.stderr.strip() if isinstance(e, subprocess.CalledProcessError) and e.stderr else e,
         )
         return None
 

--- a/posit-bakery/posit_bakery/config/changeset.py
+++ b/posit-bakery/posit_bakery/config/changeset.py
@@ -1,7 +1,8 @@
 """Map a PR's changed files to the image/version build matrix it affects.
 
-The classifier (:func:`classify_changes`) is pure so it can be unit-tested with
-synthetic file lists; git I/O lives in :func:`git_changed_files`.
+The classifiers (:func:`classify_changes` and :func:`classify_bakery_yaml_diff`) are
+pure so they can be unit-tested with synthetic inputs; git I/O lives in
+:func:`git_changed_files` and :func:`git_show_file`.
 """
 
 from __future__ import annotations
@@ -249,7 +250,10 @@ def classify_bakery_yaml_diff(old_text: str, new_text: str) -> MatrixSelection:
 # Paths (relative to the bakery context root) that never trigger a build.
 _IGNORE_EXACT = {".gitignore", ".pre-commit-config.yaml"}
 _IGNORE_PREFIXES = (".idea/", ".claude/", ".github/")
-# Paths that conservatively trigger a full build (fail safe).
+# Paths triggering full build classification (fail-safe fallback).
+# _FULL_EXACT (bakery.yaml/bakery.yml): classified via semantic diff when available,
+# falls back to full build when no old content, unparseable, malformed, or outside images[].
+# _FULL_PREFIXES (.github/workflows/): unconditionally triggers full build (no semantic analysis).
 # NOTE: the _FULL check must run before the _IGNORE check below, because
 # ".github/workflows/" is a strict sub-prefix of the ignored ".github/".
 _FULL_EXACT = {"bakery.yaml", "bakery.yml"}

--- a/posit-bakery/posit_bakery/config/changeset.py
+++ b/posit-bakery/posit_bakery/config/changeset.py
@@ -55,6 +55,36 @@ def _index_by_key(entries: object, key: str) -> dict[str, dict]:
     return {e[key]: e for e in entries if isinstance(e, dict) and isinstance(e.get(key), str)}
 
 
+def _images_confidently_shaped(images: list) -> bool:
+    """True if every images[] entry is a dict with a string name, every
+    non-matrix image's versions[] (if present) is a list of dicts each with
+    a string name, and every matrix image's matrix.dependencies (if present)
+    is a list of dicts each with a string dependency. False for anything
+    that doesn't confidently fit that shape -- the caller should fail safe
+    rather than silently ignore the entry, matching how _index_by_key would
+    otherwise drop it without a trace."""
+    for entry in images:
+        if not isinstance(entry, dict) or not isinstance(entry.get("name"), str):
+            return False
+        versions = entry.get("versions")
+        if versions is not None:
+            if not isinstance(versions, list):
+                return False
+            for v in versions:
+                if not isinstance(v, dict) or not isinstance(v.get("name"), str):
+                    return False
+        matrix = entry.get("matrix")
+        if isinstance(matrix, dict):
+            deps = matrix.get("dependencies")
+            if deps is not None:
+                if not isinstance(deps, list):
+                    return False
+                for d in deps:
+                    if not isinstance(d, dict) or not isinstance(d.get("dependency"), str):
+                        return False
+    return True
+
+
 def _dependency_versions(entry: dict) -> list[str]:
     """A DependencyVersions entry serializes as either 'versions: [...]' or,
     for a single version, 'version: x' (see DependencyVersions.serialize_versions)."""
@@ -176,6 +206,13 @@ def classify_bakery_yaml_diff(old_text: str, new_text: str) -> MatrixSelection:
     old_images = old_yaml.get("images")
     new_images = new_yaml.get("images")
     if not isinstance(old_images, list) or not isinstance(new_images, list):
+        selection.full = True
+        return selection
+
+    if not _images_confidently_shaped(old_images) or not _images_confidently_shaped(new_images):
+        # A malformed entry (e.g. an unquoted numeric version name) would
+        # otherwise be silently dropped by _index_by_key downstream, hiding
+        # its changes from every tier below instead of failing safe.
         selection.full = True
         return selection
 

--- a/posit-bakery/posit_bakery/config/changeset.py
+++ b/posit-bakery/posit_bakery/config/changeset.py
@@ -32,6 +32,22 @@ def git_changed_files(repo_root: Path, base_ref: str) -> list[str]:
     return [line.strip() for line in result.stdout.splitlines() if line.strip()]
 
 
+def git_show_file(repo_root: Path, ref: str, path: str) -> str:
+    """Return the text content of ``path`` (POSIX, relative to ``repo_root``) at ``ref``.
+
+    Raises ``subprocess.CalledProcessError`` if ``ref`` doesn't exist, ``path``
+    doesn't exist at ``ref``, or any other git failure — same failure shape as
+    :func:`git_changed_files`, left to the caller to handle.
+    """
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "show", f"{ref}:{path}"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
 # Paths (relative to the bakery context root) that never trigger a build.
 _IGNORE_EXACT = {".gitignore", ".pre-commit-config.yaml"}
 _IGNORE_PREFIXES = (".idea/", ".claude/", ".github/")

--- a/posit-bakery/posit_bakery/config/changeset.py
+++ b/posit-bakery/posit_bakery/config/changeset.py
@@ -318,8 +318,21 @@ def _attribute(cs: ImageChangeSet, image: "Image", remainder: str) -> None:
     cs.include_all_release = True
 
 
-def classify_changes(config: "BakeryConfig", changed_files: Iterable[str]) -> MatrixSelection:
-    """Classify changed file paths (relative to the bakery context) into a build selection."""
+def classify_changes(
+    config: "BakeryConfig",
+    changed_files: Iterable[str],
+    bakery_yaml_selection: MatrixSelection | None = None,
+) -> MatrixSelection:
+    """Classify changed file paths (relative to the bakery context) into a build selection.
+
+    ``bakery_yaml_selection``, if given, is the result of the caller already
+    having diffed bakery.yaml's old and new text via
+    :func:`classify_bakery_yaml_diff` (which requires reading the current
+    bakery.yaml's text from disk -- I/O this function itself must not do, to
+    stay pure). When a changed path is bakery.yaml/bakery.yml and this is
+    provided, its signal is merged into the result instead of unconditionally
+    failing safe to a full matrix.
+    """
     selection = MatrixSelection()
     base = config.base_path
 
@@ -334,7 +347,21 @@ def classify_changes(config: "BakeryConfig", changed_files: Iterable[str]) -> Ma
 
         if path.lower().endswith(".md"):
             continue
-        if path in _FULL_EXACT or path.startswith(_FULL_PREFIXES):
+        if path in _FULL_EXACT:
+            if bakery_yaml_selection is not None:
+                if bakery_yaml_selection.full:
+                    selection.full = True
+                else:
+                    for name, cs in bakery_yaml_selection.images.items():
+                        target = selection.for_image(name)
+                        target.versions |= cs.versions
+                        target.include_all_release = target.include_all_release or cs.include_all_release
+                        target.include_dev = target.include_dev or cs.include_dev
+                        target.include_matrix_latest = target.include_matrix_latest or cs.include_matrix_latest
+            else:
+                selection.full = True
+            continue
+        if path.startswith(_FULL_PREFIXES):
             selection.full = True
             continue
         if path in _IGNORE_EXACT or path.startswith(_IGNORE_PREFIXES):

--- a/posit-bakery/posit_bakery/config/changeset.py
+++ b/posit-bakery/posit_bakery/config/changeset.py
@@ -48,6 +48,167 @@ def git_show_file(repo_root: Path, ref: str, path: str) -> str:
     return result.stdout
 
 
+def _index_by_key(entries: object, key: str) -> dict[str, dict]:
+    """Index a list of dicts by one of their string-valued keys, ignoring anything malformed."""
+    if not isinstance(entries, list):
+        return {}
+    return {e[key]: e for e in entries if isinstance(e, dict) and isinstance(e.get(key), str)}
+
+
+def _dependency_versions(entry: dict) -> list[str]:
+    """A DependencyVersions entry serializes as either 'versions: [...]' or,
+    for a single version, 'version: x' (see DependencyVersions.serialize_versions)."""
+    if "versions" in entry and isinstance(entry["versions"], list):
+        return [str(v) for v in entry["versions"]]
+    if "version" in entry:
+        return [str(entry["version"])]
+    return []
+
+
+def _only_lost_latest(old_version: dict, new_version: dict) -> bool:
+    """True if new_version is identical to old_version except old_version had
+    latest: true and new_version doesn't (unset or false) -- i.e. this entry
+    is purely losing latest to some other entry, with no other change."""
+    if not (old_version.get("latest", False) and not new_version.get("latest", False)):
+        return False
+    old_without_latest = {k: v for k, v in old_version.items() if k != "latest"}
+    new_without_latest = {k: v for k, v in new_version.items() if k != "latest"}
+    return old_without_latest == new_without_latest
+
+
+def _classify_versions_diff(cs: ImageChangeSet, old_image: dict, new_image: dict) -> None:
+    """Tier 1 (non-matrix): narrow to specific versions, or fail-safe to
+    include_all_release for anything outside the versions: list."""
+    old_rest = {k: v for k, v in old_image.items() if k != "versions"}
+    new_rest = {k: v for k, v in new_image.items() if k != "versions"}
+    if old_rest != new_rest:
+        cs.include_all_release = True
+        return
+
+    old_versions = _index_by_key(old_image.get("versions"), "name")
+    new_versions = _index_by_key(new_image.get("versions"), "name")
+    for name, new_version in new_versions.items():
+        old_version = old_versions.get(name)
+        if old_version is None:
+            cs.versions.add(name)  # New entry.
+            continue
+        if old_version == new_version:
+            continue  # No change to this entry at all.
+        if _only_lost_latest(old_version, new_version):
+            continue  # Losing latest to some other entry, nothing else changed on this one.
+        cs.versions.add(name)  # Some other field changed (including latest moving onto it).
+    # Versions only in old_versions (removed): no signal needed.
+
+
+def _matrix_needs_rebuild(old_image: dict, new_image: dict) -> bool:
+    """Tier 2 (matrix): True if anything changed that isn't purely a removed
+    pinned-dependency value. Every "yes" case here resolves to the same
+    include_matrix_latest action, so this only needs a boolean answer."""
+    old_matrix = old_image.get("matrix")
+    new_matrix = new_image.get("matrix")
+    if not isinstance(old_matrix, dict) or not isinstance(new_matrix, dict):
+        return True
+
+    old_rest_image = {k: v for k, v in old_image.items() if k != "matrix"}
+    new_rest_image = {k: v for k, v in new_image.items() if k != "matrix"}
+    if old_rest_image != new_rest_image:
+        return True
+
+    ignored_matrix_keys = ("dependencies", "dependencyConstraints")
+    old_matrix_rest = {k: v for k, v in old_matrix.items() if k not in ignored_matrix_keys}
+    new_matrix_rest = {k: v for k, v in new_matrix.items() if k not in ignored_matrix_keys}
+    if old_matrix_rest != new_matrix_rest:
+        return True
+
+    # dependencyConstraints resolve externally (over time, via a network call) --
+    # identical constraint text can resolve to a different concrete set, and
+    # different text can resolve to the same set. Any change here is treated
+    # as needing a rebuild; there's no way to know from text alone whether
+    # it's an addition or removal at the concrete-version level.
+    if (old_matrix.get("dependencyConstraints") or []) != (new_matrix.get("dependencyConstraints") or []):
+        return True
+
+    old_deps = _index_by_key(old_matrix.get("dependencies"), "dependency")
+    new_deps = _index_by_key(new_matrix.get("dependencies"), "dependency")
+
+    for name, new_dep in new_deps.items():
+        old_dep = old_deps.get(name)
+        if old_dep is None:
+            return True  # A whole new dependency axis changes the matrix's shape.
+        if set(_dependency_versions(new_dep)) - set(_dependency_versions(old_dep)):
+            return True  # At least one value added to this axis.
+
+    if any(name not in new_deps for name in old_deps):
+        return True  # A whole dependency axis was removed.
+
+    return False  # Only removed values (or no change) everywhere -> nothing to build.
+
+
+def classify_bakery_yaml_diff(old_text: str, new_text: str) -> MatrixSelection:
+    """Structural diff between two bakery.yaml texts, classified the same way
+    _attribute() classifies file paths: narrow to specific images/versions where
+    the diff is confidently understood, fail safe (MatrixSelection.full) otherwise.
+
+    Pure: no git or filesystem I/O. Both texts are parsed with the same
+    ruamel.yaml settings BakeryConfig itself uses (preserve_quotes), so a
+    version string like "3.12" round-trips the same way on both sides.
+    """
+    selection = MatrixSelection()
+
+    # Local import: ruamel.yaml is only needed on this code path.
+    from ruamel.yaml import YAML
+    from ruamel.yaml.error import YAMLError
+
+    loader = YAML()
+    loader.preserve_quotes = True
+
+    try:
+        old_yaml = loader.load(old_text)
+        new_yaml = loader.load(new_text)
+    except YAMLError:
+        selection.full = True
+        return selection
+
+    if not isinstance(old_yaml, dict) or not isinstance(new_yaml, dict):
+        selection.full = True
+        return selection
+
+    old_images = old_yaml.get("images")
+    new_images = new_yaml.get("images")
+    if not isinstance(old_images, list) or not isinstance(new_images, list):
+        selection.full = True
+        return selection
+
+    old_top = {k: v for k, v in old_yaml.items() if k != "images"}
+    new_top = {k: v for k, v in new_yaml.items() if k != "images"}
+    if old_top != new_top:
+        # A change outside images[] is genuinely global, not scoped to any image.
+        selection.full = True
+        return selection
+
+    old_by_name = _index_by_key(old_images, "name")
+    new_by_name = _index_by_key(new_images, "name")
+
+    for name, new_image in new_by_name.items():
+        old_image = old_by_name.get(name)
+        if old_image is None or old_image == new_image:
+            continue  # New image (path-based classification already covers its files) or unchanged.
+
+        cs = selection.for_image(name)
+        has_dev = bool(new_image.get("devVersions"))
+
+        if "matrix" in new_image or "matrix" in old_image:
+            if _matrix_needs_rebuild(old_image, new_image):
+                cs.include_matrix_latest = True
+                cs.include_dev = cs.include_dev or has_dev
+            # else: purely removed pinned-dependency values -> no signal.
+        else:
+            _classify_versions_diff(cs, old_image, new_image)
+
+    selection.images = {name: cs for name, cs in selection.images.items() if not cs.empty}
+    return selection
+
+
 # Paths (relative to the bakery context root) that never trigger a build.
 _IGNORE_EXACT = {".gitignore", ".pre-commit-config.yaml"}
 _IGNORE_PREFIXES = (".idea/", ".claude/", ".github/")

--- a/posit-bakery/test/cli/test_ci.py
+++ b/posit-bakery/test/cli/test_ci.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import re
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -179,6 +180,35 @@ def test_resolve_changed_files_warns_when_base_ref_also_given(tmp_path, caplog):
     assert result == ["app/template/Containerfile"]
     assert any("--base-ref" in record.message and "ignored" in record.message.lower() for record in caplog.records), (
         f"expected a warning that --base-ref is ignored, got: {[r.message for r in caplog.records]}"
+    )
+
+
+def test_resolve_changed_files_falls_back_to_full_build_on_git_diff_error(tmp_path, mocker, caplog):
+    """A git-diff failure (bad ref, unrelated histories, etc.) must fall back to a
+    full build instead of crashing bakery ci matrix.
+
+    This is what makes --base-ref safe to use on push events: on a branch's
+    first-ever push, github.event.before is the all-zero SHA, which does not diff
+    cleanly. classify_changes already fails safe to a full build for unrecognized
+    paths; this extends the same philosophy to a broken base-ref.
+    """
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+
+    mocker.patch(
+        "posit_bakery.config.changeset.git_changed_files",
+        side_effect=subprocess.CalledProcessError(128, ["git", "diff", "--merge-base"]),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="posit_bakery.cli.ci"):
+        result = _resolve_changed_files(
+            base_ref="0000000000000000000000000000000000000000",
+            changed_files_from=None,
+            rebase_root=tmp_path,
+        )
+
+    assert result is None
+    assert any("falling back to a full build" in record.message.lower() for record in caplog.records), (
+        f"expected a fallback warning, got: {[r.message for r in caplog.records]}"
     )
 
 

--- a/posit-bakery/test/cli/test_ci.py
+++ b/posit-bakery/test/cli/test_ci.py
@@ -212,6 +212,27 @@ def test_resolve_changed_files_falls_back_to_full_build_on_git_diff_error(tmp_pa
     )
 
 
+def test_resolve_changed_files_does_not_swallow_unrelated_errors(tmp_path, mocker):
+    """Only subprocess.CalledProcessError is a recognized 'base_ref didn't diff
+    cleanly' failure. Any other exception must propagate uncaught, proving the
+    except clause above is exactly as narrow as intended and doesn't quietly
+    mask unrelated bugs.
+    """
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+
+    mocker.patch(
+        "posit_bakery.config.changeset.git_changed_files",
+        side_effect=RuntimeError("unrelated bug, not a git-diff failure"),
+    )
+
+    with pytest.raises(RuntimeError, match="unrelated bug"):
+        _resolve_changed_files(
+            base_ref="some-ref",
+            changed_files_from=None,
+            rebase_root=tmp_path,
+        )
+
+
 class TestChangeAwareFlagIntersection:
     """Change-aware mode must still honor --dev-versions / --matrix-versions.
 

--- a/posit-bakery/test/cli/test_ci.py
+++ b/posit-bakery/test/cli/test_ci.py
@@ -356,6 +356,81 @@ class TestChangeAwareFlagIntersection:
         assert matrix == [], f"expected an empty matrix under --dev-versions exclude, got: {matrix}"
 
 
+class TestBakeryYamlSemanticDiffEndToEnd:
+    """bakery ci matrix --base-ref, exercised against a real git repo, must
+    narrow a bakery.yaml-only version addition instead of building everything."""
+
+    def test_version_added_to_bakery_yaml_narrows_the_matrix(self, resource_path, tmp_path):
+        import shutil
+
+        context = tmp_path / "changeset"
+        shutil.copytree(resource_path / "changeset", context)
+
+        subprocess.run(["git", "init"], cwd=context, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"], cwd=context, check=True, capture_output=True
+        )
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=context, check=True, capture_output=True)
+        subprocess.run(["git", "add", "-A"], cwd=context, check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "before"], cwd=context, check=True, capture_output=True)
+        before_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=context, check=True, capture_output=True, text=True
+        ).stdout.strip()
+
+        bakery_yaml = context / "bakery.yaml"
+        content = bakery_yaml.read_text()
+        content = content.replace(
+            """      - name: 2.0.0
+        subpath: "2.0.0"
+        latest: true
+        os:
+          - name: Ubuntu 22.04
+            primary: true""",
+            """      - name: 3.0.0
+        subpath: "3.0.0"
+        latest: true
+        os:
+          - name: Ubuntu 22.04
+            primary: true
+      - name: 2.0.0
+        subpath: "2.0.0"
+        os:
+          - name: Ubuntu 22.04
+            primary: true""",
+        )
+        bakery_yaml.write_text(content)
+        subprocess.run(["git", "add", "-A"], cwd=context, check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "after"], cwd=context, check=True, capture_output=True)
+
+        from typer.testing import CliRunner
+        from posit_bakery.cli.main import app as bakery_app
+
+        runner = CliRunner()
+        result = runner.invoke(
+            bakery_app,
+            [
+                "ci",
+                "matrix",
+                "--quiet",
+                "--context",
+                str(context),
+                "--base-ref",
+                before_sha,
+                "--dev-versions",
+                "exclude",
+            ],
+            catch_exceptions=True,
+            env={"TERM": "dumb", "NO_COLOR": "true"},
+        )
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        matrix = json.loads(result.stdout.strip())
+        app_versions = {entry["version"] for entry in matrix if entry["image"] == "app"}
+
+        assert app_versions == {"3.0.0"}, (
+            f"expected only the added version, got {app_versions} -- full matrix: {matrix}"
+        )
+
+
 class TestVersionMatches:
     @pytest.mark.parametrize(
         "ver_name,filter_version",

--- a/posit-bakery/test/cli/test_ci.py
+++ b/posit-bakery/test/cli/test_ci.py
@@ -430,6 +430,91 @@ class TestBakeryYamlSemanticDiffEndToEnd:
             f"expected only the added version, got {app_versions} -- full matrix: {matrix}"
         )
 
+    def test_changed_files_from_overrides_base_ref_for_yaml_diff_too(self, resource_path, tmp_path):
+        """--changed-files-from must override --base-ref for the bakery.yaml semantic
+        diff, not just the changed-file list.
+
+        Same before/after repo as test_version_added_to_bakery_yaml_narrows_the_matrix,
+        where --base-ref alone narrows to the added version. Supplying
+        --changed-files-from alongside a valid --base-ref must still fall back to the
+        full matrix: using base_ref here despite the override would give a caller with
+        no reliable history for base_ref (the case --changed-files-from exists for) an
+        inconsistent result.
+        """
+        import shutil
+
+        context = tmp_path / "changeset"
+        shutil.copytree(resource_path / "changeset", context)
+
+        subprocess.run(["git", "init"], cwd=context, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"], cwd=context, check=True, capture_output=True
+        )
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=context, check=True, capture_output=True)
+        subprocess.run(["git", "add", "-A"], cwd=context, check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "before"], cwd=context, check=True, capture_output=True)
+        before_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=context, check=True, capture_output=True, text=True
+        ).stdout.strip()
+
+        bakery_yaml = context / "bakery.yaml"
+        content = bakery_yaml.read_text()
+        content = content.replace(
+            """      - name: 2.0.0
+        subpath: "2.0.0"
+        latest: true
+        os:
+          - name: Ubuntu 22.04
+            primary: true""",
+            """      - name: 3.0.0
+        subpath: "3.0.0"
+        latest: true
+        os:
+          - name: Ubuntu 22.04
+            primary: true
+      - name: 2.0.0
+        subpath: "2.0.0"
+        os:
+          - name: Ubuntu 22.04
+            primary: true""",
+        )
+        bakery_yaml.write_text(content)
+        subprocess.run(["git", "add", "-A"], cwd=context, check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "after"], cwd=context, check=True, capture_output=True)
+
+        changed_files = tmp_path / "changed-files.txt"
+        changed_files.write_text("bakery.yaml\n")
+
+        from typer.testing import CliRunner
+        from posit_bakery.cli.main import app as bakery_app
+
+        runner = CliRunner()
+        result = runner.invoke(
+            bakery_app,
+            [
+                "ci",
+                "matrix",
+                "--quiet",
+                "--context",
+                str(context),
+                "--base-ref",
+                before_sha,
+                "--changed-files-from",
+                str(changed_files),
+                "--dev-versions",
+                "exclude",
+            ],
+            catch_exceptions=True,
+            env={"TERM": "dumb", "NO_COLOR": "true"},
+        )
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        matrix = json.loads(result.stdout.strip())
+        app_versions = {entry["version"] for entry in matrix if entry["image"] == "app"}
+
+        assert app_versions == {"1.0.0", "2.0.0", "3.0.0"}, (
+            f"expected the full matrix (base_ref must be ignored), got {app_versions} -- full matrix: {matrix}"
+        )
+
 
 class TestVersionMatches:
     @pytest.mark.parametrize(

--- a/posit-bakery/test/cli/test_ci.py
+++ b/posit-bakery/test/cli/test_ci.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 from pytest_bdd import scenarios, then, parsers, given
 
-from posit_bakery.cli.ci import _resolve_changed_files
+from posit_bakery.cli.ci import _resolve_changed_files, _resolve_base_bakery_yaml
 from posit_bakery.config.config import version_matches
 from posit_bakery.config.image.version import ImageVersion
 
@@ -231,6 +231,45 @@ def test_resolve_changed_files_does_not_swallow_unrelated_errors(tmp_path, mocke
             changed_files_from=None,
             rebase_root=tmp_path,
         )
+
+
+def test_resolve_base_bakery_yaml_returns_none_without_base_ref(tmp_path):
+    result = _resolve_base_bakery_yaml(None, ["bakery.yaml"], tmp_path / "bakery.yaml")
+    assert result is None
+
+
+def test_resolve_base_bakery_yaml_returns_none_when_bakery_yaml_not_changed(tmp_path):
+    result = _resolve_base_bakery_yaml("HEAD~1", ["some/other/file.txt"], tmp_path / "bakery.yaml")
+    assert result is None
+
+
+def test_resolve_base_bakery_yaml_returns_content_on_success(tmp_path):
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, check=True, capture_output=True)
+    config_file = tmp_path / "bakery.yaml"
+    config_file.write_text("images: []\n")
+    subprocess.run(["git", "add", "bakery.yaml"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "initial"], cwd=tmp_path, check=True, capture_output=True)
+
+    result = _resolve_base_bakery_yaml("HEAD", ["bakery.yaml"], config_file)
+
+    assert result == "images: []\n"
+
+
+def test_resolve_base_bakery_yaml_falls_back_to_none_on_git_error(tmp_path, caplog):
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    config_file = tmp_path / "bakery.yaml"
+    config_file.write_text("images: []\n")
+    # No commit exists, so "HEAD" doesn't resolve -> git show fails.
+
+    with caplog.at_level(logging.WARNING, logger="posit_bakery.cli.ci"):
+        result = _resolve_base_bakery_yaml("HEAD", ["bakery.yaml"], config_file)
+
+    assert result is None
+    assert any("bakery.yaml" in record.message.lower() for record in caplog.records), (
+        f"expected a fallback warning, got: {[r.message for r in caplog.records]}"
+    )
 
 
 class TestChangeAwareFlagIntersection:

--- a/posit-bakery/test/cli/test_ci.py
+++ b/posit-bakery/test/cli/test_ci.py
@@ -272,6 +272,26 @@ def test_resolve_base_bakery_yaml_falls_back_to_none_on_git_error(tmp_path, capl
     )
 
 
+def test_resolve_base_bakery_yaml_falls_back_to_none_when_not_a_git_checkout(tmp_path, caplog):
+    """config_file's directory may not be a git checkout at all -- a plausible
+    future case for --changed-files-from callers, which exists precisely for
+    callers without git available. _git_repo_root then raises
+    CalledProcessError before git_show_file is ever called; that must be
+    caught here too, not just around git_show_file itself.
+    """
+    config_file = tmp_path / "bakery.yaml"
+    config_file.write_text("images: []\n")
+    # No `git init` -> tmp_path is not a git checkout at all.
+
+    with caplog.at_level(logging.WARNING, logger="posit_bakery.cli.ci"):
+        result = _resolve_base_bakery_yaml("HEAD", ["bakery.yaml"], config_file)
+
+    assert result is None
+    assert any("bakery.yaml" in record.message.lower() for record in caplog.records), (
+        f"expected a fallback warning, got: {[r.message for r in caplog.records]}"
+    )
+
+
 class TestChangeAwareFlagIntersection:
     """Change-aware mode must still honor --dev-versions / --matrix-versions.
 

--- a/posit-bakery/test/config/test_changeset.py
+++ b/posit-bakery/test/config/test_changeset.py
@@ -533,3 +533,62 @@ images:
 
         assert not selection.full
         assert selection.images["connect-content"].include_matrix_latest
+
+    def test_malformed_image_entry_fails_safe_to_full(self):
+        old = """
+images:
+  - name: workbench
+    versions:
+      - name: "2026.06.0"
+        latest: true
+"""
+        new = """
+images:
+  - just-a-string-not-a-dict
+  - name: workbench
+    versions:
+      - name: "2026.06.0"
+        latest: true
+"""
+        selection = classify_bakery_yaml_diff(old, new)
+
+        assert selection.full
+
+    def test_version_entry_with_non_string_name_fails_safe_to_full(self):
+        old = """
+images:
+  - name: workbench
+    versions:
+      - name: "2026.06.0"
+        latest: true
+"""
+        new = """
+images:
+  - name: workbench
+    versions:
+      - name: 4.0
+        latest: true
+"""
+        selection = classify_bakery_yaml_diff(old, new)
+
+        assert selection.full
+
+    def test_matrix_dependency_entry_missing_dependency_key_fails_safe_to_full(self):
+        old = """
+images:
+  - name: connect-content
+    matrix:
+      dependencies:
+        - dependency: python
+          versions: ["3.12.1"]
+"""
+        new = """
+images:
+  - name: connect-content
+    matrix:
+      dependencies:
+        - versions: ["3.12.1", "3.13.0"]
+"""
+        selection = classify_bakery_yaml_diff(old, new)
+
+        assert selection.full

--- a/posit-bakery/test/config/test_changeset.py
+++ b/posit-bakery/test/config/test_changeset.py
@@ -11,6 +11,7 @@ from posit_bakery.config.changeset import (
     git_changed_files,
     git_show_file,
     ImageChangeSet,
+    MatrixSelection,
 )
 from posit_bakery.cli.ci import _version_selected
 
@@ -626,3 +627,17 @@ class TestClassifyChangesBakeryYamlIntegration:
         )
 
         assert selection.full
+
+    def test_bakery_yaml_selection_merges_with_other_changed_files_for_the_same_image(self, changeset_config):
+        """One version comes from a file-path change, the other from
+        bakery_yaml_selection -- both must survive the merge regardless of
+        which order the changed files are processed in."""
+        bakery_yaml_selection = MatrixSelection(images={"app": ImageChangeSet(versions={"1.0.0"})})
+
+        selection = classify_changes(
+            changeset_config,
+            ["app/2.0.0/Containerfile.ubuntu2204.std", "bakery.yaml"],
+            bakery_yaml_selection=bakery_yaml_selection,
+        )
+
+        assert selection.images["app"].versions == {"1.0.0", "2.0.0"}

--- a/posit-bakery/test/config/test_changeset.py
+++ b/posit-bakery/test/config/test_changeset.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 from posit_bakery.config import BakeryConfig
-from posit_bakery.config.changeset import classify_changes, git_changed_files, ImageChangeSet
+from posit_bakery.config.changeset import classify_changes, git_changed_files, git_show_file, ImageChangeSet
 from posit_bakery.cli.ci import _version_selected
 
 
@@ -172,3 +172,28 @@ class TestVersionSelected:
         ver = _fake_ver(name="1.0.0")
         cs = ImageChangeSet(include_all_release=True)
         assert _version_selected(ver, cs) is True
+
+
+def test_git_show_file_returns_content_at_ref(tmp_path):
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, check=True, capture_output=True)
+    (tmp_path / "bakery.yaml").write_text("images: []\n")
+    subprocess.run(["git", "add", "bakery.yaml"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "initial"], cwd=tmp_path, check=True, capture_output=True)
+
+    content = git_show_file(tmp_path, "HEAD", "bakery.yaml")
+
+    assert content == "images: []\n"
+
+
+def test_git_show_file_raises_on_missing_path(tmp_path):
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, check=True, capture_output=True)
+    (tmp_path / "placeholder.txt").write_text("x")
+    subprocess.run(["git", "add", "placeholder.txt"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "initial"], cwd=tmp_path, check=True, capture_output=True)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        git_show_file(tmp_path, "HEAD", "bakery.yaml")

--- a/posit-bakery/test/config/test_changeset.py
+++ b/posit-bakery/test/config/test_changeset.py
@@ -5,7 +5,13 @@ from pathlib import Path
 import pytest
 
 from posit_bakery.config import BakeryConfig
-from posit_bakery.config.changeset import classify_bakery_yaml_diff, classify_changes, git_changed_files, git_show_file, ImageChangeSet
+from posit_bakery.config.changeset import (
+    classify_bakery_yaml_diff,
+    classify_changes,
+    git_changed_files,
+    git_show_file,
+    ImageChangeSet,
+)
 from posit_bakery.cli.ci import _version_selected
 
 
@@ -590,5 +596,33 @@ images:
         - versions: ["3.12.1", "3.13.0"]
 """
         selection = classify_bakery_yaml_diff(old, new)
+
+        assert selection.full
+
+
+class TestClassifyChangesBakeryYamlIntegration:
+    """classify_changes must merge an already-computed bakery_yaml_selection
+    when given one, and keep today's unconditional full-fail-safe when it
+    isn't given one."""
+
+    def test_bakery_yaml_change_without_selection_still_fails_safe(self, changeset_config):
+        selection = classify_changes(changeset_config, ["bakery.yaml"])
+        assert selection.full
+
+    def test_bakery_yaml_change_with_selection_merges_it_in(self, changeset_config):
+        current_text = changeset_config.config_file.read_text()
+        old_text = current_text  # identical -> diff finds no changed images.
+        bakery_yaml_selection = classify_bakery_yaml_diff(old_text, current_text)
+
+        selection = classify_changes(changeset_config, ["bakery.yaml"], bakery_yaml_selection=bakery_yaml_selection)
+
+        assert selection == bakery_yaml_selection
+
+    def test_workflows_change_still_always_fails_safe_even_with_a_selection(self, changeset_config):
+        bakery_yaml_selection = classify_bakery_yaml_diff("images: []\n", "images: []\n")
+
+        selection = classify_changes(
+            changeset_config, [".github/workflows/ci.yml"], bakery_yaml_selection=bakery_yaml_selection
+        )
 
         assert selection.full

--- a/posit-bakery/test/config/test_changeset.py
+++ b/posit-bakery/test/config/test_changeset.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 from posit_bakery.config import BakeryConfig
-from posit_bakery.config.changeset import classify_changes, git_changed_files, git_show_file, ImageChangeSet
+from posit_bakery.config.changeset import classify_bakery_yaml_diff, classify_changes, git_changed_files, git_show_file, ImageChangeSet
 from posit_bakery.cli.ci import _version_selected
 
 
@@ -197,3 +197,339 @@ def test_git_show_file_raises_on_missing_path(tmp_path):
 
     with pytest.raises(subprocess.CalledProcessError):
         git_show_file(tmp_path, "HEAD", "bakery.yaml")
+
+
+class TestClassifyBakeryYamlDiff:
+    """classify_bakery_yaml_diff: structural diff between two bakery.yaml texts."""
+
+    def test_version_added_narrows_to_that_version(self):
+        old = """
+images:
+  - name: workbench
+    versions:
+      - name: "2026.06.0"
+        latest: true
+"""
+        new = """
+images:
+  - name: workbench
+    versions:
+      - name: "2026.06.0"
+      - name: "2026.07.0"
+        latest: true
+"""
+        selection = classify_bakery_yaml_diff(old, new)
+
+        assert not selection.full
+        assert selection.images["workbench"].versions == {"2026.07.0"}
+        assert not selection.images["workbench"].include_all_release
+
+    def test_version_removed_produces_no_signal(self):
+        old = """
+images:
+  - name: workbench
+    versions:
+      - name: "2026.05.0"
+      - name: "2026.06.0"
+        latest: true
+"""
+        new = """
+images:
+  - name: workbench
+    versions:
+      - name: "2026.06.0"
+        latest: true
+"""
+        selection = classify_bakery_yaml_diff(old, new)
+
+        assert not selection.full
+        assert "workbench" not in selection.images
+
+    def test_latest_moving_narrows_only_to_the_gaining_version(self):
+        old = """
+images:
+  - name: workbench
+    versions:
+      - name: "2026.06.0"
+        latest: true
+      - name: "2026.07.0"
+"""
+        new = """
+images:
+  - name: workbench
+    versions:
+      - name: "2026.06.0"
+      - name: "2026.07.0"
+        latest: true
+"""
+        selection = classify_bakery_yaml_diff(old, new)
+
+        assert not selection.full
+        assert selection.images["workbench"].versions == {"2026.07.0"}
+
+    def test_other_field_change_falls_back_to_include_all_release(self):
+        old = """
+images:
+  - name: workbench
+    variants: [std]
+    versions:
+      - name: "2026.06.0"
+        latest: true
+"""
+        new = """
+images:
+  - name: workbench
+    variants: [std, min]
+    versions:
+      - name: "2026.06.0"
+        latest: true
+"""
+        selection = classify_bakery_yaml_diff(old, new)
+
+        assert not selection.full
+        assert selection.images["workbench"].include_all_release
+
+    def test_mixed_version_and_other_field_change_falls_back_to_include_all_release(self):
+        old = """
+images:
+  - name: workbench
+    variants: [std]
+    versions:
+      - name: "2026.06.0"
+        latest: true
+"""
+        new = """
+images:
+  - name: workbench
+    variants: [std, min]
+    versions:
+      - name: "2026.06.0"
+      - name: "2026.07.0"
+        latest: true
+"""
+        selection = classify_bakery_yaml_diff(old, new)
+
+        assert not selection.full
+        cs = selection.images["workbench"]
+        assert cs.include_all_release
+        assert "2026.07.0" not in cs.versions
+
+    def test_image_added_produces_no_signal(self):
+        old = """
+images:
+  - name: workbench
+    versions:
+      - name: "2026.06.0"
+        latest: true
+"""
+        new = """
+images:
+  - name: workbench
+    versions:
+      - name: "2026.06.0"
+        latest: true
+  - name: workbench-session-init
+    versions:
+      - name: "2026.07.0"
+        latest: true
+"""
+        selection = classify_bakery_yaml_diff(old, new)
+
+        assert not selection.full
+        assert selection.images == {}
+
+    def test_image_removed_produces_no_signal(self):
+        old = """
+images:
+  - name: workbench
+    versions:
+      - name: "2026.06.0"
+        latest: true
+  - name: old-image
+    versions:
+      - name: "1.0.0"
+        latest: true
+"""
+        new = """
+images:
+  - name: workbench
+    versions:
+      - name: "2026.06.0"
+        latest: true
+"""
+        selection = classify_bakery_yaml_diff(old, new)
+
+        assert not selection.full
+        assert selection.images == {}
+
+    def test_top_level_key_change_fails_safe_to_full(self):
+        old = """
+registries:
+  - name: ghcr
+images:
+  - name: workbench
+    versions:
+      - name: "2026.06.0"
+        latest: true
+"""
+        new = """
+registries:
+  - name: ghcr
+  - name: dockerhub
+images:
+  - name: workbench
+    versions:
+      - name: "2026.06.0"
+        latest: true
+"""
+        selection = classify_bakery_yaml_diff(old, new)
+
+        assert selection.full
+
+    def test_unparseable_old_content_fails_safe_to_full(self):
+        selection = classify_bakery_yaml_diff("images: [unterminated", "images: []\n")
+
+        assert selection.full
+
+    def test_old_content_not_shaped_as_expected_fails_safe_to_full(self):
+        selection = classify_bakery_yaml_diff("just a string, not a mapping\n", "images: []\n")
+
+        assert selection.full
+
+    def test_matrix_dependency_value_added_sets_include_matrix_latest(self):
+        old = """
+images:
+  - name: connect-content
+    matrix:
+      dependencies:
+        - dependency: python
+          versions: ["3.12.1", "3.13.0"]
+"""
+        new = """
+images:
+  - name: connect-content
+    matrix:
+      dependencies:
+        - dependency: python
+          versions: ["3.12.1", "3.13.0", "3.14.0"]
+"""
+        selection = classify_bakery_yaml_diff(old, new)
+
+        assert not selection.full
+        assert selection.images["connect-content"].include_matrix_latest
+
+    def test_matrix_dependency_value_removed_only_produces_no_signal(self):
+        old = """
+images:
+  - name: connect-content
+    matrix:
+      dependencies:
+        - dependency: python
+          versions: ["3.12.1", "3.13.0"]
+"""
+        new = """
+images:
+  - name: connect-content
+    matrix:
+      dependencies:
+        - dependency: python
+          versions: ["3.13.0"]
+"""
+        selection = classify_bakery_yaml_diff(old, new)
+
+        assert not selection.full
+        assert "connect-content" not in selection.images
+
+    def test_matrix_whole_dependency_axis_added_sets_include_matrix_latest(self):
+        old = """
+images:
+  - name: connect-content
+    matrix:
+      dependencies:
+        - dependency: python
+          versions: ["3.12.1"]
+"""
+        new = """
+images:
+  - name: connect-content
+    matrix:
+      dependencies:
+        - dependency: python
+          versions: ["3.12.1"]
+        - dependency: r
+          versions: ["4.5.0"]
+"""
+        selection = classify_bakery_yaml_diff(old, new)
+
+        assert not selection.full
+        assert selection.images["connect-content"].include_matrix_latest
+
+    def test_matrix_whole_dependency_axis_removed_sets_include_matrix_latest(self):
+        old = """
+images:
+  - name: connect-content
+    matrix:
+      dependencies:
+        - dependency: python
+          versions: ["3.12.1"]
+        - dependency: r
+          versions: ["4.5.0"]
+"""
+        new = """
+images:
+  - name: connect-content
+    matrix:
+      dependencies:
+        - dependency: python
+          versions: ["3.12.1"]
+"""
+        selection = classify_bakery_yaml_diff(old, new)
+
+        assert not selection.full
+        assert selection.images["connect-content"].include_matrix_latest
+
+    def test_matrix_dependency_constraint_change_sets_include_matrix_latest(self):
+        old = """
+images:
+  - name: connect-content
+    matrix:
+      dependencyConstraints:
+        - dependency: python
+          constraint: ">=3.12,<3.14"
+"""
+        new = """
+images:
+  - name: connect-content
+    matrix:
+      dependencyConstraints:
+        - dependency: python
+          constraint: ">=3.12,<3.15"
+"""
+        selection = classify_bakery_yaml_diff(old, new)
+
+        assert not selection.full
+        assert selection.images["connect-content"].include_matrix_latest
+
+    def test_matrix_other_field_change_sets_include_matrix_latest(self):
+        old = """
+images:
+  - name: connect-content
+    matrix:
+      namePattern: "R{r}-py{python}"
+      dependencies:
+        - dependency: python
+          versions: ["3.12.1"]
+"""
+        new = """
+images:
+  - name: connect-content
+    matrix:
+      namePattern: "r{r}-python{python}"
+      dependencies:
+        - dependency: python
+          versions: ["3.12.1"]
+"""
+        selection = classify_bakery_yaml_diff(old, new)
+
+        assert not selection.full
+        assert selection.images["connect-content"].include_matrix_latest


### PR DESCRIPTION
Release merges rebuild every version in the matrix regardless of what
changed, because the build workflows never pass `--base-ref` to `bakery
ci matrix` on push events — only PR builds get that treatment today.
Merging a release PR that touched 2 version directories still triggers
a 21-job full-matrix build across 6 versions, on every release.

This reuses the existing PR-side change-classification machinery for
push-to-main events too, diffing against `github.event.before` the
same way PR builds diff against their base commit. Two related gaps
surfaced during review and are fixed here as well:

- A git-diff failure (unreachable ref, e.g. the all-zero SHA on a
  branch's first push) used to crash the build; it now falls back to
  a full build with a warning.
- An empty change-aware matrix (e.g. a docs-only push) used to fail
  the build outright, since GitHub Actions fails rather than skips a
  job fed an empty matrix; both workflows now guard against this the
  same way the PR workflow already does.

`schedule` and `workflow_dispatch` triggers are unaffected and
continue to always build the full matrix.

`bakery.yaml` changes were still an unconditional full-matrix
fail-safe, which defeated the above for the exact case it targets:
`bakery create version` always writes the new version into
`bakery.yaml`, so every release merge tripped that fail-safe
regardless of the push-to-main change-awareness above. `bakery ci
matrix` now structurally diffs `bakery.yaml`'s old and new content
(parsed YAML, not text) and narrows to the specific image(s)/
version(s) actually affected, falling back to a full build only when
the diff can't be confidently understood (unparseable YAML, malformed
shape, or a change outside `images[]`).

- Closes https://github.com/posit-dev/images-shared/issues/652