### PR TITLE
Add bakery build --summary for target/tag counts

### DIFF
--- a/posit-bakery/posit_bakery/cli/build.py
+++ b/posit-bakery/posit_bakery/cli/build.py
@@ -14,9 +14,9 @@ from posit_bakery.config.image.posit_product.errors import (
     ArtifactNotAvailableError,
     VersionSubstitutionError,
 )
-from posit_bakery.const import DevVersionInclusionEnum, MatrixVersionInclusionEnum
+from posit_bakery.const import DevVersionInclusionEnum, MatrixVersionInclusionEnum, SummaryOutputFormat
 from posit_bakery.error import BakeryBuildErrorGroup, BakeryToolRuntimeError
-from posit_bakery.image import ImageBuildStrategy
+from posit_bakery.image import BuildSummary, ImageBuildStrategy
 from posit_bakery.log import stderr_console, stdout_console
 from posit_bakery.util import auto_path
 
@@ -91,6 +91,22 @@ def build(
             rich_help_panel=RichHelpPanelEnum.BUILD_CONFIGURATION_AND_OUTPUTS,
         ),
     ] = False,
+    summary: Annotated[
+        Optional[bool],
+        typer.Option(
+            "--summary",
+            help="Print a summary of build/tag counts for the selected targets.",
+            rich_help_panel=RichHelpPanelEnum.BUILD_CONFIGURATION_AND_OUTPUTS,
+        ),
+    ] = False,
+    summary_format: Annotated[
+        Optional[SummaryOutputFormat],
+        typer.Option(
+            "--summary-format",
+            help="Output format for --summary. 'table' prints to stderr; 'json' prints to stdout.",
+            rich_help_panel=RichHelpPanelEnum.BUILD_CONFIGURATION_AND_OUTPUTS,
+        ),
+    ] = SummaryOutputFormat.TABLE,
     load: Annotated[
         Optional[bool],
         typer.Option(
@@ -287,7 +303,16 @@ def build(
                 style="error",
             )
             raise typer.Exit(code=1)
+        if summary and summary_format == SummaryOutputFormat.JSON:
+            stderr_console.print(
+                "❌ --summary-format json is not supported with --plan, which already writes "
+                "the bake plan as JSON to stdout. Use --summary-format table, or drop --plan.",
+                style="error",
+            )
+            raise typer.Exit(code=1)
         stdout_console.print_json(config.bake_plan_targets(push=push))
+        if summary:
+            stderr_console.print(BuildSummary.from_image_targets(config.targets).table(sizes=False))
         raise typer.Exit(code=0)
 
     try:
@@ -310,5 +335,12 @@ def build(
     except (python_on_whales.DockerException, BakeryToolRuntimeError):
         stderr_console.print("❌ Build failed", style="error")
         raise typer.Exit(code=1)
+
+    if summary:
+        build_summary = BuildSummary.from_image_targets(config.targets)
+        if summary_format == SummaryOutputFormat.JSON:
+            stdout_console.print_json(build_summary.model_dump_json())
+        else:
+            stderr_console.print(build_summary.table(sizes=False))
 
     stderr_console.print("✅ Build completed", style="success")

--- a/posit-bakery/posit_bakery/cli/build.py
+++ b/posit-bakery/posit_bakery/cli/build.py
@@ -312,7 +312,8 @@ def build(
             raise typer.Exit(code=1)
         stdout_console.print_json(config.bake_plan_targets(push=push))
         if summary:
-            stderr_console.print(BuildSummary.from_image_targets(config.targets).table(sizes=False))
+            build_summary = BuildSummary.from_image_targets(config.targets, platforms=image_platform)
+            stderr_console.print(build_summary.table(sizes=False))
         raise typer.Exit(code=0)
 
     try:
@@ -337,9 +338,9 @@ def build(
         raise typer.Exit(code=1)
 
     if summary:
-        build_summary = BuildSummary.from_image_targets(config.targets)
+        build_summary = BuildSummary.from_image_targets(config.targets, platforms=image_platform)
         if summary_format == SummaryOutputFormat.JSON:
-            stdout_console.print_json(build_summary.model_dump_json())
+            stdout_console.print_json(data=build_summary.as_dict())
         else:
             stderr_console.print(build_summary.table(sizes=False))
 

--- a/posit-bakery/posit_bakery/cli/build.py
+++ b/posit-bakery/posit_bakery/cli/build.py
@@ -311,8 +311,14 @@ def build(
             )
             raise typer.Exit(code=1)
         stdout_console.print_json(config.bake_plan_targets(push=push))
-        if summary:
-            build_summary = BuildSummary.from_image_targets(config.targets, platforms=image_platform)
+        if not summary:
+            raise typer.Exit(code=0)
+
+    if summary:
+        build_summary = BuildSummary.from_image_targets(config.targets, platforms=image_platform)
+        if summary_format == SummaryOutputFormat.JSON:
+            stdout_console.print_json(data=build_summary.as_dict())
+        else:
             stderr_console.print(build_summary.table(sizes=False))
         raise typer.Exit(code=0)
 
@@ -336,12 +342,5 @@ def build(
     except (python_on_whales.DockerException, BakeryToolRuntimeError):
         stderr_console.print("❌ Build failed", style="error")
         raise typer.Exit(code=1)
-
-    if summary:
-        build_summary = BuildSummary.from_image_targets(config.targets, platforms=image_platform)
-        if summary_format == SummaryOutputFormat.JSON:
-            stdout_console.print_json(data=build_summary.as_dict())
-        else:
-            stderr_console.print(build_summary.table(sizes=False))
 
     stderr_console.print("✅ Build completed", style="success")

--- a/posit-bakery/posit_bakery/const.py
+++ b/posit-bakery/posit_bakery/const.py
@@ -24,6 +24,13 @@ class GetTagsOutputFormat(str, Enum):
     UID = "uid"
 
 
+class SummaryOutputFormat(str, Enum):
+    """Output format for the build --summary report."""
+
+    TABLE = "table"
+    JSON = "json"
+
+
 REGEX_FULL_IMAGE_TAG_PATTERN = (
     r"^(?P<repository>[\w.\-_]+((?::\d+|)(?=/[a-z0-9._-]+/[a-z0-9._-]+))|)"
     r"(?:/|)(?P<image>[a-z0-9.\-_]+(?:/[a-z0-9.\-_]+|))(:(?P<tag>[\w.\-_]{1,127})|)$"

--- a/posit-bakery/posit_bakery/image/__init__.py
+++ b/posit-bakery/posit_bakery/image/__init__.py
@@ -1,4 +1,5 @@
 from .bake import BakePlan
 from .image_target import ImageTarget, ImageBuildStrategy, ImageTargetContext
+from .summary import BuildSummary, BuildSummaryRow
 
-__all__ = ["BakePlan", "ImageBuildStrategy", "ImageTargetContext", "ImageTarget"]
+__all__ = ["BakePlan", "ImageBuildStrategy", "ImageTargetContext", "ImageTarget", "BuildSummary", "BuildSummaryRow"]

--- a/posit-bakery/posit_bakery/image/summary.py
+++ b/posit-bakery/posit_bakery/image/summary.py
@@ -14,6 +14,7 @@ TAG_ALIAS_NOTE = (
 class BuildSummaryRow(BaseModel):
     """A single labeled metric in a build summary report."""
 
+    key: str
     label: str
     value: int
 
@@ -24,34 +25,52 @@ class BuildSummary(BaseModel):
     rows: list[BuildSummaryRow]
 
     @classmethod
-    def from_image_targets(cls, targets: list[ImageTarget]) -> Self:
+    def from_image_targets(cls, targets: list[ImageTarget], *, platforms: list[str] | None = None) -> Self:
         """Compute build and artifact counts for the given image targets.
 
         Performs no I/O: every count is derived from configuration already resolved onto
         the targets, so this is safe to call for both `--plan` and real builds.
 
         :param targets: The resolved image targets to summarize.
+        :param platforms: The `--image-platform` CLI override, if any. A target that
+            survives that filter keeps its full declared `image_os.platforms` list
+            unchanged (`config/config.py:1056-1071` is an any-match gate, not a narrowing
+            one) — the actual narrowing to fewer platforms happens later, uniformly across
+            targets, via this same value (`image_target.py:664`: `platforms or (...)`).
+            Passing it here keeps the count matching what will actually build.
         """
         platform_builds = sum(
-            len(target.image_os.platforms) if target.image_os else len(DEFAULT_PLATFORMS) for target in targets
+            len(platforms)
+            if platforms
+            else (len(target.image_os.platforms) if target.image_os else len(DEFAULT_PLATFORMS))
+            for target in targets
         )
         registry_tags = sum(len(target.tags) for target in targets)
 
         return cls(
             rows=[
-                BuildSummaryRow(label="Build Targets", value=len(targets)),
-                BuildSummaryRow(label="Platform Builds", value=platform_builds),
-                BuildSummaryRow(label="Registry Tags", value=registry_tags),
+                BuildSummaryRow(key="build_targets", label="Build Targets", value=len(targets)),
+                BuildSummaryRow(key="platform_builds", label="Platform Builds", value=platform_builds),
+                BuildSummaryRow(key="registry_tags", label="Registry Tags", value=registry_tags),
             ]
         )
+
+    def as_dict(self) -> dict[str, int]:
+        """Flatten to `{key: value}` for machine consumption (e.g. `--summary-format json`)."""
+        return {row.key: row.value for row in self.rows}
 
     def table(self, *, sizes: bool) -> Table:
         """Render the summary as a Rich table.
 
         :param sizes: Reserved for the registry/local size rows added once a build has
-            actually produced artifacts to measure. No size data source exists yet, so this
-            currently has no effect on the rendered table.
+            actually produced artifacts to measure.
+        :raises NotImplementedError: if `sizes` is True. No size data source exists yet —
+            there is nothing to show, so a caller asking for size columns is a bug, not a
+            silent no-op.
         """
+        if sizes:
+            raise NotImplementedError("BuildSummary.table(sizes=True) is not supported yet; sizes ship in Phase 2.")
+
         table = Table(title="Build Summary", caption=TAG_ALIAS_NOTE)
         table.add_column("Metric", justify="left")
         table.add_column("Count", justify="right")

--- a/posit-bakery/posit_bakery/image/summary.py
+++ b/posit-bakery/posit_bakery/image/summary.py
@@ -1,0 +1,62 @@
+from typing import Self
+
+from pydantic import BaseModel
+from rich.table import Table
+
+from posit_bakery.config.image.build_os import DEFAULT_PLATFORMS
+from posit_bakery.image.image_target import ImageTarget
+
+TAG_ALIAS_NOTE = (
+    "Registry Tags counts tag aliases (version, os, latest, etc.) across registries, not distinct stored images."
+)
+
+
+class BuildSummaryRow(BaseModel):
+    """A single labeled metric in a build summary report."""
+
+    label: str
+    value: int
+
+
+class BuildSummary(BaseModel):
+    """Counts (and, once a build has produced artifacts, sizes) for a set of image targets."""
+
+    rows: list[BuildSummaryRow]
+
+    @classmethod
+    def from_image_targets(cls, targets: list[ImageTarget]) -> Self:
+        """Compute build and artifact counts for the given image targets.
+
+        Performs no I/O: every count is derived from configuration already resolved onto
+        the targets, so this is safe to call for both `--plan` and real builds.
+
+        :param targets: The resolved image targets to summarize.
+        """
+        platform_builds = sum(
+            len(target.image_os.platforms) if target.image_os else len(DEFAULT_PLATFORMS) for target in targets
+        )
+        registry_tags = sum(len(target.tags) for target in targets)
+
+        return cls(
+            rows=[
+                BuildSummaryRow(label="Build Targets", value=len(targets)),
+                BuildSummaryRow(label="Platform Builds", value=platform_builds),
+                BuildSummaryRow(label="Registry Tags", value=registry_tags),
+            ]
+        )
+
+    def table(self, *, sizes: bool) -> Table:
+        """Render the summary as a Rich table.
+
+        :param sizes: Reserved for the registry/local size rows added once a build has
+            actually produced artifacts to measure. No size data source exists yet, so this
+            currently has no effect on the rendered table.
+        """
+        table = Table(title="Build Summary", caption=TAG_ALIAS_NOTE)
+        table.add_column("Metric", justify="left")
+        table.add_column("Count", justify="right")
+
+        for row in self.rows:
+            table.add_row(row.label, str(row.value))
+
+        return table

--- a/posit-bakery/test/cli/test_build.py
+++ b/posit-bakery/test/cli/test_build.py
@@ -3,6 +3,7 @@ import re
 import subprocess
 from pathlib import Path
 from shutil import which
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -23,6 +24,8 @@ scenarios(
 runner = CliRunner()
 
 BASIC_CONTEXT = str(Path(__file__).parent.parent / "resources" / "basic")
+# COLUMNS matters: Rich hard-wraps table/caption output, which would break substring assertions.
+_ENV = {"TERM": "dumb", "NO_COLOR": "true", "COLUMNS": "200"}
 
 
 @pytest.fixture
@@ -33,6 +36,11 @@ def mock_build_config():
         instance.build_targets.return_value = None
         mock.from_context.return_value = instance
         yield mock
+
+
+def _fake_target(platforms=("linux/amd64",), tags=("a", "b")):
+    """A minimal stand-in for ImageTarget exposing only what BuildSummary reads."""
+    return SimpleNamespace(image_os=SimpleNamespace(platforms=list(platforms)), tags=list(tags))
 
 
 class TestBuildErrorHandling:
@@ -137,6 +145,69 @@ class TestBuildJobsFlag:
         assert instance.build_targets.call_args.kwargs["jobs"] is None
 
 
+class TestBuildSummaryFlag:
+    """`--summary` reports build/tag counts without changing what the command does."""
+
+    def test_omitted_by_default(self, mock_build_config):
+        instance = mock_build_config.from_context.return_value
+        instance.targets = [_fake_target()]
+        result = runner.invoke(app, ["build", "--context", BASIC_CONTEXT], catch_exceptions=False, env=_ENV)
+        assert result.exit_code == 0
+        assert "Build Summary" not in result.stderr
+
+    def test_prints_table_to_stderr_on_success(self, mock_build_config):
+        instance = mock_build_config.from_context.return_value
+        instance.targets = [_fake_target()]
+        result = runner.invoke(
+            app, ["build", "--summary", "--context", BASIC_CONTEXT], catch_exceptions=False, env=_ENV
+        )
+        assert result.exit_code == 0
+        assert "Build Summary" in result.stderr
+        assert "Build Targets" in result.stderr
+        assert "Platform Builds" in result.stderr
+        assert "Registry Tags" in result.stderr
+        assert "Build Summary" not in result.stdout
+
+    def test_format_json_prints_to_stdout_on_success(self, mock_build_config):
+        instance = mock_build_config.from_context.return_value
+        instance.targets = [_fake_target()]
+        result = runner.invoke(
+            app,
+            ["build", "--summary", "--summary-format", "json", "--context", BASIC_CONTEXT],
+            catch_exceptions=False,
+            env=_ENV,
+        )
+        assert result.exit_code == 0
+        assert "Build Summary" not in result.stderr
+        data = json.loads(result.stdout)
+        assert [row["label"] for row in data["rows"]] == ["Build Targets", "Platform Builds", "Registry Tags"]
+
+    def test_plan_with_summary_prints_plan_json_and_table(self, mock_build_config):
+        instance = mock_build_config.from_context.return_value
+        instance.targets = [_fake_target()]
+        instance.bake_plan_targets.return_value = "{}"
+        result = runner.invoke(
+            app, ["build", "--plan", "--summary", "--context", BASIC_CONTEXT], catch_exceptions=False, env=_ENV
+        )
+        assert result.exit_code == 0
+        assert "Build Summary" in result.stderr
+        assert json.loads(result.stdout) == {}
+        instance.bake_plan_targets.assert_called_once()
+
+    def test_format_json_with_plan_is_a_hard_error(self, mock_build_config):
+        instance = mock_build_config.from_context.return_value
+        instance.targets = [_fake_target()]
+        result = runner.invoke(
+            app,
+            ["build", "--plan", "--summary", "--summary-format", "json", "--context", BASIC_CONTEXT],
+            catch_exceptions=False,
+            env=_ENV,
+        )
+        assert result.exit_code == 1
+        assert "not supported with --plan" in result.stderr
+        instance.bake_plan_targets.assert_not_called()
+
+
 @then("the bake plan is valid", target_fixture="bake_plan_data")
 def check_bake_plan_json(bakery_command):
     try:
@@ -160,6 +231,11 @@ def check_bake_plan_json(bakery_command):
 @then(parsers.parse("the bake plan has {num_targets} targets"))
 def check_bake_plan_num_targets(num_targets, bake_plan_data):
     assert len(bake_plan_data["target"]) == int(num_targets)
+
+
+@then(parsers.parse("the build summary shows {count:d} build targets"))
+def check_build_summary_build_targets(bakery_command, count: int):
+    assert re.search(rf"Build Targets\s*\W\s*{count}\b", bakery_command.result.stderr) is not None
 
 
 @then("the targets include the commit hash")

--- a/posit-bakery/test/cli/test_build.py
+++ b/posit-bakery/test/cli/test_build.py
@@ -146,7 +146,7 @@ class TestBuildJobsFlag:
 
 
 class TestBuildSummaryFlag:
-    """`--summary` reports build/tag counts without changing what the command does."""
+    """`--summary` is a dry-run flag: it prints aggregate counts and exits without building."""
 
     def test_omitted_by_default(self, mock_build_config):
         instance = mock_build_config.from_context.return_value
@@ -155,7 +155,8 @@ class TestBuildSummaryFlag:
         assert result.exit_code == 0
         assert "Build Summary" not in result.stderr
 
-    def test_prints_table_to_stderr_on_success(self, mock_build_config):
+    def test_prints_table_to_stderr_exits_without_building(self, mock_build_config):
+        """--summary alone exits early with the 3-row aggregate count table; no build runs."""
         instance = mock_build_config.from_context.return_value
         instance.targets = [_fake_target()]
         result = runner.invoke(
@@ -164,11 +165,11 @@ class TestBuildSummaryFlag:
         assert result.exit_code == 0
         assert "Build Summary" in result.stderr
         assert "Build Targets" in result.stderr
-        assert "Platform Builds" in result.stderr
-        assert "Registry Tags" in result.stderr
+        assert "Registry Size" not in result.stderr
         assert "Build Summary" not in result.stdout
+        instance.build_targets.assert_not_called()
 
-    def test_format_json_prints_to_stdout_on_success(self, mock_build_config):
+    def test_format_json_prints_to_stdout_exits_without_building(self, mock_build_config):
         instance = mock_build_config.from_context.return_value
         instance.targets = [_fake_target()]
         result = runner.invoke(
@@ -181,6 +182,7 @@ class TestBuildSummaryFlag:
         assert "Build Summary" not in result.stderr
         data = json.loads(result.stdout)
         assert data == {"build_targets": 1, "platform_builds": 1, "registry_tags": 2}
+        instance.build_targets.assert_not_called()
 
     def test_platform_builds_sums_platforms_not_targets(self, mock_build_config):
         """A 2-platform target must count as 2 platform builds -- the whole point of this
@@ -249,6 +251,17 @@ class TestBuildSummaryFlag:
         assert result.exit_code == 1
         assert "not supported with --plan" in result.stderr
         instance.bake_plan_targets.assert_not_called()
+
+    def test_plan_with_summary_does_not_build(self, mock_build_config):
+        """--plan --summary shows bake JSON then the count table, with no build."""
+        instance = mock_build_config.from_context.return_value
+        instance.targets = [_fake_target()]
+        instance.bake_plan_targets.return_value = "{}"
+        result = runner.invoke(
+            app, ["build", "--plan", "--summary", "--context", BASIC_CONTEXT], catch_exceptions=False, env=_ENV
+        )
+        assert result.exit_code == 0
+        instance.build_targets.assert_not_called()
 
 
 @then("the bake plan is valid", target_fixture="bake_plan_data")

--- a/posit-bakery/test/cli/test_build.py
+++ b/posit-bakery/test/cli/test_build.py
@@ -180,7 +180,50 @@ class TestBuildSummaryFlag:
         assert result.exit_code == 0
         assert "Build Summary" not in result.stderr
         data = json.loads(result.stdout)
-        assert [row["label"] for row in data["rows"]] == ["Build Targets", "Platform Builds", "Registry Tags"]
+        assert data == {"build_targets": 1, "platform_builds": 1, "registry_tags": 2}
+
+    def test_platform_builds_sums_platforms_not_targets(self, mock_build_config):
+        """A 2-platform target must count as 2 platform builds -- the whole point of this
+        row is that it differs from the target count."""
+        instance = mock_build_config.from_context.return_value
+        instance.targets = [_fake_target(platforms=("linux/amd64", "linux/arm64"))]
+        result = runner.invoke(
+            app,
+            ["build", "--summary", "--summary-format", "json", "--context", BASIC_CONTEXT],
+            catch_exceptions=False,
+            env=_ENV,
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["build_targets"] == 1
+        assert data["platform_builds"] == 2
+
+    def test_image_platform_filter_narrows_platform_builds(self, mock_build_config):
+        """--image-platform must narrow the *count* of platform builds, not just which
+        targets survive -- a surviving multi-platform target keeps its full declared
+        platforms list (config.py's filter is any-match, not narrowing), so the count has
+        to apply the same override the real build uses instead of trusting the target."""
+        instance = mock_build_config.from_context.return_value
+        instance.targets = [_fake_target(platforms=("linux/amd64", "linux/arm64"))]
+        result = runner.invoke(
+            app,
+            [
+                "build",
+                "--summary",
+                "--summary-format",
+                "json",
+                "--image-platform",
+                "linux/arm64",
+                "--context",
+                BASIC_CONTEXT,
+            ],
+            catch_exceptions=False,
+            env=_ENV,
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["build_targets"] == 1
+        assert data["platform_builds"] == 1
 
     def test_plan_with_summary_prints_plan_json_and_table(self, mock_build_config):
         instance = mock_build_config.from_context.return_value
@@ -233,9 +276,10 @@ def check_bake_plan_num_targets(num_targets, bake_plan_data):
     assert len(bake_plan_data["target"]) == int(num_targets)
 
 
-@then(parsers.parse("the build summary shows {count:d} build targets"))
-def check_build_summary_build_targets(bakery_command, count: int):
-    assert re.search(rf"Build Targets\s*\W\s*{count}\b", bakery_command.result.stderr) is not None
+@then(parsers.parse("the build summary shows {count:d} {metric}"))
+def check_build_summary_metric(bakery_command, count: int, metric: str):
+    label = metric.title()  # "platform builds" -> "Platform Builds", etc.
+    assert re.search(rf"{label}\s*\W\s*{count}\b", bakery_command.result.stderr) is not None
 
 
 @then("the targets include the commit hash")

--- a/posit-bakery/test/features/cli/build.feature
+++ b/posit-bakery/test/features/cli/build.feature
@@ -180,6 +180,16 @@ Feature: build
         * the stderr output includes:
             | not supported with --plan |
 
+    Scenario: --image-platform narrows the platform build count, not just the target list
+        Given I call bakery build
+        * in a temp multiplatform context
+        * with the arguments:
+            | --plan | --image-platform | linux/arm64 | --summary |
+        When I execute the command
+        Then The command succeeds
+        * the build summary shows 2 build targets
+        * the build summary shows 2 platform builds
+
     @image_build
     Scenario: Building images from a project using bake with a matrix
         Given I call bakery build

--- a/posit-bakery/test/features/cli/build.feature
+++ b/posit-bakery/test/features/cli/build.feature
@@ -157,6 +157,29 @@ Feature: build
         * the bake plan is valid
         * the bake plan has 4 targets
 
+    Scenario: Generating a buildkit bake plan with a summary
+        Given I call bakery build
+        * in a temp matrix context
+        * with the arguments:
+            | --plan | --matrix-versions | include | --summary |
+        When I execute the command
+        Then The command succeeds
+        * the bake plan is valid
+        * the bake plan has 4 targets
+        * the stderr output includes:
+            | Build Summary |
+        * the build summary shows 4 build targets
+
+    Scenario: Combining --summary-format json with --plan is a hard error
+        Given I call bakery build
+        * in a temp matrix context
+        * with the arguments:
+            | --plan | --matrix-versions | include | --summary | --summary-format | json |
+        When I execute the command
+        Then The command exits with code 1
+        * the stderr output includes:
+            | not supported with --plan |
+
     @image_build
     Scenario: Building images from a project using bake with a matrix
         Given I call bakery build


### PR DESCRIPTION
This ships Phase 1 of the `--summary` design: build target, platform build, and registry tag counts for whatever the current filters selected, with no build or registry I/O. Phases 2 (image sizes) and 3 (cache size) follow separately, since they need a real build and a registry client bakery doesn't have yet.

- `--summary-format {table,json}` defaults to table; table goes to stderr, json to stdout, matching the existing stream convention.
- `--summary-format json` is a hard error with `--plan`, mirroring the existing `--plan` + `--strategy build` guard, since `--plan` already owns stdout JSON.
- Registry tag counts are aliases (version, os, latest, etc.) across registries, not distinct stored images, so the table caption calls that out explicitly.

Verified live against images-connect, images-workbench, and images-package-manager via `--context`: counts match hand-counted figures exactly, and `--latest` correctly narrows filtered counts.

https://github.com/posit-dev/images-shared/issues/709