### PR TITLE
feat: add opt-in Trivy scanning to PR builds

### DIFF
--- a/.github/workflows/bakery-build-pr.yml
+++ b/.github/workflows/bakery-build-pr.yml
@@ -299,6 +299,31 @@ jobs:
             "${CACHE_FLAGS[@]}" \
             --context "$BAKERY_CONTEXT"
 
+      - name: Test
+        env:
+          IMAGE_NAME: ${{ matrix.img.image }}
+          IMAGE_VERSION: ${{ matrix.img.version }}
+          IMAGE_PLATFORM: ${{ matrix.img.platform }}
+          IMG_DEV: ${{ matrix.img.dev }}
+          MATRIX_VERSIONS: ${{ inputs.matrix-versions }}
+          BAKERY_CONTEXT: ${{ inputs.context }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "$IMG_DEV" = "true" ]; then
+            DEV_VERSIONS=only
+          else
+            DEV_VERSIONS=exclude
+          fi
+          GOSS_PATH=${GITHUB_WORKSPACE}/tools/goss \
+          DGOSS_PATH=${GITHUB_WORKSPACE}/tools/dgoss \
+          bakery dgoss run \
+            --image-name "^${IMAGE_NAME}$" \
+            --image-version "$IMAGE_VERSION" \
+            --image-platform "$IMAGE_PLATFORM" \
+            --dev-versions "$DEV_VERSIONS" \
+            --matrix-versions "$MATRIX_VERSIONS" \
+            --context "$BAKERY_CONTEXT"
+
       - name: Setup trivy
         if: ${{ inputs.scan-image }}
         uses: aquasecurity/setup-trivy@81e514348e19b6112ce2a7e3ecbafe19c1e1f567  # v0.3.1
@@ -306,10 +331,10 @@ jobs:
           version: ${{ inputs.trivy-version }}
           cache: true
 
-      # Opt-in per caller. This runs on every PR build for a repo that enables
-      # it, and a scan costs roughly as long again as the build it follows, so
-      # the default stays off until a caller decides the signal is worth it.
-      - name: Scan
+      # After Test: only Test's `docker run` makes every target addressable
+      # locally. Scanning earlier resolves stale tags and silently scans the
+      # published image instead of the one just built.
+      - name: Trivy Scan
         if: ${{ inputs.scan-image }}
         continue-on-error: true
         env:
@@ -335,31 +360,6 @@ jobs:
             --dev-versions "$DEV_VERSIONS" \
             --matrix-versions "$MATRIX_VERSIONS" \
             "${FAIL_FLAGS[@]}" \
-            --context "$BAKERY_CONTEXT"
-
-      - name: Test
-        env:
-          IMAGE_NAME: ${{ matrix.img.image }}
-          IMAGE_VERSION: ${{ matrix.img.version }}
-          IMAGE_PLATFORM: ${{ matrix.img.platform }}
-          IMG_DEV: ${{ matrix.img.dev }}
-          MATRIX_VERSIONS: ${{ inputs.matrix-versions }}
-          BAKERY_CONTEXT: ${{ inputs.context }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if [ "$IMG_DEV" = "true" ]; then
-            DEV_VERSIONS=only
-          else
-            DEV_VERSIONS=exclude
-          fi
-          GOSS_PATH=${GITHUB_WORKSPACE}/tools/goss \
-          DGOSS_PATH=${GITHUB_WORKSPACE}/tools/dgoss \
-          bakery dgoss run \
-            --image-name "^${IMAGE_NAME}$" \
-            --image-version "$IMAGE_VERSION" \
-            --image-platform "$IMAGE_PLATFORM" \
-            --dev-versions "$DEV_VERSIONS" \
-            --matrix-versions "$MATRIX_VERSIONS" \
             --context "$BAKERY_CONTEXT"
 
   build-test-result:

--- a/.github/workflows/bakery-build-pr.yml
+++ b/.github/workflows/bakery-build-pr.yml
@@ -35,6 +35,21 @@ on:
         default: "exclude"
         required: false
         type: string
+      scan-image:
+        description: "Scan built images with Trivy [default: false]"
+        default: false
+        required: false
+        type: boolean
+      scan-fail-on-severity:
+        description: "Comma-separated severities that fail the scan if found (e.g. CRITICAL). Empty means findings never fail."
+        default: ""
+        required: false
+        type: string
+      trivy-version:
+        description: "Trivy release to install (e.g. v0.73.0). 'latest' disables binary caching in setup-trivy."
+        default: "v0.73.0"
+        required: false
+        type: string
       retry:
         description: "Number of times to retry a failed build"
         default: 1
@@ -282,6 +297,44 @@ jobs:
             --dev-versions "$DEV_VERSIONS" \
             --matrix-versions "$MATRIX_VERSIONS" \
             "${CACHE_FLAGS[@]}" \
+            --context "$BAKERY_CONTEXT"
+
+      - name: Setup trivy
+        if: ${{ inputs.scan-image }}
+        uses: aquasecurity/setup-trivy@81e514348e19b6112ce2a7e3ecbafe19c1e1f567  # v0.3.1
+        with:
+          version: ${{ inputs.trivy-version }}
+          cache: true
+
+      # Opt-in per caller. This runs on every PR build for a repo that enables
+      # it, and a scan costs roughly as long again as the build it follows, so
+      # the default stays off until a caller decides the signal is worth it.
+      - name: Scan
+        if: ${{ inputs.scan-image }}
+        continue-on-error: true
+        env:
+          IMAGE_NAME: ${{ matrix.img.image }}
+          IMAGE_VERSION: ${{ matrix.img.version }}
+          NORMALIZED_PLATFORM: ${{ steps.normalize-platform.outputs.platform }}
+          IMG_DEV: ${{ matrix.img.dev }}
+          MATRIX_VERSIONS: ${{ inputs.matrix-versions }}
+          BAKERY_CONTEXT: ${{ inputs.context }}
+          FAIL_ON_SEVERITY: ${{ inputs.scan-fail-on-severity }}
+        run: |
+          if [ "$IMG_DEV" = "true" ]; then
+            DEV_VERSIONS=only
+          else
+            DEV_VERSIONS=exclude
+          fi
+          FAIL_FLAGS=()
+          [[ -n "$FAIL_ON_SEVERITY" ]] && FAIL_FLAGS=(--fail-on-severity "$FAIL_ON_SEVERITY")
+          bakery trivy scan \
+            --image-name "^${IMAGE_NAME}$" \
+            --image-version "$IMAGE_VERSION" \
+            --image-platform "$NORMALIZED_PLATFORM" \
+            --dev-versions "$DEV_VERSIONS" \
+            --matrix-versions "$MATRIX_VERSIONS" \
+            "${FAIL_FLAGS[@]}" \
             --context "$BAKERY_CONTEXT"
 
       - name: Test


### PR DESCRIPTION
Re-adds the PR-build `Scan` step split out of #722, behind a `scan-image` input defaulting to `false`.

The always-on version this replaces couldn't fail a build even in principle — no `--fail-on-severity`, plus `continue-on-error` — so it cost ~4 minutes per job on every PR in three repos and produced a table in a collapsed log group. Now a caller opts in, and `scan-fail-on-severity` lets one that does actually gate on the result.

`trivy-version` is pinned rather than tracking `latest`, because `setup-trivy` logs *"doesn't currently support caching the 'latest' version"* — the previous default re-downloaded the binary on every job.

Not wired to code scanning. Fork PRs get a read-only token and can't be granted `security-events: write`, and main only analyses latest versions, so PR-time uploads of older versions would have no baseline and would report every finding as new.

- https://github.com/posit-dev/images-shared/pull/722
