### PR TITLE
Require explicit scope for bakery update files

### DIFF
--- a/posit-bakery/posit_bakery/cli/update.py
+++ b/posit-bakery/posit_bakery/cli/update.py
@@ -61,6 +61,15 @@ def files(
             rich_help_panel=RichHelpPanelEnum.FILTERS,
         ),
     ] = None,
+    all_images: Annotated[
+        bool,
+        typer.Option(
+            "--all",
+            help="Render every image and version in the project. Required when no --image-name or "
+            "--image-version filter is given.",
+            rich_help_panel=RichHelpPanelEnum.FILTERS,
+        ),
+    ] = False,
 ) -> None:
     """Renders templates to version files matching the given filters
 
@@ -71,7 +80,19 @@ def files(
 
     \b
     Existing files will not be removed, but may be overwritten during template rendering.
+
+    \b
+    At least one of --image-name or --image-version is required to scope the render. Pass --all to
+    explicitly render every image and version in the project.
     """
+    if image_name is None and image_version is None and not all_images:
+        stderr_console.print(
+            "❌ No scope specified. Pass --image-name and/or --image-version to scope the render, "
+            "or --all to intentionally render every image and version.",
+            style="error",
+        )
+        raise typer.Exit(code=1)
+
     _filter = BakeryConfigFilter(
         image_name=image_name,
         image_version=image_version,

--- a/posit-bakery/test/features/cli/update/files.feature
+++ b/posit-bakery/test/features/cli/update/files.feature
@@ -31,3 +31,25 @@ Feature: update files
       * the default matrix rendered templates exist
       * the stderr output includes:
           | Files updated successfully |
+
+  Scenario: Updating files without a scope fails
+      Given I call bakery update files
+      * in a temp with-macros context
+      When I execute the command
+      Then The command fails
+      * the stderr output includes:
+          | No scope specified |
+
+  Scenario: Updating all files with --all
+      Given I call bakery update files
+      * in a temp with-macros context
+      * with the 'test-image/1.0.0' path removed
+      * with the arguments:
+          | --all |
+      When I execute the command
+      Then The command succeeds
+      * the image "test-image" exists
+      * the version "1.0.0" exists
+      * the default rendered templates exist
+      * the stderr output includes:
+          | Files updated successfully |


### PR DESCRIPTION
Closes https://github.com/posit-dev/images-shared/issues/752

## Summary
`bakery update files` re-rendered every image and version in the project whenever `--image-name` and `--image-version` were both omitted, with no warning or confirmation. This adds a required `--all` flag that must be passed explicitly to render everything, mirroring the existing `--matrix-versions include/exclude` pattern on `bakery build`. Unscoped calls without `--all` now fail fast with a clear error instead of silently defaulting to the widest possible scope. Existing scoped calls are unaffected.

## Verification
`uv run bakery update files` (no filters) now exits 1 with "No scope specified..."; `uv run bakery update files --all` renders every image/version as before. Added BDD scenarios in `test/features/cli/update/files.feature` covering both cases; full `pytest test/cli/test_update.py` suite passes.