### PR TITLE
Add max-parallel input to bakery-build-native.yml

### DIFF
--- a/.github/workflows/bakery-build-native.yml
+++ b/.github/workflows/bakery-build-native.yml
@@ -77,6 +77,11 @@ on:
         default: true
         required: false
         type: boolean
+      max-parallel:
+        description: "Maximum number of matrix jobs (build/test and merge) to run simultaneously [default: 0, unlimited]"
+        default: 0
+        required: false
+        type: number
       cache-registry:
         description: "Registry to use for build layer caching [default: ghcr.io/<repository_owner>]"
         default: ""
@@ -247,6 +252,7 @@ jobs:
     if: ${{ needs.matrix.outputs.platform-matrix != '[]' }}
     strategy:
       fail-fast: false
+      max-parallel: ${{ inputs.max-parallel > 0 && inputs.max-parallel || 256 }}
       matrix:
         img: ${{ fromJson(needs.matrix.outputs.platform-matrix) }}
     runs-on: ${{ matrix.img.platform == 'linux/arm64' && inputs.arm64-builder || inputs.amd64-builder }}
@@ -484,6 +490,7 @@ jobs:
     if: ${{ needs.matrix.outputs.image-matrix != '[]' }}
     strategy:
       fail-fast: false
+      max-parallel: ${{ inputs.max-parallel > 0 && inputs.max-parallel || 256 }}
       matrix:
         image: ${{ fromJson(needs.matrix.outputs.image-matrix) }}
     runs-on: ${{ inputs.merge-builder }}

--- a/CI.md
+++ b/CI.md
@@ -92,6 +92,7 @@ Builds, tests, and pushes images on native hardware. Each `{image, version, plat
 | `push` | No | `false` | Push merged manifests to Docker Hub, GHCR, and Amazon Elastic Container Registry (ECR). |
 | `retry` | No | `1` | Retry count for a failed build. |
 | `cache` | No | `true` | Use the GHCR registry-backed buildx cache. |
+| `max-parallel` | No | `0` | Cap on simultaneous build/test and merge matrix jobs. `0` means unlimited. |
 | `merge-builder` | No | `ubuntu-latest-4x` | Runner label for the merge job. |
 | `amd64-builder` | No | `ubuntu-latest-4x` | Runner label for amd64 build jobs. |
 | `arm64-builder` | No | `ubuntu-24.04-arm64-4-core` | Runner label for arm64 build jobs. |


### PR DESCRIPTION
Adds a `max-parallel` input to `bakery-build-native.yml`, capping the number of simultaneous `build-test` and `merge` matrix jobs. Default (`0`) resolves to GitHub's own 256-job matrix limit, so behavior is unchanged for any caller that doesn't set it explicitly.

Documents the new input in `CI.md`.

- https://github.com/posit-dev/images-shared/issues/679

Closes https://github.com/posit-dev/images-shared/issues/757