### PR TITLE
Add version-diff comment to release PRs

### DIFF
--- a/.github/workflows/product-release.yml
+++ b/.github/workflows/product-release.yml
@@ -214,3 +214,48 @@ jobs:
             --head "$BRANCH" || echo "PR already exists"
 
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Post or update release-diff comment
+        if: steps.release.outputs.latest_changed == 'true' && steps.plan.outputs.old_display_version != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          IMAGES: ${{ inputs.images }}
+          DISPLAY_VERSION: ${{ steps.parse.outputs.display_version }}
+          OLD_DISPLAY: ${{ steps.plan.outputs.old_display_version }}
+          BRANCH: ${{ steps.pr.outputs.branch }}
+        run: |
+          MARKER="<!-- bakery-release-diff -->"
+          BODY_FILE="$RUNNER_TEMP/release-diff-comment.md"
+
+          HAS_CONTENT=false
+          {
+            echo "$MARKER"
+            echo "## Diff vs previous edition (\`${OLD_DISPLAY}\` → \`${DISPLAY_VERSION}\`)"
+            echo
+            for IMAGE in $IMAGES; do
+              DIFF_FILE="$RUNNER_TEMP/diff-$IMAGE.md"
+              if [ -s "$DIFF_FILE" ]; then
+                cat "$DIFF_FILE"
+                echo
+                HAS_CONTENT=true
+              fi
+            done
+          } > "$BODY_FILE"
+
+          if [ "$HAS_CONTENT" = false ]; then
+            echo "No per-image diff content generated; skipping comment."
+            exit 0
+          fi
+
+          PR_NUMBER=$(gh pr view "$BRANCH" --json number -q .number)
+
+          EXISTING_COMMENT_ID=$(gh api "repos/{owner}/{repo}/issues/$PR_NUMBER/comments" \
+            --jq "[.[] | select(.body | startswith(\"$MARKER\"))][0].id")
+
+          if [ -n "$EXISTING_COMMENT_ID" ] && [ "$EXISTING_COMMENT_ID" != "null" ]; then
+            gh api "repos/{owner}/{repo}/issues/comments/$EXISTING_COMMENT_ID" \
+              -X PATCH -F body=@"$BODY_FILE"
+          else
+            gh pr comment "$BRANCH" --body-file "$BODY_FILE"
+          fi

--- a/.github/workflows/product-release.yml
+++ b/.github/workflows/product-release.yml
@@ -216,7 +216,7 @@ jobs:
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
 
       - name: Post or update release-diff comment
-        if: steps.release.outputs.latest_changed == 'true' && steps.plan.outputs.old_display_version != ''
+        if: success() && steps.release.outputs.latest_changed == 'true' && steps.plan.outputs.old_display_version != ''
         continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/product-release.yml
+++ b/.github/workflows/product-release.yml
@@ -62,50 +62,89 @@ jobs:
             echo "edition=$EDITION"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Create or update versions
-        id: release
+      - name: Determine release plan
+        id: plan
         env:
           IMAGES: ${{ inputs.images }}
-          VERSION: ${{ steps.parse.outputs.version }}
-          DISPLAY_VERSION: ${{ steps.parse.outputs.display_version }}
           EDITION: ${{ steps.parse.outputs.edition }}
+          DISPLAY_VERSION: ${{ steps.parse.outputs.display_version }}
         run: |
-          FIRST_IMAGE=$(echo "$IMAGES" | awk '{print $1}')
+          # Everything above the branch checkout reads bakery.yaml as it
+          # stands on main (this job's initial checkout), before switching to
+          # an in-flight release branch might replace it. That ordering is
+          # what keeps this correct across re-dispatches: once a prior
+          # dispatch has pushed a new edition, that edition is already marked
+          # latest on the release branch, and there's no longer any other
+          # version to find as "the previous edition" by looking at what's
+          # currently latest. Capturing it here, from main, keeps it correct
+          # no matter how many times this workflow re-runs for one release.
+          PLAN_FILE="$RUNNER_TEMP/release-plan.txt"
+          : > "$PLAN_FILE"
 
-          # Capture the current latest version before any modifications.
+          FIRST_IMAGE=$(echo "$IMAGES" | awk '{print $1}')
           OLD_LATEST=$(bakery get version "$FIRST_IMAGE" 2>/dev/null || true)
           OLD_DISPLAY_VERSION="${OLD_LATEST%%[+-]*}"
+          echo "old_display_version=$OLD_DISPLAY_VERSION" >> "$GITHUB_OUTPUT"
 
           for IMAGE in $IMAGES; do
             EXISTING=$(bakery get version "$IMAGE" --subpath "$EDITION" 2>/dev/null || true)
-
             if [ -n "$EXISTING" ]; then
-              echo "Patching $IMAGE: $EXISTING -> $VERSION"
-              bakery update version "$IMAGE" "$VERSION" --target-version "$EXISTING"
+              echo "$IMAGE patch $EXISTING" >> "$PLAN_FILE"
             else
-              # Determine whether this edition should become latest.
               CURRENT_LATEST=$(bakery get version "$IMAGE" 2>/dev/null || true)
-              if [ -z "$CURRENT_LATEST" ]; then
-                MARK_LATEST="--mark-latest"
-              else
-                CURRENT_DISPLAY="${CURRENT_LATEST%%[+-]*}"
-                CURRENT_EDITION="${CURRENT_DISPLAY%.*}"
-                if [[ "$EDITION" > "$CURRENT_EDITION" ]]; then
-                  MARK_LATEST="--mark-latest"
-                else
-                  MARK_LATEST="--no-mark-latest"
-                fi
-              fi
-
-              echo "Creating $IMAGE: $VERSION (subpath=$EDITION, $MARK_LATEST)"
-              bakery create version "$IMAGE" "$VERSION" --subpath "$EDITION" $MARK_LATEST
+              echo "$IMAGE create ${CURRENT_LATEST:-"-"}" >> "$PLAN_FILE"
             fi
           done
+
+          echo "Release plan:"
+          cat "$PLAN_FILE"
+
+          BRANCH="release/${DISPLAY_VERSION}"
+          if git fetch origin "$BRANCH" 2>/dev/null; then
+            echo "Existing release branch found; continuing from it."
+            git checkout -B "$BRANCH" "origin/$BRANCH"
+          else
+            echo "No existing release branch; branching from main."
+            git checkout -B "$BRANCH"
+          fi
+
+      - name: Create or update versions
+        id: release
+        env:
+          VERSION: ${{ steps.parse.outputs.version }}
+          EDITION: ${{ steps.parse.outputs.edition }}
+          OLD_DISPLAY_VERSION: ${{ steps.plan.outputs.old_display_version }}
+        run: |
+          PLAN_FILE="$RUNNER_TEMP/release-plan.txt"
+
+          while read -r IMAGE ACTION TARGET; do
+            if [ "$ACTION" = "patch" ]; then
+              echo "Patching $IMAGE: $TARGET -> $VERSION"
+              bakery update version "$IMAGE" "$VERSION" --target-version "$TARGET"
+            elif [ "$TARGET" = "-" ]; then
+              echo "Creating $IMAGE: $VERSION (subpath=$EDITION, --mark-latest, no previous edition to diff against)"
+              bakery create version "$IMAGE" "$VERSION" --subpath "$EDITION" --force --mark-latest \
+                > "$RUNNER_TEMP/diff-$IMAGE.md"
+            else
+              TARGET_DISPLAY="${TARGET%%[+-]*}"
+              TARGET_EDITION="${TARGET_DISPLAY%.*}"
+              if [[ "$EDITION" > "$TARGET_EDITION" ]]; then
+                MARK_LATEST="--mark-latest"
+              else
+                MARK_LATEST="--no-mark-latest"
+              fi
+
+              echo "Creating $IMAGE: $VERSION (subpath=$EDITION, $MARK_LATEST, diff-against=$TARGET)"
+              bakery create version "$IMAGE" "$VERSION" --subpath "$EDITION" --force $MARK_LATEST --diff-against "$TARGET" \
+                > "$RUNNER_TEMP/diff-$IMAGE.md"
+            fi
+          done < "$PLAN_FILE"
 
           # Check if the latest version changed. This happens when:
           # - A new edition is created that becomes latest (2026.02.1 → 2026.03.0)
           # - The current latest edition is patched (2026.02.1 → 2026.02.2)
           # It does NOT happen when patching an older edition (2026.01.1 → 2026.01.3).
+          FIRST_IMAGE=$(head -n1 "$PLAN_FILE" | awk '{print $1}')
           NEW_LATEST=$(bakery get version "$FIRST_IMAGE" 2>/dev/null || true)
           NEW_DISPLAY_VERSION="${NEW_LATEST%%[+-]*}"
 
@@ -116,14 +155,13 @@ jobs:
           fi
 
           echo "latest_changed=$LATEST_CHANGED" >> "$GITHUB_OUTPUT"
-          echo "old_display_version=$OLD_DISPLAY_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Update READMEs
-        if: steps.release.outputs.latest_changed == 'true' && steps.release.outputs.old_display_version != ''
+        if: steps.release.outputs.latest_changed == 'true' && steps.plan.outputs.old_display_version != ''
         env:
           DISPLAY_VERSION: ${{ steps.parse.outputs.display_version }}
           EDITION: ${{ steps.parse.outputs.edition }}
-          OLD_DISPLAY_VERSION: ${{ steps.release.outputs.old_display_version }}
+          OLD_DISPLAY_VERSION: ${{ steps.plan.outputs.old_display_version }}
         run: |
           OLD_EDITION="${OLD_DISPLAY_VERSION%.*}"
 
@@ -139,42 +177,28 @@ jobs:
           fi
 
       - name: Create pull request
+        id: pr
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           IMAGES: ${{ inputs.images }}
           VERSION: ${{ steps.parse.outputs.version }}
           DISPLAY_VERSION: ${{ steps.parse.outputs.display_version }}
           LATEST_CHANGED: ${{ steps.release.outputs.latest_changed }}
-          OLD_DISPLAY: ${{ steps.release.outputs.old_display_version }}
+          OLD_DISPLAY: ${{ steps.plan.outputs.old_display_version }}
         run: |
           BRANCH="release/${DISPLAY_VERSION}"
-          git fetch origin "$BRANCH" 2>/dev/null || true
-          git checkout -B "$BRANCH"
           git add -A
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           if git diff --cached --quiet; then
-            # Nothing changed vs. HEAD: this display version's content is
-            # already on main (e.g. re-dispatched after the release merged).
+            # Nothing changed vs. whatever's currently checked out (main, or
+            # the existing release branch's tip if "Determine release plan"
+            # found and checked one out). Re-rendering was a no-op.
             echo "No changes to release for ${DISPLAY_VERSION}; skipping."
           else
-            NEW_TREE=$(git write-tree)
-            OLD_TREE=""
-            if git rev-parse -q --verify "refs/remotes/origin/$BRANCH" >/dev/null; then
-              OLD_TREE=$(git rev-parse "refs/remotes/origin/$BRANCH^{tree}")
-            fi
-
-            if [ -n "$OLD_TREE" ] && [ "$NEW_TREE" = "$OLD_TREE" ]; then
-              # Already fully reflected on the existing branch/PR (e.g.
-              # re-dispatched while it's still open or queued to merge).
-              # Force-pushing here would be a no-op at best and can collide
-              # with a branch locked by a merge queue at worst.
-              echo "No changes vs. existing $BRANCH; skipping push."
-            else
-              git commit -m "Release ${DISPLAY_VERSION}"
-              git push -u origin "$BRANCH" --force-with-lease
-            fi
+            git commit -m "Release ${DISPLAY_VERSION}"
+            git push -u origin "$BRANCH" --force-with-lease
           fi
 
           BODY="Updates images to version \`${VERSION}\`."
@@ -188,3 +212,5 @@ jobs:
             --body "$BODY" \
             --base main \
             --head "$BRANCH" || echo "PR already exists"
+
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"

--- a/posit-bakery/posit_bakery/cli/create.py
+++ b/posit-bakery/posit_bakery/cli/create.py
@@ -276,7 +276,7 @@ def version(
             # Plain print, not stderr_console/stdout_console: this text is captured
             # verbatim by the calling workflow, and Rich's console would reflow
             # long diff lines to the terminal width, corrupting the output.
-            print(render_markdown(image_name, file_diffs))
+            print(render_markdown(image_name, file_diffs))  # noqa: T201
         except Exception:
             log.exception(
                 f"Failed to generate --diff-against comparison for '{image_name}/{image_version}'; "

--- a/posit-bakery/posit_bakery/cli/create.py
+++ b/posit-bakery/posit_bakery/cli/create.py
@@ -13,6 +13,7 @@ from posit_bakery.cli.common import (
     __parse_dependency_versions,
 )
 from posit_bakery.config import BakeryConfig
+from posit_bakery.config.dirdiff import diff_directories, read_directory_tree, render_markdown
 from posit_bakery.const import DEFAULT_BASE_IMAGE
 from posit_bakery.log import stderr_console
 from posit_bakery.util import auto_path
@@ -205,6 +206,16 @@ def version(
     force: Annotated[
         Optional[bool], typer.Option("--force", help="Force overwrite of existing version directory.")
     ] = False,
+    diff_against: Annotated[
+        Optional[str],
+        typer.Option(
+            "--diff-against",
+            show_default=False,
+            help="An existing version of this image to diff the newly created version's directory against. "
+            "Prints the comparison to stdout.",
+            rich_help_panel=RichHelpPanelEnum.VERSION_CONFIGURATION,
+        ),
+    ] = None,
 ) -> None:
     """Renders templates for an image to a versioned subdirectory of the image directory.
 
@@ -230,6 +241,16 @@ def version(
 
     try:
         c = BakeryConfig.from_context(context)
+
+        diff_against_version = None
+        if diff_against is not None:
+            image = c.model.get_image(image_name)
+            if image is None:
+                raise ValueError(f"Image '{image_name}' does not exist in the config.")
+            diff_against_version = image.get_version(diff_against)
+            if diff_against_version is None:
+                raise ValueError(f"Version '{diff_against}' does not exist for image '{image_name}'.")
+
         c.create_version(
             image_name=image_name,
             subpath=subpath,
@@ -244,6 +265,23 @@ def version(
         raise typer.Exit(code=1)
 
     stderr_console.print(f"✅ Successfully created version '{image_name}/{image_version}'", style="success")
+
+    if diff_against_version is not None:
+        try:
+            image = c.model.get_image(image_name)
+            new_version = image.get_version(image_version)
+            old_tree = read_directory_tree(diff_against_version.path)
+            new_tree = read_directory_tree(new_version.path)
+            file_diffs = diff_directories(old_tree, new_tree)
+            # Plain print, not stderr_console/stdout_console: this text is captured
+            # verbatim by the calling workflow, and Rich's console would reflow
+            # long diff lines to the terminal width, corrupting the output.
+            print(render_markdown(image_name, file_diffs))
+        except Exception:
+            log.exception(
+                f"Failed to generate --diff-against comparison for '{image_name}/{image_version}'; "
+                "the version was still created successfully."
+            )
 
 
 @app.command()

--- a/posit-bakery/posit_bakery/config/dirdiff.py
+++ b/posit-bakery/posit_bakery/config/dirdiff.py
@@ -1,0 +1,117 @@
+"""Compare two rendered version directories and render a markdown comment.
+
+Used by ``bakery create version --diff-against`` to show reviewers what
+changed between a newly-created release edition and a previous one, since
+both are wholesale re-renders rather than incremental edits. Unrelated to
+``config/changeset.py``'s diffing: that module compares one file (bakery.yaml)
+across two *commits* to decide what to rebuild; this module compares two
+different *paths* that both exist, live, at the same time, to render a
+human-readable comment.
+"""
+
+from __future__ import annotations
+
+import difflib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+
+def read_directory_tree(path: Path) -> dict[str, bytes]:
+    """Read every file under `path` into {relative_posix_path: raw_bytes}."""
+    tree: dict[str, bytes] = {}
+    for file_path in path.rglob("*"):
+        if file_path.is_file():
+            rel = file_path.relative_to(path).as_posix()
+            tree[rel] = file_path.read_bytes()
+    return tree
+
+
+@dataclass
+class FileDiff:
+    path: str
+    status: Literal["added", "removed", "modified", "binary"]
+    diff_text: str | None
+
+
+def _is_binary(content: bytes) -> bool:
+    if b"\x00" in content:
+        return True
+    try:
+        content.decode("utf-8")
+    except UnicodeDecodeError:
+        return True
+    return False
+
+
+def diff_directories(old_tree: dict[str, bytes], new_tree: dict[str, bytes]) -> list[FileDiff]:
+    """Compare two directory trees, pure (no filesystem access).
+
+    Returns one FileDiff per file that differs, sorted by path; identical
+    files are omitted entirely.
+    """
+    results: list[FileDiff] = []
+    for path in sorted(set(old_tree) | set(new_tree)):
+        old_content = old_tree.get(path)
+        new_content = new_tree.get(path)
+
+        if old_content == new_content:
+            continue
+
+        if old_content is None:
+            status: Literal["added", "removed", "modified"] = "added"
+        elif new_content is None:
+            status = "removed"
+        else:
+            status = "modified"
+
+        if _is_binary(old_content or b"") or _is_binary(new_content or b""):
+            results.append(FileDiff(path=path, status="binary", diff_text=None))
+            continue
+
+        old_lines = (old_content or b"").decode("utf-8").splitlines(keepends=True)
+        new_lines = (new_content or b"").decode("utf-8").splitlines(keepends=True)
+        diff_text = "".join(
+            difflib.unified_diff(old_lines, new_lines, fromfile=f"a/{path}", tofile=f"b/{path}")
+        )
+        results.append(FileDiff(path=path, status=status, diff_text=diff_text))
+
+    return results
+
+
+def render_markdown(image_name: str, file_diffs: list[FileDiff], max_chars: int = 20000) -> str:
+    """Render one image's PR-comment section.
+
+    Both nesting levels use <details open> rather than plain <details>: the
+    diff content should be visible as soon as the comment is opened, not
+    hidden behind two layers of clicks. `open` still leaves each section
+    individually collapsible. If the fully-rendered structure would exceed
+    max_chars, falls back to a flat file list instead -- there's no diff
+    content to hide behind a per-file toggle in that case, so there's nothing
+    to nest.
+    """
+    if not file_diffs:
+        return (
+            f"<details open><summary><code>{image_name}</code></summary>\n\n"
+            f"_No differences from previous edition._\n\n"
+            f"</details>"
+        )
+
+    file_sections = []
+    for fd in file_diffs:
+        body = "_Binary file changed._" if fd.status == "binary" else f"```diff\n{fd.diff_text}```"
+        file_sections.append(f"<details open><summary><code>{fd.path}</code></summary>\n\n{body}\n\n</details>")
+
+    full_body = "\n\n".join(file_sections)
+    full_rendered = f"<details open><summary><code>{image_name}</code></summary>\n\n{full_body}\n\n</details>"
+
+    if len(full_rendered) <= max_chars:
+        return full_rendered
+
+    flat_lines = [f"- `{fd.path}` ({fd.status})" for fd in file_diffs]
+    flat_body = "\n".join(flat_lines)
+    return (
+        f"<details open><summary><code>{image_name}</code></summary>\n\n"
+        f"Diff too large to display in full ({len(file_diffs)} files changed):\n\n"
+        f"{flat_body}\n\n</details>"
+    )

--- a/posit-bakery/posit_bakery/config/dirdiff.py
+++ b/posit-bakery/posit_bakery/config/dirdiff.py
@@ -12,13 +12,20 @@ human-readable comment.
 from __future__ import annotations
 
 import difflib
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
 
 def read_directory_tree(path: Path) -> dict[str, bytes]:
-    """Read every file under `path` into {relative_posix_path: raw_bytes}."""
+    """Read every file under `path` into {relative_posix_path: raw_bytes}.
+
+    :raises FileNotFoundError: if `path` does not exist or is not a directory.
+    """
+    if not path.is_dir():
+        raise FileNotFoundError(f"'{path}' does not exist or is not a directory.")
+
     tree: dict[str, bytes] = {}
     for file_path in path.rglob("*"):
         if file_path.is_file():
@@ -71,12 +78,19 @@ def diff_directories(old_tree: dict[str, bytes], new_tree: dict[str, bytes]) -> 
 
         old_lines = (old_content or b"").decode("utf-8").splitlines(keepends=True)
         new_lines = (new_content or b"").decode("utf-8").splitlines(keepends=True)
-        diff_text = "".join(
-            difflib.unified_diff(old_lines, new_lines, fromfile=f"a/{path}", tofile=f"b/{path}")
-        )
+        diff_text = "".join(difflib.unified_diff(old_lines, new_lines, fromfile=f"a/{path}", tofile=f"b/{path}"))
         results.append(FileDiff(path=path, status=status, diff_text=diff_text))
 
     return results
+
+
+def _fence_for(text: str) -> str:
+    """Return a backtick fence at least one character longer than the
+    longest run of backticks in `text`, so the fence can't be closed early
+    by content that happens to contain its own triple-backtick sequence."""
+    runs = re.findall(r"`+", text)
+    longest = max((len(r) for r in runs), default=0)
+    return "`" * max(3, longest + 1)
 
 
 def render_markdown(image_name: str, file_diffs: list[FileDiff], max_chars: int = 20000) -> str:
@@ -99,7 +113,11 @@ def render_markdown(image_name: str, file_diffs: list[FileDiff], max_chars: int 
 
     file_sections = []
     for fd in file_diffs:
-        body = "_Binary file changed._" if fd.status == "binary" else f"```diff\n{fd.diff_text}```"
+        if fd.status == "binary":
+            body = "_Binary file changed._"
+        else:
+            fence = _fence_for(fd.diff_text)
+            body = f"{fence}diff\n{fd.diff_text}{fence}"
         file_sections.append(f"<details open><summary><code>{fd.path}</code></summary>\n\n{body}\n\n</details>")
 
     full_body = "\n\n".join(file_sections)

--- a/posit-bakery/test/config/test_dirdiff.py
+++ b/posit-bakery/test/config/test_dirdiff.py
@@ -1,0 +1,122 @@
+from posit_bakery.config.dirdiff import FileDiff, diff_directories, read_directory_tree, render_markdown
+
+
+class TestReadDirectoryTree:
+    def test_reads_nested_files(self, tmp_path):
+        (tmp_path / "a.txt").write_text("hello\n")
+        nested = tmp_path / "sub"
+        nested.mkdir()
+        (nested / "b.txt").write_text("world\n")
+
+        tree = read_directory_tree(tmp_path)
+
+        assert tree == {
+            "a.txt": b"hello\n",
+            "sub/b.txt": b"world\n",
+        }
+
+    def test_reads_binary_file(self, tmp_path):
+        (tmp_path / "bin.dat").write_bytes(b"\x00\x01\x02")
+
+        tree = read_directory_tree(tmp_path)
+
+        assert tree == {"bin.dat": b"\x00\x01\x02"}
+
+    def test_empty_directory(self, tmp_path):
+        assert read_directory_tree(tmp_path) == {}
+
+
+class TestDiffDirectories:
+    def test_identical_trees_produce_no_diffs(self):
+        tree = {"a.txt": b"hello\n"}
+        assert diff_directories(tree, dict(tree)) == []
+
+    def test_added_file(self):
+        old = {}
+        new = {"a.txt": b"hello\n"}
+
+        result = diff_directories(old, new)
+
+        assert len(result) == 1
+        assert result[0].path == "a.txt"
+        assert result[0].status == "added"
+        assert "+hello" in result[0].diff_text
+
+    def test_removed_file(self):
+        old = {"a.txt": b"hello\n"}
+        new = {}
+
+        result = diff_directories(old, new)
+
+        assert len(result) == 1
+        assert result[0].path == "a.txt"
+        assert result[0].status == "removed"
+        assert "-hello" in result[0].diff_text
+
+    def test_modified_text_file(self):
+        old = {"a.txt": b"line one\nline two\n"}
+        new = {"a.txt": b"line one\nline TWO\n"}
+
+        result = diff_directories(old, new)
+
+        assert len(result) == 1
+        assert result[0].status == "modified"
+        assert "-line two" in result[0].diff_text
+        assert "+line TWO" in result[0].diff_text
+
+    def test_binary_file_changed(self):
+        old = {"bin.dat": b"\x00\x01"}
+        new = {"bin.dat": b"\x00\x02"}
+
+        result = diff_directories(old, new)
+
+        assert len(result) == 1
+        assert result[0].status == "binary"
+        assert result[0].diff_text is None
+
+    def test_unchanged_file_omitted_alongside_changed_one(self):
+        old = {"same.txt": b"unchanged\n", "changed.txt": b"before\n"}
+        new = {"same.txt": b"unchanged\n", "changed.txt": b"after\n"}
+
+        result = diff_directories(old, new)
+
+        assert [fd.path for fd in result] == ["changed.txt"]
+
+
+class TestRenderMarkdown:
+    def test_no_diffs_renders_no_differences_message(self):
+        markdown = render_markdown("connect", [])
+
+        assert "<details open>" in markdown
+        assert "<summary><code>connect</code></summary>" in markdown
+        assert "No differences from previous edition" in markdown
+
+    def test_full_diff_renders_nested_details_per_file(self):
+        file_diffs = [
+            FileDiff(path="Containerfile", status="modified", diff_text="--- a/Containerfile\n+++ b/Containerfile\n"),
+        ]
+
+        markdown = render_markdown("connect", file_diffs)
+
+        assert markdown.count("<details open>") == 2  # image-level + one file-level
+        assert "<summary><code>Containerfile</code></summary>" in markdown
+        assert "```diff" in markdown
+
+    def test_binary_file_shows_placeholder_not_diff_fence(self):
+        file_diffs = [FileDiff(path="image.png", status="binary", diff_text=None)]
+
+        markdown = render_markdown("connect", file_diffs)
+
+        assert "_Binary file changed._" in markdown
+        assert "```diff" not in markdown
+
+    def test_oversized_diff_falls_back_to_flat_list(self):
+        file_diffs = [
+            FileDiff(path="big.txt", status="modified", diff_text="+" + ("x" * 500)),
+        ]
+
+        markdown = render_markdown("connect", file_diffs, max_chars=50)
+
+        assert "Diff too large to display in full" in markdown
+        assert "`big.txt` (modified)" in markdown
+        assert "```diff" not in markdown

--- a/posit-bakery/test/config/test_dirdiff.py
+++ b/posit-bakery/test/config/test_dirdiff.py
@@ -1,3 +1,5 @@
+import pytest
+
 from posit_bakery.config.dirdiff import FileDiff, diff_directories, read_directory_tree, render_markdown
 
 
@@ -24,6 +26,12 @@ class TestReadDirectoryTree:
 
     def test_empty_directory(self, tmp_path):
         assert read_directory_tree(tmp_path) == {}
+
+    def test_nonexistent_path_raises_file_not_found_error(self, tmp_path):
+        missing = tmp_path / "does-not-exist"
+
+        with pytest.raises(FileNotFoundError):
+            read_directory_tree(missing)
 
 
 class TestDiffDirectories:
@@ -120,3 +128,42 @@ class TestRenderMarkdown:
         assert "Diff too large to display in full" in markdown
         assert "`big.txt` (modified)" in markdown
         assert "```diff" not in markdown
+
+    def test_diff_text_with_backtick_fence_uses_wider_fence(self):
+        # The diffed file's own content happens to contain a fenced code block
+        # (e.g. a README with an embedded ```python example). A hardcoded
+        # triple-backtick wrapper would close early on that content and
+        # corrupt the rest of the rendered comment.
+        diff_text = (
+            "--- a/README.md\n+++ b/README.md\n@@ -1,2 +1,4 @@\n existing line\n+```python\n+print('hi')\n+```\n"
+        )
+        file_diffs = [FileDiff(path="README.md", status="modified", diff_text=diff_text)]
+
+        markdown = render_markdown("connect", file_diffs)
+
+        # The embedded ``` fence survives unbroken inside the wider wrapper.
+        assert diff_text in markdown
+        # The wrapping fence is longer (4 backticks) than the embedded run (3).
+        assert "````diff" in markdown
+        assert markdown.count("````") == 2  # opening + closing fence only
+
+    def test_multiple_files_render_as_separate_nested_sections(self):
+        file_diffs = [
+            FileDiff(
+                path="Containerfile",
+                status="modified",
+                diff_text="--- a/Containerfile\n+++ b/Containerfile\n@@ -1 +1 @@\n-old\n+new\n",
+            ),
+            FileDiff(
+                path="deps/packages.txt",
+                status="added",
+                diff_text="--- a/deps/packages.txt\n+++ b/deps/packages.txt\n@@ -0,0 +1 @@\n+new-package\n",
+            ),
+        ]
+
+        markdown = render_markdown("connect", file_diffs)
+
+        assert markdown.count("<details open>") == 3  # image-level + 2 file-level
+        assert "<summary><code>Containerfile</code></summary>" in markdown
+        assert "<summary><code>deps/packages.txt</code></summary>" in markdown
+        assert markdown.count("```diff") == 2

--- a/posit-bakery/test/features/cli/create/version.feature
+++ b/posit-bakery/test/features/cli/create/version.feature
@@ -98,3 +98,33 @@ Feature: create version
         * the stderr output includes:
             | Successfully created version |
             | 'test-image/1.0.0' |
+
+    Scenario: Creating a new version with a diff against a previous version
+        Given I call bakery create version
+        * in a temp basic context
+        * with the arguments:
+            | test-image |
+            | 1.1.0 |
+            | --diff-against |
+            | 1.0.0 |
+        When I execute the command
+        Then The command succeeds
+        * the image "test-image" exists
+        * the version "1.1.0" exists
+        * the stdout output includes:
+            | test-image |
+            | ARG IMAGE_VERSION |
+
+    Scenario: Diffing against a nonexistent version fails
+        Given I call bakery create version
+        * in a temp basic context
+        * with the arguments:
+            | test-image |
+            | 1.1.0 |
+            | --diff-against |
+            | 9.9.9 |
+        When I execute the command
+        Then The command exits with code 1
+        * the stderr output includes:
+            | Failed to create version |
+            | 'test-image/1.1.0' |

--- a/posit-bakery/test/features/cli/create/version.feature
+++ b/posit-bakery/test/features/cli/create/version.feature
@@ -128,3 +128,5 @@ Feature: create version
         * the stderr output includes:
             | Failed to create version |
             | 'test-image/1.1.0' |
+        * the log includes:
+            | Version '9.9.9' does not exist for image 'test-image'. |


### PR DESCRIPTION
Release PRs for new editions (e.g. `2026.06` → `2026.07`) show every file as "added," since each edition renders into a fresh directory. Most of that content is identical to the previous edition, making these PRs hard to review.

Adds `--diff-against` to `bakery create version` and has the release workflow post the real diff as a PR comment. The workflow also now captures the diff target from `main`'s state before checking out any existing release branch, so re-dispatching while a PR is open updates the comment instead of duplicating it.

- Closes https://github.com/posit-dev/images-shared/issues/654