### PR TITLE
Disable git credential persistence on checkouts

### DIFF
--- a/.github/workflows/bakery-build-native.yml
+++ b/.github/workflows/bakery-build-native.yml
@@ -157,6 +157,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Install
@@ -253,6 +254,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup bakery
         uses: "posit-dev/images-shared/setup-bakery@main"
@@ -488,6 +491,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup bakery
         uses: "posit-dev/images-shared/setup-bakery@main"
@@ -624,6 +629,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       # Restores the shared cache like every other job but never saves it:
       # bakery ci readme has no --image-name filter and always resolves

--- a/.github/workflows/bakery-build-pr.yml
+++ b/.github/workflows/bakery-build-pr.yml
@@ -96,6 +96,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Install
@@ -207,6 +208,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup bakery
         uses: "posit-dev/images-shared/setup-bakery@main"

--- a/.github/workflows/bakery-build.yml
+++ b/.github/workflows/bakery-build.yml
@@ -131,6 +131,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Install
@@ -219,6 +220,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup bakery
         uses: "posit-dev/images-shared/setup-bakery@main"
@@ -385,6 +388,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       # Restores the shared cache like every other job but never saves it:
       # bakery ci readme has no --image-name filter and always resolves

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
           fetch-tags: true
 
@@ -248,6 +249,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
           fetch-tags: true
 

--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -94,6 +94,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup bakery
         uses: "posit-dev/images-shared/setup-bakery@main"
@@ -140,6 +142,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup bakery
         uses: "posit-dev/images-shared/setup-bakery@main"

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -38,6 +38,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup bakery
         uses: "posit-dev/images-shared/setup-bakery@main"

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -9,23 +9,12 @@ rules:
         "*": hash-pin
   artipacked:
     ignore:
-      # Existing checkouts precede artifact uploads. Keep the exemptions scoped
-      # to these exact locations so new instances still require review.
-      - bakery-build-native.yml:145
-      - bakery-build-native.yml:242
-      - bakery-build-native.yml:427
-      - bakery-build-native.yml:563
-      - bakery-build-pr.yml:96
-      - bakery-build-pr.yml:208
-      - bakery-build.yml:131
-      - bakery-build.yml:220
-      - bakery-build.yml:386
-      - ci.yml:69
-      - ci.yml:248
-      - clean.yml:95
-      - clean.yml:141
+      # Only these two checkouts persist credentials on purpose, and both need
+      # to: product-release pushes commits/PRs with its App token, and docs
+      # publishes to gh-pages. Neither job uploads .git as an artifact, so
+      # there is no leak path. Every other checkout sets
+      # persist-credentials: false inline instead of being exempted here.
       - docs.yml:17
-      - hadolint.yml:39
       - product-release.yml:45
   superfluous-actions:
     ignore:


### PR DESCRIPTION
Sets `persist-credentials: false` on the checkouts whose jobs run no authenticated git operation afterward, so the checkout token isn't persisted where later steps don't need it. The two checkouts that do push (product-release, docs) keep it and remain the only `artipacked` exemptions.

- https://github.com/posit-dev/images-shared/pull/732
