### PR TITLE
Scope merge-queue builds to changed files

### DIFF
--- a/.github/workflows/bakery-build-pr.yml
+++ b/.github/workflows/bakery-build-pr.yml
@@ -108,9 +108,12 @@ jobs:
           DEV_VERSIONS: ${{ inputs.dev-versions }}
           MATRIX_VERSIONS: ${{ inputs.matrix-versions }}
           BAKERY_CONTEXT: ${{ inputs.context }}
-          # PR-only: empty on merge_group/push/scheduled, which intentionally
-          # fall back to the full matrix. Do not wire in merge_group.base_sha.
-          BASE_REF: ${{ github.event.pull_request.base.sha }}
+          # pull_request.base.sha for regular PR pushes; merge_group.base_sha
+          # for merge-queue runs. base_sha is the real, unmoved tip of the
+          # target branch -- head_sha is what carries any PRs stacked ahead
+          # of this one in the queue -- so this scopes merge-queue builds to
+          # changes the same way production push builds do via event.before.
+          BASE_REF: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
         run: |
           BASE_FLAG=()
           if [ -n "$BASE_REF" ]; then
@@ -129,9 +132,9 @@ jobs:
           DEV_VERSIONS: ${{ inputs.dev-versions }}
           MATRIX_VERSIONS: ${{ inputs.matrix-versions }}
           BAKERY_CONTEXT: ${{ inputs.context }}
-          # PR-only: empty on merge_group/push/scheduled, which intentionally
-          # fall back to the full matrix. Do not wire in merge_group.base_sha.
-          BASE_REF: ${{ github.event.pull_request.base.sha }}
+          # See the "Images by Version/Platform" step above for why this
+          # falls back to merge_group.base_sha.
+          BASE_REF: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
         run: |
           BASE_FLAG=()
           if [ -n "$BASE_REF" ]; then


### PR DESCRIPTION
merge_group builds always built the full matrix because BASE_REF
only came from github.event.pull_request.base.sha, which is empty
on merge_group events. That fallback was previously intentional
(the merge queue was meant to fully validate before landing on
main), but github.event.merge_group.base_sha -- the real, unmoved
tip of the target branch -- lets us scope merge-queue builds the
same way push-to-main production builds already do via
event.before, without losing coverage: head_sha already carries
any PRs stacked ahead of this one in the queue, so diffing
base_sha..HEAD still covers every stacked change in the batch.

- Closes https://github.com/posit-dev/images-shared/issues/670