### PR TITLE
Add restore-cache opt-out to setup-bakery

### DIFF
--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -99,6 +99,7 @@ jobs:
         uses: "posit-dev/images-shared/setup-bakery@main"
         with:
           version: ${{ inputs.version }}
+          restore-cache: "false"
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
@@ -144,6 +145,7 @@ jobs:
         uses: "posit-dev/images-shared/setup-bakery@main"
         with:
           version: ${{ inputs.version }}
+          restore-cache: "false"
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -43,6 +43,7 @@ jobs:
         uses: "posit-dev/images-shared/setup-bakery@main"
         with:
           version: ${{ inputs.version }}
+          restore-cache: "false"
 
       - name: Setup hadolint
         uses: "posit-dev/images-shared/setup-hadolint@main"

--- a/.github/workflows/product-release.yml
+++ b/.github/workflows/product-release.yml
@@ -46,6 +46,8 @@ jobs:
 
       - name: Install bakery
         uses: posit-dev/images-shared/setup-bakery@main
+        with:
+          restore-cache: "false"
 
       - name: Parse version
         id: parse

--- a/setup-bakery/action.yml
+++ b/setup-bakery/action.yml
@@ -25,6 +25,15 @@ inputs:
       prior restore pointless. Leave "false" for every other job.
     required: false
     default: "false"
+  restore-cache:
+    description: >-
+      "false" for jobs that never run alongside an is-writer job in this
+      invocation (no matrix job resolves dependency versions anywhere in the
+      calling workflow), so the restore step is skipped instead of always
+      missing. Leave "true" (default) for jobs that run downstream of a
+      writer job.
+    required: false
+    default: "true"
 
 outputs:
   cache-artifact-name:
@@ -82,7 +91,7 @@ runs:
         echo "name=$NAME" >> "$GITHUB_OUTPUT"
 
     - name: Restore dependency version cache
-      if: inputs.is-writer != 'true'
+      if: inputs.is-writer != 'true' && inputs.restore-cache != 'false'
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
       # No artifact yet (first job to run this invocation) is expected, not
       # fatal: continue with an empty /tmp/bakery_cache and let it populate


### PR DESCRIPTION
Several setup-bakery callers never run alongside an is-writer job in
their invocation, so the "Restore dependency version cache" step's
download-artifact call always misses -- not a cold-cache edge case,
but every single run. continue-on-error hides the resulting job
failure, but the noisy "Artifact not found" error still clutters
logs.

Add a restore-cache input (default "true") that lets those callers
skip the restore step entirely instead of attempting a download that
can never succeed, and wire it to "false" on clean.yml, hadolint.yml,
and product-release.yml here.

This is narrower than the API-existence-check originally proposed in
the issue below: it silences the guaranteed-miss cases but doesn't
stop continue-on-error from masking a genuine restore failure for
jobs that do participate in the shared cache. Leaving that open as a
possible follow-up rather than folding it into this change.

images-connect, images-package-manager, images-workbench, and
images-examples each have a matching one-line change queued, blocked
on this merging to main since they pin setup-bakery@main and
composite actions reject unrecognized inputs.

- Closes https://github.com/posit-dev/images-shared/issues/686