### PR TITLE
fix: gate BASE_REF on push events in bakery-build/bakery-build-native

### DIFF
--- a/.github/workflows/bakery-build-native.yml
+++ b/.github/workflows/bakery-build-native.yml
@@ -189,11 +189,13 @@ jobs:
           DEV_CHANNEL: ${{ inputs.dev-channel || inputs.dev-stream }}
           DEV_SPEC_RESOLVED: ${{ steps.resolve-dev-spec.outputs.dev-spec }}
           CONTEXT: ${{ inputs.context }}
-          # Only set on push (github.event.before); empty on schedule/
+          # Only set on push events; empty on pull_request/schedule/
           # workflow_dispatch, which intentionally always build the full matrix.
+          # github.event.before is also populated on pull_request synchronize,
+          # so it must be gated on event_name rather than checked for presence alone.
           # A bad or all-zero ref (e.g. a branch's first push) is caught by
           # bakery's git-diff fail-safe, which falls back to a full build.
-          BASE_REF: ${{ github.event.before }}
+          BASE_REF: ${{ github.event_name == 'push' && github.event.before || '' }}
         run: |
           IMAGE_VERSION="${IMAGE_VERSION#v}"
           ARGS=(--quiet --dev-versions "$DEV_VERSIONS" --matrix-versions "$MATRIX_VERSIONS" --context "$CONTEXT")

--- a/.github/workflows/bakery-build.yml
+++ b/.github/workflows/bakery-build.yml
@@ -169,11 +169,13 @@ jobs:
           DEV_CHANNEL: ${{ inputs.dev-channel || inputs.dev-stream }}
           DEV_SPEC_RESOLVED: ${{ steps.resolve-dev-spec.outputs.dev-spec }}
           CONTEXT: ${{ inputs.context }}
-          # Only set on push (github.event.before); empty on schedule/
+          # Only set on push events; empty on pull_request/schedule/
           # workflow_dispatch, which intentionally always build the full matrix.
+          # github.event.before is also populated on pull_request synchronize,
+          # so it must be gated on event_name rather than checked for presence alone.
           # A bad or all-zero ref (e.g. a branch's first push) is caught by
           # bakery's git-diff fail-safe, which falls back to a full build.
-          BASE_REF: ${{ github.event.before }}
+          BASE_REF: ${{ github.event_name == 'push' && github.event.before || '' }}
         run: |
           IMAGE_VERSION="${IMAGE_VERSION#v}"
           ARGS=(--quiet --dev-versions "$DEV_VERSIONS" --matrix-versions "$MATRIX_VERSIONS" --context "$CONTEXT")


### PR DESCRIPTION
## Summary
- `github.event.before` is also populated on `pull_request` `synchronize` events, not just `push`. Passing it through unconditionally as `--base-ref` to `bakery ci matrix` caused the diff to run against the wrong ref on PR pushes.
- Concretely, this made `bakery-native`/`bakery` jobs in `ci.yml` produce an empty build matrix (and silently skip build/test) whenever a PR push didn't touch the test fixture context — e.g. PR #692's CI-only "chore: pass AWS_ROLE" commit.
- Gate `BASE_REF` on `github.event_name == 'push'` in both `bakery-build.yml` and `bakery-build-native.yml`. `bakery-build-pr.yml` already uses `pull_request.base.sha`/`merge_group.base_sha` correctly and needed no change.

## Test plan
- [ ] Push a CI-only commit to an open PR and confirm `bakery-native`/`bakery` jobs still build/test rather than skipping with an empty matrix
- [ ] Confirm a real `push` event (e.g. merge to main) still diffs against the previous commit as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)