### PR TITLE
Fix checksum and URL bugs in setup-goss/hadolint

### DIFF
--- a/setup-goss/action.yml
+++ b/setup-goss/action.yml
@@ -20,6 +20,7 @@ runs:
       shell: bash
       run: mkdir -p tools
     - name: Install goss
+      id: install-goss
       shell: bash
       run: |
         # Determine architecture if not provided
@@ -52,6 +53,7 @@ runs:
           tag="${{ inputs.version }}"
         fi
         version="${tag#v}"
+        echo "tag=${tag}" >> "$GITHUB_OUTPUT"
 
         release_url="https://github.com/goss-org/goss/releases/download/${tag}"
         asset="goss_${version}_linux_${goss_arch}.tar.gz"
@@ -68,8 +70,10 @@ runs:
         chmod +rx tools/goss
     - name: Install dgoss
       shell: bash
+      env:
+        TAG: ${{ steps.install-goss.outputs.tag }}
       run: |
-        release_url="https://github.com/goss-org/goss/releases/${{ inputs.version }}/download"
+        release_url="https://github.com/goss-org/goss/releases/download/${TAG}"
 
         curl -fsSL "${release_url}/dgoss" -o tools/dgoss
 

--- a/setup-hadolint/action.yml
+++ b/setup-hadolint/action.yml
@@ -47,20 +47,28 @@ runs:
         fi
         dest="${BASE_PATH}/tools"
 
-        # v2.13.0+ uses lowercase "linux"; older releases use "Linux"
-        binary="hadolint-linux-${arch}"
-        if ! curl -fsSL "${release_url}/${binary}" -o "${dest}/${binary}" 2>/dev/null; then
-            binary="hadolint-Linux-${arch}"
-            curl -fsSL "${release_url}/${binary}" -o "${dest}/${binary}"
-        fi
-
+        # GitHub's release-download URLs resolve asset names case-insensitively,
+        # so probing "hadolint-linux-${arch}" and falling back to
+        # "hadolint-Linux-${arch}" on failure never actually falls back: the
+        # lowercase request succeeds anyway and downloads the real
+        # (possibly differently-cased) asset under the wrong local filename.
+        # Extract the true filename from the checksum file's own content
+        # instead (which is authoritative), and use that for both the
+        # download and the local name.
+        #
         # v2.15.0+ ships one checksums.sha256 covering all binaries; older
         # releases ship a per-binary "${binary}.sha256" file instead.
-        if curl -fsSL "${release_url}/checksums.sha256" -o "${dest}/checksums.sha256" 2>/dev/null; then
+        if curl -fsSL --remove-on-error "${release_url}/checksums.sha256" -o "${dest}/checksums.sha256" 2>/dev/null; then
+            binary=$(awk -v want="hadolint-linux-${arch}" '{name=$2; sub(/^\*/,"",name); if (tolower(name)==tolower(want)) {print name; exit}}' "${dest}/checksums.sha256")
+            [ -n "$binary" ] || { echo "no checksums.sha256 entry for hadolint-linux-${arch}" >&2; exit 1; }
+            curl -fsSL --remove-on-error "${release_url}/${binary}" -o "${dest}/${binary}"
             (cd "${dest}" && grep -F "${binary}" checksums.sha256 | sha256sum -c -)
             rm -f "${dest}/checksums.sha256"
         else
-            curl -fsSL "${release_url}/${binary}.sha256" -o "${dest}/${binary}.sha256"
+            curl -fsSL --remove-on-error "${release_url}/hadolint-linux-${arch}.sha256" -o "${dest}/guess.sha256"
+            binary=$(awk '{name=$2; sub(/^\*/,"",name); print name}' "${dest}/guess.sha256")
+            mv "${dest}/guess.sha256" "${dest}/${binary}.sha256"
+            curl -fsSL --remove-on-error "${release_url}/${binary}" -o "${dest}/${binary}"
             (cd "${dest}" && sha256sum -c "${binary}.sha256")
             rm -f "${dest}/${binary}.sha256"
         fi


### PR DESCRIPTION
A review of oven/Containerfile on branch feat/bakery-oven found two dormant bugs. Both actions use the default `"latest"` version today, so neither bug shows up yet. If someone pins an older version, each bug will occur.

- setup-hadolint: GitHub matches download URLs without case, so the fallback from a lowercase name to a capitalized name never runs. I confirmed this against hadolint v2.12.0. The fix reads the true filename from the checksum file instead of guessing it.
- setup-goss: the dgoss download URL had the wrong segment order. It worked only for the literal value `"latest"`, by coincidence. I confirmed this against four real goss tags. The fix passes the resolved tag to the dgoss step through `GITHUB_OUTPUT`.

Closes https://github.com/posit-dev/images-shared/issues/713