### PR TITLE
Add cache-registry and temp-registry inputs to build/clean workflows

### DIFF
--- a/.github/workflows/bakery-build-native.yml
+++ b/.github/workflows/bakery-build-native.yml
@@ -77,6 +77,16 @@ on:
         default: true
         required: false
         type: boolean
+      cache-registry:
+        description: "Registry to use for build layer caching [default: ghcr.io/<repository_owner>]"
+        default: ""
+        required: false
+        type: string
+      temp-registry:
+        description: "Registry to use for temporary per-platform build artifacts before merge [default: ghcr.io/<repository_owner>]"
+        default: ""
+        required: false
+        type: string
       merge-builder:
         description: "The type of runner to use for merging [default: ubuntu-latest-4x]"
         default: "ubuntu-latest-4x"
@@ -330,7 +340,8 @@ jobs:
           DEV_VERSIONS: ${{ inputs.dev-versions }}
           MATRIX_VERSIONS: ${{ inputs.matrix-versions }}
           DEV_SPEC_RESOLVED: ${{ steps.resolve-dev-spec.outputs.dev-spec }}
-          REGISTRY: ghcr.io/${{ github.repository_owner }}
+          CACHE_REGISTRY: ${{ inputs.cache-registry || format('ghcr.io/{0}', github.repository_owner) }}
+          TEMP_REGISTRY: ${{ inputs.temp-registry || format('ghcr.io/{0}', github.repository_owner) }}
           NORMALIZED_PLATFORM: ${{ steps.normalize-platform.outputs.platform }}
           CONTEXT: ${{ inputs.context }}
           CACHE: ${{ inputs.cache }}
@@ -339,7 +350,7 @@ jobs:
         run: |
           CACHE_FLAGS=()
           if [ "$CACHE" = "true" ]; then
-            CACHE_FLAGS=(--cache-registry "$REGISTRY")
+            CACHE_FLAGS=(--cache-registry "$CACHE_REGISTRY")
           fi
           DEV_SPEC_FLAGS=()
           [[ -n "$DEV_SPEC_RESOLVED" ]] && DEV_SPEC_FLAGS=(--dev-spec "$DEV_SPEC_RESOLVED")
@@ -353,7 +364,7 @@ jobs:
             --matrix-versions "$MATRIX_VERSIONS" \
             "${CACHE_FLAGS[@]}" \
             "${DEV_SPEC_FLAGS[@]}" \
-            --temp-registry "$REGISTRY" \
+            --temp-registry "$TEMP_REGISTRY" \
             --metadata-file "./${IMAGE_NAME}-${IMAGE_VERSION}-${NORMALIZED_PLATFORM}-metadata.json" \
             --context "$CONTEXT" \
             --push
@@ -509,7 +520,7 @@ jobs:
         env:
           GIT_SHA: ${{ github.sha }}
           CONTEXT: ${{ inputs.context }}
-          REGISTRY: ghcr.io/${{ github.repository_owner }}
+          TEMP_REGISTRY: ${{ inputs.temp-registry || format('ghcr.io/{0}', github.repository_owner) }}
           PUSH: ${{ inputs.push }}
           IMAGE_NAME: ${{ matrix.image }}
           DEV_SPEC_RESOLVED: ${{ steps.resolve-dev-spec.outputs.dev-spec }}
@@ -520,7 +531,7 @@ jobs:
           bakery ci publish \
             --context "$CONTEXT" \
             --image-name "^${IMAGE_NAME}$" \
-            --temp-registry "$REGISTRY" \
+            --temp-registry "$TEMP_REGISTRY" \
             "${DEV_SPEC_FLAGS[@]}" \
             $PUSH_FLAG \
             ./*-metadata.json

--- a/.github/workflows/bakery-build-pr.yml
+++ b/.github/workflows/bakery-build-pr.yml
@@ -45,6 +45,11 @@ on:
         default: true
         required: false
         type: boolean
+      cache-registry:
+        description: "Registry to use for build layer caching [default: ghcr.io/<repository_owner>]"
+        default: ""
+        required: false
+        type: string
       amd64-builder:
         description: "Runner label for amd64 builds"
         default: "ubuntu-latest-4x"
@@ -255,7 +260,7 @@ jobs:
           IMG_DEV: ${{ matrix.img.dev }}
           MATRIX_VERSIONS: ${{ inputs.matrix-versions }}
           BAKERY_CONTEXT: ${{ inputs.context }}
-          REGISTRY_OWNER: ${{ github.repository_owner }}
+          CACHE_REGISTRY: ${{ inputs.cache-registry || format('ghcr.io/{0}', github.repository_owner) }}
           CACHE: ${{ inputs.cache }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -266,7 +271,7 @@ jobs:
           fi
           CACHE_FLAGS=()
           if [ "$IS_FORK" != "true" ] && [ "$CACHE" = "true" ]; then
-            CACHE_FLAGS=(--cache-registry "ghcr.io/${REGISTRY_OWNER}")
+            CACHE_FLAGS=(--cache-registry "$CACHE_REGISTRY")
           fi
           bakery build \
             --strategy build --pull --load \

--- a/.github/workflows/bakery-build.yml
+++ b/.github/workflows/bakery-build.yml
@@ -79,6 +79,11 @@ on:
         default: true
         required: false
         type: boolean
+      cache-registry:
+        description: "Registry to use for build layer caching [default: ghcr.io/<repository_owner>]"
+        default: ""
+        required: false
+        type: string
       runs-on:
         description: "The type of runner to use [default: ubuntu-latest]"
         default: "ubuntu-latest"
@@ -292,14 +297,14 @@ jobs:
           DEV_VERSIONS: ${{ inputs.dev-versions }}
           MATRIX_VERSIONS: ${{ inputs.matrix-versions }}
           DEV_SPEC_RESOLVED: ${{ steps.resolve-dev-spec.outputs.dev-spec }}
-          REGISTRY: ghcr.io/${{ github.repository_owner }}
+          CACHE_REGISTRY: ${{ inputs.cache-registry || format('ghcr.io/{0}', github.repository_owner) }}
           CONTEXT: ${{ inputs.context }}
           CACHE: ${{ inputs.cache }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           CACHE_FLAGS=()
           if [ "$CACHE" = "true" ]; then
-            CACHE_FLAGS=(--cache-registry "$REGISTRY")
+            CACHE_FLAGS=(--cache-registry "$CACHE_REGISTRY")
           fi
           DEV_SPEC_FLAGS=()
           [[ -n "$DEV_SPEC_RESOLVED" ]] && DEV_SPEC_FLAGS=(--dev-spec "$DEV_SPEC_RESOLVED")

--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -12,6 +12,16 @@ on:
         default: "."
         required: false
         type: string
+      cache-registry:
+        description: "Registry to clean build layer caches from [default: ghcr.io/<repository_owner>]"
+        default: ""
+        required: false
+        type: string
+      temp-registry:
+        description: "Registry to clean temporary build images from [default: ghcr.io/<repository_owner>]"
+        default: ""
+        required: false
+        type: string
       clean-caches:
         description: "Whether to clean caches [default: true]"
         default: true
@@ -100,7 +110,7 @@ jobs:
       - name: Clean caches
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REGISTRY: ghcr.io/${{ github.repository_owner }}
+          REGISTRY: ${{ inputs.cache-registry || format('ghcr.io/{0}', github.repository_owner) }}
           CONTEXT: ${{ inputs.context }}
           DEV_VERSIONS: ${{ inputs.dev-versions }}
           MATRIX_VERSIONS: ${{ inputs.matrix-versions }}
@@ -145,7 +155,7 @@ jobs:
       - name: Clean temporary images
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REGISTRY: ghcr.io/${{ github.repository_owner }}
+          REGISTRY: ${{ inputs.temp-registry || format('ghcr.io/{0}', github.repository_owner) }}
           CONTEXT: ${{ inputs.context }}
           DEV_VERSIONS: ${{ inputs.dev-versions }}
           MATRIX_VERSIONS: ${{ inputs.matrix-versions }}


### PR DESCRIPTION
## Summary
- Add optional `cache-registry` and `temp-registry` workflow_call inputs to `bakery-build.yml`, `bakery-build-native.yml`, `bakery-build-pr.yml`, and `clean.yml`
- Default to empty string, falling back to the existing `ghcr.io/<repository_owner>` behavior when unset, so no behavior change for current callers
- `bakery-build-native.yml`'s merge/publish job reads `temp-registry` from the same input the build job uses, keeping them in sync

Refs #688

## Test plan
- [ ] `yamllint`/`actionlint` pass on modified workflow files (pre-commit hooks passed)
- [ ] Downstream repo overrides `temp-registry`/`cache-registry` and confirms build, merge, and clean stages target the expected registry