### PR TITLE
fix: preserve DependencyVersion metadata across packaging upgrades

### DIFF
--- a/posit-bakery/posit_bakery/config/dependencies/version.py
+++ b/posit-bakery/posit_bakery/config/dependencies/version.py
@@ -84,6 +84,12 @@ class DependencyVersion(Version):
         self._has_minor = len(parts) > 1
         self._has_micro = len(parts) > 2
 
+    def __deepcopy__(self, memo: dict[int, Any]) -> Self:
+        """Return a copy without depending on packaging's internal state."""
+        copied = type(self)(self._original)
+        memo[id(self)] = copied
+        return copied
+
     def __str__(self) -> str:
         """Return the original version string."""
         return self._original

--- a/posit-bakery/test/config/dependencies/test_version.py
+++ b/posit-bakery/test/config/dependencies/test_version.py
@@ -1,3 +1,4 @@
+import copy
 import itertools
 
 import pytest
@@ -72,6 +73,17 @@ class TestDependencyVersion:
         assert ver.base_version == version
         assert (ver.minor is not None) == has_minor
         assert (ver.micro is not None) == has_micro
+
+    def test_deepcopy_preserves_dependency_version_metadata(self):
+        """Deep copies retain metadata added by DependencyVersion."""
+        original = DependencyVersion("2026.03.0-212")
+        copied = copy.deepcopy(original)
+
+        assert copied is not original
+        assert copied == original
+        assert str(copied) == str(original)
+        assert copied.minor == original.minor
+        assert copied.micro == original.micro
 
     def test_dependency_version_prefix(self):
         """Test that a version with a prefix is accepted."""


### PR DESCRIPTION
## Summary

- Preserve `DependencyVersion` metadata when dependency versions are deep-copied.
- Avoid relying on `packaging.version.Version` internal copy state, which changed in packaging 26.x.
- Add regression coverage for copied version metadata.

Fixes #721

## Validation

- `just posit-bakery/test` with packaging 26.3
- 2056 tests passed