### PR TITLE
Fix ECR login gating in bakery-build-native.yml

### DIFF
--- a/.github/workflows/bakery-build-native.yml
+++ b/.github/workflows/bakery-build-native.yml
@@ -288,8 +288,12 @@ jobs:
           username: "posit"
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
+      # Not gated on inputs.push: the Build step below always pushes the
+      # per-platform temp image (and the merge job always pulls it back),
+      # regardless of whether this run pushes final product images. If
+      # temp-registry points at ECR, login must happen on every run.
       - name: Configure AWS Credentials
-        if: ${{ inputs.push && steps.filter-steps.outputs.ecr == 'true' }}
+        if: ${{ steps.filter-steps.outputs.ecr == 'true' }}
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b  # v6.2.0
         with:
           role-to-assume: ${{ secrets.AWS_ROLE }}
@@ -297,7 +301,7 @@ jobs:
           role-session-name: gha-bakery-build
 
       - name: Login to Amazon ECR
-        if: ${{ inputs.push && steps.filter-steps.outputs.ecr == 'true' }}
+        if: ${{ steps.filter-steps.outputs.ecr == 'true' }}
         uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64  # v2.1.6
 
       - name: Normalize platform
@@ -461,8 +465,12 @@ jobs:
           username: "posit"
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
+      # Not gated on inputs.push: the Build step below always pushes the
+      # per-platform temp image (and the merge job always pulls it back),
+      # regardless of whether this run pushes final product images. If
+      # temp-registry points at ECR, login must happen on every run.
       - name: Configure AWS Credentials
-        if: ${{ inputs.push && steps.filter-steps.outputs.ecr == 'true' }}
+        if: ${{ steps.filter-steps.outputs.ecr == 'true' }}
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b  # v6.2.0
         with:
           role-to-assume: ${{ secrets.AWS_ROLE }}
@@ -470,7 +478,7 @@ jobs:
           role-session-name: gha-bakery-build
 
       - name: Login to Amazon ECR
-        if: ${{ inputs.push && steps.filter-steps.outputs.ecr == 'true' }}
+        if: ${{ steps.filter-steps.outputs.ecr == 'true' }}
         uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64  # v2.1.6
 
       - name: Setup docker buildx


### PR DESCRIPTION
## Summary
- Ungate `Configure AWS Credentials`/`Login to Amazon ECR` in `bakery-build-native.yml` from `inputs.push`, keeping them gated only on the `AWS_ROLE` secret being present
- The `build-test` job unconditionally pushes the per-platform temp image (and `merge` unconditionally pulls it back) on every run, regardless of the final `push` input — so ECR auth needs to happen whenever `temp-registry` points at ECR, not only when the final product image is pushed
- Found while auditing #689 in preparation for pointing `temp-registry` at ECR per #682: any `workflow_dispatch` run off `main` (push=false) would have failed to authenticate against ECR temp images

Refs #682

## Test plan
- [ ] `yamllint`/`actionlint` pass (pre-commit hooks passed locally)
- [ ] A downstream repo's `workflow_dispatch` build off a non-`main` branch with `temp-registry` pointed at ECR succeeds