### PR TITLE
Fix invalid escape sequence warnings in test_macros.py

### DIFF
--- a/posit-bakery/test/config/templating/test_macros.py
+++ b/posit-bakery/test/config/templating/test_macros.py
@@ -2410,7 +2410,7 @@ class TestRMacros:
         expected = textwrap.dedent(
             """\
             RUN_UNATTENDED=1 R_VERSION=4.4.3 bash -c "$(curl -fsSL https://rstd.io/r-install)" && \\
-            find . -type f -name '[rR]-4.4.3.*\.(deb|rpm)' -delete"""
+            find . -type f -name '[rR]-4.4.3.*\\.(deb|rpm)' -delete"""
         )
         rendered = environment_with_macros.from_string(template).render()
         assert rendered == expected
@@ -2423,7 +2423,7 @@ class TestRMacros:
                 textwrap.dedent(
                     """\
                     RUN RUN_UNATTENDED=1 R_VERSION=4.4.3 bash -c "$(curl -fsSL https://rstd.io/r-install)" && \\
-                        find . -type f -name '[rR]-4.4.3.*\.(deb|rpm)' -delete"""
+                        find . -type f -name '[rR]-4.4.3.*\\.(deb|rpm)' -delete"""
                 ),
                 id="single-version",
             ),
@@ -2432,9 +2432,9 @@ class TestRMacros:
                 textwrap.dedent(
                     """\
                     RUN RUN_UNATTENDED=1 R_VERSION=4.4.3 bash -c "$(curl -fsSL https://rstd.io/r-install)" && \\
-                        find . -type f -name '[rR]-4.4.3.*\.(deb|rpm)' -delete
+                        find . -type f -name '[rR]-4.4.3.*\\.(deb|rpm)' -delete
                     RUN RUN_UNATTENDED=1 R_VERSION=4.3.3 bash -c "$(curl -fsSL https://rstd.io/r-install)" && \\
-                        find . -type f -name '[rR]-4.3.3.*\.(deb|rpm)' -delete"""
+                        find . -type f -name '[rR]-4.3.3.*\\.(deb|rpm)' -delete"""
                 ),
                 id="multiple-versions",
             ),
@@ -2443,9 +2443,9 @@ class TestRMacros:
                 textwrap.dedent(
                     """\
                     RUN RUN_UNATTENDED=1 R_VERSION=4.4.3 bash -c "$(curl -fsSL https://rstd.io/r-install)" && \\
-                        find . -type f -name '[rR]-4.4.3.*\.(deb|rpm)' -delete
+                        find . -type f -name '[rR]-4.4.3.*\\.(deb|rpm)' -delete
                     RUN RUN_UNATTENDED=1 R_VERSION=4.3.3 bash -c "$(curl -fsSL https://rstd.io/r-install)" && \\
-                        find . -type f -name '[rR]-4.3.3.*\.(deb|rpm)' -delete"""
+                        find . -type f -name '[rR]-4.3.3.*\\.(deb|rpm)' -delete"""
                 ),
                 id="string-versions",
             ),


### PR DESCRIPTION
Regex patterns embedded in expected test strings used a bare `\.` inside regular (non-raw) triple-quoted strings, which Python 3.12 flags as `SyntaxWarning: invalid escape sequence`. Escaped the backslash (`\.` -> `\\.`) so the literal string value is unchanged but the warning is eliminated.

CI was emitting eight of these warnings per occurrence across parallel workers, cluttering the pytest output.