### PR TITLE
Fix setup-hadolint checksum verification and pinned version URLs

### DIFF
--- a/setup-hadolint/action.yml
+++ b/setup-hadolint/action.yml
@@ -23,10 +23,13 @@ runs:
       run: mkdir -p "${{ inputs.base_path }}/tools"
     - name: Install hadolint
       shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+        ARCHITECTURE: ${{ inputs.architecture }}
+        BASE_PATH: ${{ inputs.base_path }}
       run: |
         # Determine architecture if not provided
-        arch="${{ inputs.architecture }}"
-        if [ -z "$arch" ]; then
+        if [ -z "$ARCHITECTURE" ]; then
           arch=$(uname -m)
         fi
 
@@ -37,13 +40,12 @@ runs:
             arch="arm64"
         fi
 
-        version="${{ inputs.version }}"
-        if [ "$version" = "latest" ]; then
+        if [ "$VERSION" = "latest" ]; then
             release_url="https://github.com/hadolint/hadolint/releases/latest/download"
         else
-            release_url="https://github.com/hadolint/hadolint/releases/download/${version}"
+            release_url="https://github.com/hadolint/hadolint/releases/download/${VERSION}"
         fi
-        dest="${{ inputs.base_path }}/tools"
+        dest="${BASE_PATH}/tools"
 
         # v2.13.0+ uses lowercase "linux"; older releases use "Linux"
         binary="hadolint-linux-${arch}"

--- a/setup-hadolint/action.yml
+++ b/setup-hadolint/action.yml
@@ -37,7 +37,12 @@ runs:
             arch="arm64"
         fi
 
-        release_url="https://github.com/hadolint/hadolint/releases/${{ inputs.version }}/download"
+        version="${{ inputs.version }}"
+        if [ "$version" = "latest" ]; then
+            release_url="https://github.com/hadolint/hadolint/releases/latest/download"
+        else
+            release_url="https://github.com/hadolint/hadolint/releases/download/${version}"
+        fi
         dest="${{ inputs.base_path }}/tools"
 
         # v2.13.0+ uses lowercase "linux"; older releases use "Linux"
@@ -47,9 +52,16 @@ runs:
             curl -fsSL "${release_url}/${binary}" -o "${dest}/${binary}"
         fi
 
-        curl -fsSL "${release_url}/${binary}.sha256" -o "${dest}/${binary}.sha256"
-        (cd "${dest}" && sha256sum -c "${binary}.sha256")
-        rm -f "${dest}/${binary}.sha256"
+        # v2.15.0+ ships one checksums.sha256 covering all binaries; older
+        # releases ship a per-binary "${binary}.sha256" file instead.
+        if curl -fsSL "${release_url}/checksums.sha256" -o "${dest}/checksums.sha256" 2>/dev/null; then
+            (cd "${dest}" && grep -F "${binary}" checksums.sha256 | sha256sum -c -)
+            rm -f "${dest}/checksums.sha256"
+        else
+            curl -fsSL "${release_url}/${binary}.sha256" -o "${dest}/${binary}.sha256"
+            (cd "${dest}" && sha256sum -c "${binary}.sha256")
+            rm -f "${dest}/${binary}.sha256"
+        fi
 
         mv "${dest}/${binary}" "${dest}/hadolint"
         chmod +rx "${dest}/hadolint"


### PR DESCRIPTION
## Summary
- Support hadolint v2.15.0+'s new consolidated `checksums.sha256` release asset, falling back to the old per-binary `.sha256` file for pre-2.15.0 releases
- Fix release URL construction so pinned versions (e.g. `v2.13.1`) resolve to `releases/download/TAG` instead of the broken `releases/TAG/download` pattern; `latest` continues to use `releases/latest/download`

## Test plan
- [x] Verified against live hadolint v2.15.1 release (latest): checksum passes, binary runs
- [x] Verified against live hadolint v2.13.1 pinned release: checksum passes, binary runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)