### PR TITLE
Fix doubled newlines and blank separators in build logs

### DIFF
--- a/posit-bakery/posit_bakery/parallel/executor.py
+++ b/posit-bakery/posit_bakery/parallel/executor.py
@@ -186,8 +186,12 @@ class PrefixedLogSink:
         Strips a trailing line terminator first: sources like `python_on_whales`'s
         ``stream_logs`` yield lines via `readline()`, which keeps the `\\n` -- printing
         that verbatim would double up with the newline `Console.print` already appends.
+        Blank lines (buildx's own step separators) are dropped rather than printed as a
+        bare `[key]` with no content.
         """
         line = line.rstrip("\r\n")
+        if not line.strip():
+            return
         with self._lock:
             self._console.print(Text.assemble((f"[{key}]", "quiet"), f" {line}"))
 

--- a/posit-bakery/posit_bakery/parallel/executor.py
+++ b/posit-bakery/posit_bakery/parallel/executor.py
@@ -186,8 +186,9 @@ class PrefixedLogSink:
         Strips a trailing line terminator first: sources like `python_on_whales`'s
         ``stream_logs`` yield lines via `readline()`, which keeps the `\\n` -- printing
         that verbatim would double up with the newline `Console.print` already appends.
-        Blank lines (buildx's own step separators) are dropped rather than printed as a
-        bare `[key]` with no content.
+        Also drops blank lines outright rather than printing a bare `[key]` with no
+        content -- buildx's plain progress emits these as step separators, but this
+        drops any blank line, regardless of source.
         """
         line = line.rstrip("\r\n")
         if not line.strip():

--- a/posit-bakery/posit_bakery/parallel/executor.py
+++ b/posit-bakery/posit_bakery/parallel/executor.py
@@ -181,7 +181,13 @@ class PrefixedLogSink:
         self._lock = threading.Lock()
 
     def write(self, key: str, line: str) -> None:
-        """Print `line` prefixed with `[key]`, guarded by a lock shared across all keys."""
+        """Print `line` prefixed with `[key]`, guarded by a lock shared across all keys.
+
+        Strips a trailing line terminator first: sources like `python_on_whales`'s
+        ``stream_logs`` yield lines via `readline()`, which keeps the `\\n` -- printing
+        that verbatim would double up with the newline `Console.print` already appends.
+        """
+        line = line.rstrip("\r\n")
         with self._lock:
             self._console.print(Text.assemble((f"[{key}]", "quiet"), f" {line}"))
 

--- a/posit-bakery/test/parallel/test_executor.py
+++ b/posit-bakery/test/parallel/test_executor.py
@@ -360,6 +360,24 @@ class TestPrefixedLogSink:
         output = buf.getvalue()
         assert "[internal] load build definition from Dockerfile" in output
 
+    def test_write_strips_trailing_newline_from_streamed_line(self):
+        """`python_on_whales`'s stream_logs yields lines via `readline()`, which keeps the
+        trailing `\\n` -- write() must not double it up with its own newline."""
+        buf = io.StringIO()
+        sink = PrefixedLogSink(console=Console(file=buf))
+
+        sink.write("target-a", "#1 DONE 0.0s\n")
+
+        assert buf.getvalue() == "[target-a] #1 DONE 0.0s\n"
+
+    def test_write_strips_trailing_crlf_from_streamed_line(self):
+        buf = io.StringIO()
+        sink = PrefixedLogSink(console=Console(file=buf))
+
+        sink.write("target-a", "#1 DONE 0.0s\r\n")
+
+        assert buf.getvalue() == "[target-a] #1 DONE 0.0s\n"
+
     def test_write_is_thread_safe_no_interleaving(self):
         buf = io.StringIO()
         sink = PrefixedLogSink(console=Console(file=buf, width=200))

--- a/posit-bakery/test/parallel/test_executor.py
+++ b/posit-bakery/test/parallel/test_executor.py
@@ -380,8 +380,9 @@ class TestPrefixedLogSink:
 
     @pytest.mark.parametrize("blank_line", ["\n", "\r\n", "", "   \n"])
     def test_write_drops_blank_lines(self, blank_line):
-        """buildx's plain progress output uses bare blank lines as step separators;
-        these should be dropped rather than printed as a bare `[key]` with no content."""
+        """Blank lines are dropped rather than printed as a bare `[key]` with no content --
+        buildx's plain progress emits these as step separators, but any blank line is
+        dropped, regardless of source."""
         buf = io.StringIO()
         sink = PrefixedLogSink(console=Console(file=buf))
 

--- a/posit-bakery/test/parallel/test_executor.py
+++ b/posit-bakery/test/parallel/test_executor.py
@@ -378,6 +378,17 @@ class TestPrefixedLogSink:
 
         assert buf.getvalue() == "[target-a] #1 DONE 0.0s\n"
 
+    @pytest.mark.parametrize("blank_line", ["\n", "\r\n", "", "   \n"])
+    def test_write_drops_blank_lines(self, blank_line):
+        """buildx's plain progress output uses bare blank lines as step separators;
+        these should be dropped rather than printed as a bare `[key]` with no content."""
+        buf = io.StringIO()
+        sink = PrefixedLogSink(console=Console(file=buf))
+
+        sink.write("target-a", blank_line)
+
+        assert buf.getvalue() == ""
+
     def test_write_is_thread_safe_no_interleaving(self):
         buf = io.StringIO()
         sink = PrefixedLogSink(console=Console(file=buf, width=200))


### PR DESCRIPTION
`PrefixedLogSink.write()` doubled every line's newline and printed buildx's blank separator lines as bare `[key]` tags.

Strips the line's own trailing terminator before printing and drops blank lines outright.

Closes https://github.com/posit-dev/images-shared/issues/724