### PR TITLE
fix: cache goss binaries

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,36 @@
+name: Renovate
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  renovate:
+    # Only run against the canonical repository, where the GitHub App is installed.
+    if: github.repository == 'posit-dev/images-shared'
+    runs-on: ubuntu-latest
+    steps:
+      - name: GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          client-id: ${{ secrets.POSIT_PLATFORM_CLIENT_ID }}
+          private-key: ${{ secrets.POSIT_PLATFORM_PEM }}
+          # Renovate only creates branches and pull requests in this repository.
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Run Renovate
+        uses: renovatebot/github-action@e09d604f8f803bb527bd8321ed5be06c460b8682  # v46.2.2
+        with:
+          configurationFile: renovate.json
+          token: ${{ steps.app-token.outputs.token }}

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ See [CI Workflows](./CI.md) for shared GitHub Actions workflows used by product 
 
 Bakery uses [goss](https://github.com/goss-org/goss) and [dgoss](https://github.com/goss-org/goss/tree/master/extras/dgoss) to define and execute tests that ensure that the container image was built properly.
 
-You can include the [setup-goss](./setup-goss) action in a [GitHub Actions Workflow](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax) to automatically install the latest versions of `goss` and `dgoss` in the `tools` directory at the top level of the repository.
+You can include the [setup-goss](./setup-goss) action in a [GitHub Actions Workflow](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax) to automatically install `goss` and `dgoss` in the `tools` directory at the top level of the repository. The binaries are cached by version and architecture, so subsequent workflow runs do not need to download them from GitHub. Renovate maintains the action's pinned default Goss release.
 
 ## Share your Feedback
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^setup-goss\\/action\\.yml$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)\\s+default: \\\"(?<currentValue>[^\\\"]+)\\\""
+      ]
+    }
+  ],
+  "dependencyDashboard": false,
+  "enabledManagers": [
+    "custom.regex"
+  ],
+  "onboarding": false
+}

--- a/setup-goss/action.yml
+++ b/setup-goss/action.yml
@@ -5,7 +5,8 @@ inputs:
   version:
     description: "The goss release version to install"
     required: false
-    default: "latest"
+    # renovate: datasource=github-releases depName=goss-org/goss
+    default: "v0.4.10"
   architecture:
     description: "The system architecture (e.g., amd64, arm64). If not set, it will be detected automatically."
     required: false
@@ -14,51 +15,53 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Install jq
-      uses: dcarbone/install-jq-action@4fcb5062d7ce9bc4382d1a352d19ba3ba2c317c1  # v4.0.1
     - name: Make tools directory
       shell: bash
       run: mkdir -p tools
-    - name: Install goss
+    - name: Resolve goss architecture
+      id: goss
       shell: bash
+      env:
+        ARCHITECTURE: ${{ inputs.architecture }}
       run: |
-        # Determine architecture if not provided
-        arch="${{ inputs.architecture }}"
+        arch="$ARCHITECTURE"
         if [ -z "$arch" ]; then
           arch=$(uname -m)
         fi
 
-        # Map architecture names to goss's pre-v0.4.10 naming, then to its current naming
-        if [ "$arch" = "x86_64" ]; then
-            arch="amd64"
-        elif [ "$arch" = "aarch64" ]; then
-            arch="arm64"
-        fi
-
         case "$arch" in
-          amd64) goss_arch="x86_64" ;;
-          arm64) goss_arch="arm64" ;;
+          x86_64 | amd64) goss_arch="x86_64" ;;
+          aarch64 | arm64) goss_arch="arm64" ;;
           *)
             echo "Unsupported architecture for goss: ${arch}" >&2
             exit 1
             ;;
         esac
 
-        # v0.4.10+ ships versioned tarballs with a consolidated SHA256SUMS file, so "latest"
-        # must be resolved to a concrete tag up front to build the asset filename.
-        if [ "${{ inputs.version }}" = "latest" ]; then
-          tag=$(curl -fsSL "https://api.github.com/repos/goss-org/goss/releases/latest" | jq '.tag_name' -r)
-        else
-          tag="${{ inputs.version }}"
-        fi
+        echo "architecture=${goss_arch}" >> "$GITHUB_OUTPUT"
+    - name: Restore goss cache
+      id: goss-cache
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      with:
+        path: |
+          tools/goss
+          tools/dgoss
+        key: setup-goss-${{ runner.os }}-${{ steps.goss.outputs.architecture }}-${{ inputs.version }}
+    - name: Install goss and dgoss
+      if: steps.goss-cache.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        GOSS_ARCH: ${{ steps.goss.outputs.architecture }}
+        GOSS_VERSION: ${{ inputs.version }}
+      run: |
+        tag="$GOSS_VERSION"
         version="${tag#v}"
 
         release_url="https://github.com/goss-org/goss/releases/download/${tag}"
-        asset="goss_${version}_linux_${goss_arch}.tar.gz"
+        asset="goss_${version}_linux_${GOSS_ARCH}.tar.gz"
         checksums="goss_${version}_SHA256SUMS"
 
         curl -fsSL "${release_url}/${asset}" -o "tools/${asset}"
-
         curl -fsSL "${release_url}/${checksums}" -o "tools/${checksums}"
         (cd tools && sha256sum -c <(grep -F "${asset}" "${checksums}"))
         rm -f "tools/${checksums}"
@@ -66,15 +69,9 @@ runs:
         tar -xzf "tools/${asset}" -C tools goss
         rm -f "tools/${asset}"
         chmod +rx tools/goss
-    - name: Install dgoss
-      shell: bash
-      run: |
-        release_url="https://github.com/goss-org/goss/releases/${{ inputs.version }}/download"
 
         curl -fsSL "${release_url}/dgoss" -o tools/dgoss
-
         curl -fsSL "${release_url}/dgoss.sha256" -o tools/dgoss.sha256
         (cd tools && sha256sum -c dgoss.sha256)
         rm -f tools/dgoss.sha256
-
         chmod +rx tools/dgoss


### PR DESCRIPTION
## Summary
- cache goss and dgoss binaries by requested version and architecture
- avoid release API and download requests when the cache is restored
- provide a cache-version input to refresh the cached `latest` release

## Testing
- pre-commit hooks (including YAML validation)