### PR TITLE
Group dependabot security updates into single PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,23 @@ updates:
       actions:
         patterns:
           - "*"
+      actions-security:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+  - package-ecosystem: "uv"
+    directories:
+      - "/posit-bakery"
+      - "/.claude/skills/bakery/evals"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    groups:
+      python-deps:
+        patterns:
+          - "*"
+      python-security:
+        applies-to: "security-updates"
+        patterns:
+          - "*"


### PR DESCRIPTION
Dependabot's `groups` key only covers version updates by default;
security-alert PRs need an explicit `applies-to: security-updates`
group or they arrive individually. This repo currently has 6 open,
ungrouped security PRs for Python packages in /posit-bakery and
/.claude/skills/bakery/evals because those directories had no `uv`
ecosystem block at all.

Add the `uv` ecosystem for both directories and give every
ecosystem a security-updates sibling group so future security
alerts land as one grouped PR instead of one per dependency.