### PR TITLE
Surface bakery build --summary in GitHub Actions job summaries

### DIFF
--- a/.github/workflows/bakery-build-native.yml
+++ b/.github/workflows/bakery-build-native.yml
@@ -399,10 +399,22 @@ jobs:
             --push \
             --summary --summary-format json \
             > "./${IMAGE_NAME}-${IMAGE_VERSION}-${NORMALIZED_PLATFORM}-summary.json"
+      # Distinguishes this call's artifacts from a sibling call's when a caller invokes
+      # this workflow more than once in the same run (e.g. separate production/development
+      # calls with different `with:` values) -- artifacts are scoped to the run, not to
+      # the invocation, so without this the summary job of each call would download the
+      # other's artifacts too. Same technique `cache-scope: ${{ toJSON(inputs) }}` already
+      # uses elsewhere in this file, just hashed into a name-safe token.
+      - name: Compute artifact scope
+        id: artifact-scope
+        env:
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: |
+          echo "hash=$(printf '%s' "$INPUTS_JSON" | sha256sum | cut -c1-12)" >> "$GITHUB_OUTPUT"
       - name: Upload Build Summary
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: "${{ matrix.img.image }}-${{ matrix.img.version }}-${{ steps.normalize-platform.outputs.platform }}-summary"
+          name: "${{ steps.artifact-scope.outputs.hash }}-${{ matrix.img.image }}-${{ matrix.img.version }}-${{ steps.normalize-platform.outputs.platform }}-summary"
           path: "./${{ matrix.img.image }}-${{ matrix.img.version }}-${{ steps.normalize-platform.outputs.platform }}-summary.json"
           retention-days: 3
           overwrite: 'true'
@@ -623,10 +635,16 @@ jobs:
             --summary --summary-format json \
             ./*-metadata.json \
             > "./${IMAGE_NAME}-publish-summary.json"
+      - name: Compute artifact scope
+        id: artifact-scope
+        env:
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: |
+          echo "hash=$(printf '%s' "$INPUTS_JSON" | sha256sum | cut -c1-12)" >> "$GITHUB_OUTPUT"
       - name: Upload Publish Summary
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: "${{ matrix.image }}-publish-summary"
+          name: "${{ steps.artifact-scope.outputs.hash }}-${{ matrix.image }}-publish-summary"
           path: "./${{ matrix.image }}-publish-summary.json"
           retention-days: 3
           overwrite: 'true'
@@ -650,10 +668,17 @@ jobs:
         with:
           version: ${{ inputs.version }}
 
+      - name: Compute artifact scope
+        id: artifact-scope
+        env:
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: |
+          echo "hash=$(printf '%s' "$INPUTS_JSON" | sha256sum | cut -c1-12)" >> "$GITHUB_OUTPUT"
+
       - name: Download Build Summaries
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
-          pattern: "*-summary"
+          pattern: "${{ steps.artifact-scope.outputs.hash }}-*-summary"
           merge-multiple: true
 
       - name: Render Combined Summary

--- a/.github/workflows/bakery-build-native.yml
+++ b/.github/workflows/bakery-build-native.yml
@@ -399,15 +399,6 @@ jobs:
             --push \
             --summary --summary-format json \
             > "./${IMAGE_NAME}-${IMAGE_VERSION}-${NORMALIZED_PLATFORM}-summary.json"
-      - name: Render Build Summary
-        env:
-          IMAGE_NAME: ${{ matrix.img.image }}
-          IMAGE_VERSION: ${{ matrix.img.version }}
-          NORMALIZED_PLATFORM: ${{ steps.normalize-platform.outputs.platform }}
-        run: |
-          bakery ci summary "./${IMAGE_NAME}-${IMAGE_VERSION}-${NORMALIZED_PLATFORM}-summary.json" \
-            --output job-summary.md
-          cat job-summary.md >> "$GITHUB_STEP_SUMMARY"
       - name: Upload Build Summary
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
@@ -632,12 +623,6 @@ jobs:
             --summary --summary-format json \
             ./*-metadata.json \
             > "./${IMAGE_NAME}-publish-summary.json"
-      - name: Render Publish Summary
-        env:
-          IMAGE_NAME: ${{ matrix.image }}
-        run: |
-          bakery ci summary "./${IMAGE_NAME}-publish-summary.json" --output job-summary.md
-          cat job-summary.md >> "$GITHUB_STEP_SUMMARY"
       - name: Upload Publish Summary
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:

--- a/.github/workflows/bakery-build-native.yml
+++ b/.github/workflows/bakery-build-native.yml
@@ -396,7 +396,25 @@ jobs:
             --temp-registry "$TEMP_REGISTRY" \
             --metadata-file "./${IMAGE_NAME}-${IMAGE_VERSION}-${NORMALIZED_PLATFORM}-metadata.json" \
             --context "$CONTEXT" \
-            --push
+            --push \
+            --summary --summary-format json \
+            > "./${IMAGE_NAME}-${IMAGE_VERSION}-${NORMALIZED_PLATFORM}-summary.json"
+      - name: Render Build Summary
+        env:
+          IMAGE_NAME: ${{ matrix.img.image }}
+          IMAGE_VERSION: ${{ matrix.img.version }}
+          NORMALIZED_PLATFORM: ${{ steps.normalize-platform.outputs.platform }}
+        run: |
+          bakery ci summary "./${IMAGE_NAME}-${IMAGE_VERSION}-${NORMALIZED_PLATFORM}-summary.json" \
+            --output job-summary.md
+          cat job-summary.md >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload Build Summary
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: "${{ matrix.img.image }}-${{ matrix.img.version }}-${{ steps.normalize-platform.outputs.platform }}-summary"
+          path: "./${{ matrix.img.image }}-${{ matrix.img.version }}-${{ steps.normalize-platform.outputs.platform }}-summary.json"
+          retention-days: 3
+          overwrite: 'true'
       - name: Test
         env:
           IMAGE_NAME: ${{ matrix.img.image }}
@@ -611,7 +629,70 @@ jobs:
             --temp-registry "$TEMP_REGISTRY" \
             "${DEV_SPEC_FLAGS[@]}" \
             $PUSH_FLAG \
-            ./*-metadata.json
+            --summary --summary-format json \
+            ./*-metadata.json \
+            > "./${IMAGE_NAME}-publish-summary.json"
+      - name: Render Publish Summary
+        env:
+          IMAGE_NAME: ${{ matrix.image }}
+        run: |
+          bakery ci summary "./${IMAGE_NAME}-publish-summary.json" --output job-summary.md
+          cat job-summary.md >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload Publish Summary
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: "${{ matrix.image }}-publish-summary"
+          path: "./${{ matrix.image }}-publish-summary.json"
+          retention-days: 3
+          overwrite: 'true'
+
+  summary:
+    name: Build Summary
+    permissions: {}
+    needs: [matrix, build-test, merge]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup bakery
+        uses: "posit-dev/images-shared/setup-bakery@main"
+        with:
+          version: ${{ inputs.version }}
+
+      - name: Download Build Summaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          pattern: "*-summary"
+          merge-multiple: true
+
+      - name: Render Combined Summary
+        env:
+          BUILD_TEST_RESULT: ${{ needs.build-test.result }}
+          MERGE_RESULT: ${{ needs.merge.result }}
+        run: |
+          DISCLAIMER=""
+          if [ "$BUILD_TEST_RESULT" = "failure" ] || [ "$BUILD_TEST_RESULT" = "cancelled" ] \
+             || [ "$MERGE_RESULT" = "failure" ] || [ "$MERGE_RESULT" = "cancelled" ]; then
+            DISCLAIMER="One or more builds failed or were cancelled. This summary reflects only the targets that completed and is not a complete picture of this run."
+          fi
+          shopt -s nullglob
+          FILES=(./*-summary.json)
+          if [ ${#FILES[@]} -eq 0 ]; then
+            echo "No build summaries were produced for this run." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          if [ -n "$DISCLAIMER" ]; then
+            bakery ci summary "${FILES[@]}" --output summary.md --disclaimer "$DISCLAIMER"
+          else
+            bakery ci summary "${FILES[@]}" --output summary.md
+          fi
+          cat summary.md >> "$GITHUB_STEP_SUMMARY"
 
   readme:
     name: Push READMEs

--- a/.github/workflows/bakery-build-pr.yml
+++ b/.github/workflows/bakery-build-pr.yml
@@ -290,16 +290,6 @@ jobs:
             --summary --summary-format json \
             > "./${IMAGE_NAME}-${IMAGE_VERSION}-${NORMALIZED_PLATFORM}-summary.json"
 
-      - name: Render Build Summary
-        env:
-          IMAGE_NAME: ${{ matrix.img.image }}
-          IMAGE_VERSION: ${{ matrix.img.version }}
-          NORMALIZED_PLATFORM: ${{ steps.normalize-platform.outputs.platform }}
-        run: |
-          bakery ci summary "./${IMAGE_NAME}-${IMAGE_VERSION}-${NORMALIZED_PLATFORM}-summary.json" \
-            --output job-summary.md
-          cat job-summary.md >> "$GITHUB_STEP_SUMMARY"
-
       - name: Upload Build Summary
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:

--- a/.github/workflows/bakery-build-pr.yml
+++ b/.github/workflows/bakery-build-pr.yml
@@ -290,10 +290,22 @@ jobs:
             --summary --summary-format json \
             > "./${IMAGE_NAME}-${IMAGE_VERSION}-${NORMALIZED_PLATFORM}-summary.json"
 
+      # See the identical step in bakery-build-native.yml's build-test job for why this
+      # hash exists: it distinguishes this call's artifacts from a sibling call's when a
+      # caller invokes this workflow more than once in the same run (this workflow's own
+      # pr.yml callers already do exactly that, once for "production" and once for
+      # "development").
+      - name: Compute artifact scope
+        id: artifact-scope
+        env:
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: |
+          echo "hash=$(printf '%s' "$INPUTS_JSON" | sha256sum | cut -c1-12)" >> "$GITHUB_OUTPUT"
+
       - name: Upload Build Summary
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: "${{ matrix.img.image }}-${{ matrix.img.version }}-${{ steps.normalize-platform.outputs.platform }}-summary"
+          name: "${{ steps.artifact-scope.outputs.hash }}-${{ matrix.img.image }}-${{ matrix.img.version }}-${{ steps.normalize-platform.outputs.platform }}-summary"
           path: "./${{ matrix.img.image }}-${{ matrix.img.version }}-${{ steps.normalize-platform.outputs.platform }}-summary.json"
           retention-days: 3
           overwrite: 'true'
@@ -361,10 +373,17 @@ jobs:
         with:
           version: ${{ inputs.version }}
 
+      - name: Compute artifact scope
+        id: artifact-scope
+        env:
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: |
+          echo "hash=$(printf '%s' "$INPUTS_JSON" | sha256sum | cut -c1-12)" >> "$GITHUB_OUTPUT"
+
       - name: Download Build Summaries
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
-          pattern: "*-summary"
+          pattern: "${{ steps.artifact-scope.outputs.hash }}-*-summary"
           merge-multiple: true
 
       - name: Render Combined Summary

--- a/.github/workflows/bakery-build-pr.yml
+++ b/.github/workflows/bakery-build-pr.yml
@@ -265,6 +265,7 @@ jobs:
           BAKERY_CONTEXT: ${{ inputs.context }}
           CACHE_REGISTRY: ${{ inputs.cache-registry || format('ghcr.io/{0}', github.repository_owner) }}
           CACHE: ${{ inputs.cache }}
+          NORMALIZED_PLATFORM: ${{ steps.normalize-platform.outputs.platform }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ "$IMG_DEV" = "true" ]; then
@@ -285,7 +286,27 @@ jobs:
             --dev-versions "$DEV_VERSIONS" \
             --matrix-versions "$MATRIX_VERSIONS" \
             "${CACHE_FLAGS[@]}" \
-            --context "$BAKERY_CONTEXT"
+            --context "$BAKERY_CONTEXT" \
+            --summary --summary-format json \
+            > "./${IMAGE_NAME}-${IMAGE_VERSION}-${NORMALIZED_PLATFORM}-summary.json"
+
+      - name: Render Build Summary
+        env:
+          IMAGE_NAME: ${{ matrix.img.image }}
+          IMAGE_VERSION: ${{ matrix.img.version }}
+          NORMALIZED_PLATFORM: ${{ steps.normalize-platform.outputs.platform }}
+        run: |
+          bakery ci summary "./${IMAGE_NAME}-${IMAGE_VERSION}-${NORMALIZED_PLATFORM}-summary.json" \
+            --output job-summary.md
+          cat job-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Build Summary
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: "${{ matrix.img.image }}-${{ matrix.img.version }}-${{ steps.normalize-platform.outputs.platform }}-summary"
+          path: "./${{ matrix.img.image }}-${{ matrix.img.version }}-${{ steps.normalize-platform.outputs.platform }}-summary.json"
+          retention-days: 3
+          overwrite: 'true'
 
       - name: Test
         env:
@@ -330,3 +351,49 @@ jobs:
             exit 1
           fi
           echo "build-test result: $RESULT (ok)"
+
+  summary:
+    name: Build Summary
+    permissions: {}
+    needs: [matrix, build-test]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install
+        uses: "posit-dev/images-shared/setup-bakery@main"
+        with:
+          version: ${{ inputs.version }}
+
+      - name: Download Build Summaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          pattern: "*-summary"
+          merge-multiple: true
+
+      - name: Render Combined Summary
+        env:
+          BUILD_TEST_RESULT: ${{ needs.build-test.result }}
+        run: |
+          DISCLAIMER=""
+          if [ "$BUILD_TEST_RESULT" = "failure" ] || [ "$BUILD_TEST_RESULT" = "cancelled" ]; then
+            DISCLAIMER="One or more builds failed or were cancelled. This summary reflects only the targets that completed and is not a complete picture of this run."
+          fi
+          shopt -s nullglob
+          FILES=(./*-summary.json)
+          if [ ${#FILES[@]} -eq 0 ]; then
+            echo "No build summaries were produced for this run." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          if [ -n "$DISCLAIMER" ]; then
+            bakery ci summary "${FILES[@]}" --output summary.md --disclaimer "$DISCLAIMER"
+          else
+            bakery ci summary "${FILES[@]}" --output summary.md
+          fi
+          cat summary.md >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/bakery-build.yml
+++ b/.github/workflows/bakery-build.yml
@@ -376,10 +376,20 @@ jobs:
             --summary --summary-format json \
             > "./${IMAGE_NAME}-${IMAGE_VERSION}-push-summary.json"
 
+      # See the identical step in bakery-build-native.yml's build-test job for why this
+      # hash exists: it distinguishes this call's artifacts from a sibling call's when a
+      # caller invokes this workflow more than once in the same run.
+      - name: Compute artifact scope
+        id: artifact-scope
+        env:
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: |
+          echo "hash=$(printf '%s' "$INPUTS_JSON" | sha256sum | cut -c1-12)" >> "$GITHUB_OUTPUT"
+
       - name: Upload Build Summary
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: "${{ matrix.img.image }}-${{ matrix.img.version }}-summary"
+          name: "${{ steps.artifact-scope.outputs.hash }}-${{ matrix.img.image }}-${{ matrix.img.version }}-summary"
           path: |
             ./${{ matrix.img.image }}-${{ matrix.img.version }}-build-summary.json
             ./${{ matrix.img.image }}-${{ matrix.img.version }}-push-summary.json
@@ -406,10 +416,17 @@ jobs:
         with:
           version: ${{ inputs.version }}
 
+      - name: Compute artifact scope
+        id: artifact-scope
+        env:
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: |
+          echo "hash=$(printf '%s' "$INPUTS_JSON" | sha256sum | cut -c1-12)" >> "$GITHUB_OUTPUT"
+
       - name: Download Build Summaries
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
-          pattern: "*-summary"
+          pattern: "${{ steps.artifact-scope.outputs.hash }}-*-summary"
           merge-multiple: true
 
       - name: Render Combined Summary

--- a/.github/workflows/bakery-build.yml
+++ b/.github/workflows/bakery-build.yml
@@ -321,7 +321,9 @@ jobs:
             --matrix-versions "$MATRIX_VERSIONS" \
             "${CACHE_FLAGS[@]}" \
             "${DEV_SPEC_FLAGS[@]}" \
-            --context "$CONTEXT"
+            --context "$CONTEXT" \
+            --summary --summary-format json \
+            > "./${IMAGE_NAME}-${IMAGE_VERSION}-build-summary.json"
 
       - name: Test
         env:
@@ -370,7 +372,79 @@ jobs:
             --dev-versions "$DEV_VERSIONS" \
             --matrix-versions "$MATRIX_VERSIONS" \
             "${DEV_SPEC_FLAGS[@]}" \
-            --context "$CONTEXT"
+            --context "$CONTEXT" \
+            --summary --summary-format json \
+            > "./${IMAGE_NAME}-${IMAGE_VERSION}-push-summary.json"
+
+      - name: Render Build Summary
+        env:
+          IMAGE_NAME: ${{ matrix.img.image }}
+          IMAGE_VERSION: ${{ matrix.img.version }}
+          PUSH: ${{ inputs.push }}
+        run: |
+          FILES=("./${IMAGE_NAME}-${IMAGE_VERSION}-build-summary.json")
+          if [ "$PUSH" = "true" ]; then
+            FILES+=("./${IMAGE_NAME}-${IMAGE_VERSION}-push-summary.json")
+          fi
+          bakery ci summary "${FILES[@]}" --output job-summary.md
+          cat job-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Build Summary
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: "${{ matrix.img.image }}-${{ matrix.img.version }}-summary"
+          path: |
+            ./${{ matrix.img.image }}-${{ matrix.img.version }}-build-summary.json
+            ./${{ matrix.img.image }}-${{ matrix.img.version }}-push-summary.json
+          if-no-files-found: ignore
+          retention-days: 3
+          overwrite: 'true'
+
+  summary:
+    name: Build Summary
+    permissions: {}
+    needs: [matrix, build]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup bakery
+        uses: "posit-dev/images-shared/setup-bakery@main"
+        with:
+          version: ${{ inputs.version }}
+
+      - name: Download Build Summaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          pattern: "*-summary"
+          merge-multiple: true
+
+      - name: Render Combined Summary
+        env:
+          BUILD_RESULT: ${{ needs.build.result }}
+        run: |
+          DISCLAIMER=""
+          if [ "$BUILD_RESULT" = "failure" ] || [ "$BUILD_RESULT" = "cancelled" ]; then
+            DISCLAIMER="One or more builds failed or were cancelled. This summary reflects only the targets that completed and is not a complete picture of this run."
+          fi
+          shopt -s nullglob
+          FILES=(./*-summary.json)
+          if [ ${#FILES[@]} -eq 0 ]; then
+            echo "No build summaries were produced for this run." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          if [ -n "$DISCLAIMER" ]; then
+            bakery ci summary "${FILES[@]}" --output summary.md --disclaimer "$DISCLAIMER"
+          else
+            bakery ci summary "${FILES[@]}" --output summary.md
+          fi
+          cat summary.md >> "$GITHUB_STEP_SUMMARY"
 
   readme:
     name: Push READMEs

--- a/.github/workflows/bakery-build.yml
+++ b/.github/workflows/bakery-build.yml
@@ -376,19 +376,6 @@ jobs:
             --summary --summary-format json \
             > "./${IMAGE_NAME}-${IMAGE_VERSION}-push-summary.json"
 
-      - name: Render Build Summary
-        env:
-          IMAGE_NAME: ${{ matrix.img.image }}
-          IMAGE_VERSION: ${{ matrix.img.version }}
-          PUSH: ${{ inputs.push }}
-        run: |
-          FILES=("./${IMAGE_NAME}-${IMAGE_VERSION}-build-summary.json")
-          if [ "$PUSH" = "true" ]; then
-            FILES+=("./${IMAGE_NAME}-${IMAGE_VERSION}-push-summary.json")
-          fi
-          bakery ci summary "${FILES[@]}" --output job-summary.md
-          cat job-summary.md >> "$GITHUB_STEP_SUMMARY"
-
       - name: Upload Build Summary
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:

--- a/CI.md
+++ b/CI.md
@@ -76,7 +76,7 @@ Order (applied identically to the weekly Sunday window and the daily window): `i
 
 ## `bakery-build-native.yml`
 
-Builds, tests, and pushes images on native hardware. Each `{image, version, platform}` combination builds on its own runner and pushes to a temporary GHCR registry. A `merge` job then combines them into multi-platform manifests using `bakery ci merge`, and a `readme` job pushes Docker Hub READMEs after a successful push.
+Builds, tests, and pushes images on native hardware. Each `{image, version, platform}` combination builds on its own runner and pushes to a temporary GHCR registry. A `merge` job then combines them into multi-platform manifests using `bakery ci publish` (the `bakery ci merge` alias still works), and a `readme` job pushes Docker Hub READMEs after a successful push. A `summary` job always runs last -- even if a build or the merge failed -- and merges every job's `--summary` artifact into one report on the run's Summary page.
 
 ### Inputs
 
@@ -145,27 +145,37 @@ flowchart TD
     end
     subgraph build_amd64[Build/Test amd64]
         a_setup[Checkout + bakery + goss + docker + buildx + oras] --> a_login[Login GHCR/DH/ECR]
-        a_login --> a_build["bakery build --strategy build<br/>--push to temp registry"]
-        a_build --> a_test["bakery dgoss run"]
+        a_login --> a_build["bakery build --strategy build<br/>--push to temp registry --summary"]
+        a_build --> a_sum[Upload build summary artifact]
+        a_sum --> a_test["bakery dgoss run"]
         a_test --> a_meta[Upload metadata artifact]
     end
     subgraph build_arm64[Build/Test arm64]
         r_setup[Checkout + bakery + goss + docker + buildx + oras] --> r_login[Login GHCR/DH/ECR]
-        r_login --> r_build["bakery build --strategy build<br/>--push to temp registry"]
-        r_build --> r_test["bakery dgoss run"]
+        r_login --> r_build["bakery build --strategy build<br/>--push to temp registry --summary"]
+        r_build --> r_sum[Upload build summary artifact]
+        r_sum --> r_test["bakery dgoss run"]
         r_test --> r_meta[Upload metadata artifact]
     end
     subgraph merge[Merge / Push]
-        m_dl[Download metadata] --> m_merge["bakery ci merge<br/>(--dry-run unless push=true)"]
+        m_dl[Download metadata] --> m_merge["bakery ci publish --summary<br/>(--dry-run unless push=true)"]
+        m_merge --> m_pubsum[Upload publish summary artifact]
     end
     subgraph readme[Push READMEs]
         r_run["bakery ci readme<br/>(only when push=true)"]
+    end
+    subgraph summary[Build Summary]
+        s_dl[Download every summary artifact] --> s_render["bakery ci summary<br/>(disclaimer if a job failed)"]
+        s_render --> s_post[Append to GITHUB_STEP_SUMMARY]
     end
     m_matrix -.->|"per platform"| build_amd64
     m_matrix -.->|"per platform"| build_arm64
     a_meta --> m_dl
     r_meta --> m_dl
     m_merge --> r_run
+    a_sum -.-> s_dl
+    r_sum -.-> s_dl
+    m_pubsum -.-> s_dl
 ```
 
 ## `bakery-build.yml`
@@ -203,22 +213,29 @@ flowchart TD
     end
     subgraph build[Build / Test / Push]
         b_setup[Checkout + bakery + goss + QEMU + buildx] --> b_login[Login GHCR/DH/ECR]
-        b_login --> b_build["bakery build --load --pull"]
+        b_login --> b_build["bakery build --load --pull --summary"]
         b_build --> b_test["bakery dgoss run"]
         b_test --> b_push{"push=true?"}
-        b_push -- yes --> b_pushrun["bakery build --push"]
+        b_push -- yes --> b_pushrun["bakery build --push --summary"]
         b_push -- no --> b_skip[skip]
+        b_pushrun --> b_sum[Upload build summary artifact]
+        b_skip --> b_sum
     end
     subgraph readme[Push READMEs]
         r_run["bakery ci readme<br/>(only when push=true)"]
     end
+    subgraph summary[Build Summary]
+        s_dl[Download every summary artifact] --> s_render["bakery ci summary<br/>(disclaimer if a job failed)"]
+        s_render --> s_post[Append to GITHUB_STEP_SUMMARY]
+    end
     m_matrix -.->|"per image version"| build
     b_pushrun --> r_run
+    b_sum -.-> s_dl
 ```
 
 ## `bakery-build-pr.yml`
 
-Fork-safe variant for pull requests. Inherits only `GITHUB_TOKEN`, never pushes, and skips arm64 jobs on fork PRs (paid arm64 runners might not be available). Runs the same build + dgoss test on each `{image, version, platform}` combination.
+Fork-safe variant for pull requests. Inherits only `GITHUB_TOKEN`, never pushes, and skips arm64 jobs on fork PRs (paid arm64 runners might not be available). Runs the same build + dgoss test on each `{image, version, platform}` combination. This workflow never pushes to a final registry, so its `summary` job never has a registry size to report -- only build counts, layers, local size, and cache size.
 
 ### Inputs
 

--- a/posit-bakery/posit_bakery/cli/ci.py
+++ b/posit-bakery/posit_bakery/cli/ci.py
@@ -15,7 +15,7 @@ from posit_bakery.config.changeset import classify_changes, classify_bakery_yaml
 from posit_bakery.config.config import BakerySettings, BakeryConfigFilter, version_matches
 from posit_bakery.config.image.posit_product.const import ReleaseChannelEnum
 from posit_bakery.config.image.version import ImageVersion
-from posit_bakery.const import DevVersionInclusionEnum, MatrixVersionInclusionEnum
+from posit_bakery.const import DevVersionInclusionEnum, MatrixVersionInclusionEnum, SummaryOutputFormat
 from posit_bakery.image import BuildSummary
 from posit_bakery.log import stderr_console, stdout_console
 from posit_bakery.registry_management.dockerhub.readme import find_oversized_readmes, push_readmes
@@ -507,6 +507,22 @@ def publish(
             callback=parse_dev_spec,
         ),
     ] = None,
+    summary: Annotated[
+        Optional[bool],
+        typer.Option(
+            "--summary",
+            help="After publishing, report per-target sizes and layer counts alongside build/tag counts.",
+            rich_help_panel=RichHelpPanelEnum.FILTERS,
+        ),
+    ] = False,
+    summary_format: Annotated[
+        Optional[SummaryOutputFormat],
+        typer.Option(
+            "--summary-format",
+            help="Output format for --summary. 'table' prints to stderr; 'json' prints to stdout.",
+            rich_help_panel=RichHelpPanelEnum.FILTERS,
+        ),
+    ] = SummaryOutputFormat.TABLE,
 ) -> None:
     """Publish multi-platform images by composing oras index-create →
     soci-convert → oras index-copy.
@@ -542,6 +558,8 @@ def publish(
         dev_channel=dev_channel,
         dev_spec=dev_spec,
         jobs=jobs,
+        summary=summary,
+        summary_format=summary_format,
     )
 
 

--- a/posit-bakery/posit_bakery/cli/ci.py
+++ b/posit-bakery/posit_bakery/cli/ci.py
@@ -16,6 +16,7 @@ from posit_bakery.config.config import BakerySettings, BakeryConfigFilter, versi
 from posit_bakery.config.image.posit_product.const import ReleaseChannelEnum
 from posit_bakery.config.image.version import ImageVersion
 from posit_bakery.const import DevVersionInclusionEnum, MatrixVersionInclusionEnum
+from posit_bakery.image import BuildSummary
 from posit_bakery.log import stderr_console, stdout_console
 from posit_bakery.registry_management.dockerhub.readme import find_oversized_readmes, push_readmes
 from posit_bakery.util import auto_path
@@ -641,3 +642,32 @@ def readme(
         stderr_console.print(f"✅ Pushed {count} README(s) to Docker Hub", style="success")
     else:
         stderr_console.print("No READMEs pushed", style="dim")
+
+
+@app.command()
+@with_verbosity_flags
+def summary(
+    summary_file: Annotated[
+        list[Path],
+        typer.Argument(
+            help="Path to one or more `--summary-format json` files from `bakery build --summary` or `bakery ci publish --summary`."
+        ),
+    ],
+    output: Annotated[Path, typer.Option("--output", help="Path to write the combined Markdown report to.")],
+    disclaimer: Annotated[
+        Optional[str],
+        typer.Option(
+            "--disclaimer",
+            help="If set, prepended to the report as a warning banner (e.g. when an upstream job failed).",
+        ),
+    ] = None,
+) -> None:
+    """Merge one or more `--summary-format json` files into a single GitHub-Flavored
+    Markdown report, suitable for `$GITHUB_STEP_SUMMARY`.
+
+    Multiple files describing the same target (e.g. one file per platform for a
+    multi-platform target) are combined, not concatenated -- see `BuildSummary.merge()`.
+    """
+    summaries = [BuildSummary.from_json_file(f) for f in summary_file]
+    combined = BuildSummary.merge(summaries)
+    output.write_text(combined.to_markdown(disclaimer=disclaimer))

--- a/posit-bakery/posit_bakery/cli/ci.py
+++ b/posit-bakery/posit_bakery/cli/ci.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Annotated, Optional
 
 import typer
+from pydantic import ValidationError
 
 from posit_bakery.cli.common import with_verbosity_flags, parse_dev_spec
 from posit_bakery.config import BakeryConfig
@@ -685,7 +686,17 @@ def summary(
 
     Multiple files describing the same target (e.g. one file per platform for a
     multi-platform target) are combined, not concatenated -- see `BuildSummary.merge()`.
+
+    A file that can't be read or parsed is skipped with a warning rather than raising --
+    this command is a best-effort report on top of an otherwise-passing build, run under
+    GitHub Actions' default `bash -eo pipefail` shell with no `continue-on-error`, so an
+    uncaught exception here would fail the whole job over a report, not a build.
     """
-    summaries = [BuildSummary.from_json_file(f) for f in summary_file]
+    summaries = []
+    for f in summary_file:
+        try:
+            summaries.append(BuildSummary.from_json_file(f))
+        except (OSError, json.JSONDecodeError, ValidationError) as e:
+            stderr_console.print(f"⚠️  Skipping unreadable summary file '{f}': {e}")
     combined = BuildSummary.merge(summaries)
     output.write_text(combined.to_markdown(disclaimer=disclaimer))

--- a/posit-bakery/posit_bakery/image/summary.py
+++ b/posit-bakery/posit_bakery/image/summary.py
@@ -515,3 +515,65 @@ class BuildSummary(BaseModel):
                 ),
             ],
         )
+
+    def to_markdown(self, *, disclaimer: str | None = None) -> str:
+        """Renders this summary as a GitHub-Flavored Markdown report, for a GitHub job or
+        run summary. Always renders the full per-target breakdown -- a summary page reader
+        wants the detail, not just the three aggregate counts a terminal caller sees by
+        default without `--summary-format table`'s sizes view.
+
+        :param disclaimer: If given, prepended as a warning-styled blockquote ahead of the
+            table -- e.g. "this run had failures, so these totals are incomplete."
+        """
+        lines: list[str] = []
+        if disclaimer:
+            lines.append(f"> ⚠️ **{disclaimer}**")
+            lines.append("")
+        lines.append("### Build Summary")
+        lines.append("")
+        header = [
+            "Image",
+            "Version",
+            "OS",
+            "Variant",
+            "Platforms",
+            "Tags",
+            "Layers",
+            "Registry Size",
+            "Local Size",
+            "Cache Size",
+        ]
+        lines.append("| " + " | ".join(header) + " |")
+        lines.append("|" + "|".join(["---"] * len(header)) + "|")
+
+        sorted_targets = sorted(self.targets, key=lambda t: (t.image_name, t.version, t.os, t.variant))
+        for t in sorted_targets:
+            lines.append(
+                "| "
+                + " | ".join(
+                    [
+                        t.image_name,
+                        t.version,
+                        t.os,
+                        t.variant,
+                        str(t.platforms),
+                        str(t.tags),
+                        str(t.layers) if t.layers is not None else DASH,
+                        format_size(t.registry_size) if t.registry_size is not None else DASH,
+                        format_size(t.local_size) if t.local_size is not None else DASH,
+                        format_size(t.cache_size) if t.cache_size is not None else DASH,
+                    ]
+                )
+                + " |"
+            )
+
+        total_platforms = sum(t.platforms for t in sorted_targets)
+        total_tags = sum(t.tags for t in sorted_targets)
+        lines.append(
+            f"| **Total ({len(sorted_targets)} targets)** | | | | "
+            f"**{total_platforms}** | **{total_tags}** | | "
+            f"**{_total_bytes([t.registry_size for t in sorted_targets])}** | "
+            f"**{_total_bytes([t.local_size for t in sorted_targets])}** | "
+            f"**{_total_bytes(_deduped_cache_sizes(sorted_targets))}** |"
+        )
+        return "\n".join(lines) + "\n"

--- a/posit-bakery/posit_bakery/image/summary.py
+++ b/posit-bakery/posit_bakery/image/summary.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from pathlib import Path
 from typing import Any, Self
 
 import python_on_whales
@@ -179,6 +180,21 @@ def _sum_or_none(values: list[int | None]) -> int | None:
     return sum(known) if known else None
 
 
+def _combine_optional(a: int | None, b: int | None) -> int | None:
+    """Sums two optional platform-scoped values: `None` only when both are `None` --
+    matches `_sum_or_none`'s "unmeasured, not zero" rule for a two-value merge."""
+    if a is None and b is None:
+        return None
+    return (a or 0) + (b or 0)
+
+
+def _first_non_none(a: Any, b: Any) -> Any:
+    """The first non-`None` of two identity-field values -- used for fields that must
+    never be summed across platform slices of the same target (tags, layers, cache_ref,
+    cache_size), since they describe the whole manifest, not one platform's share of it."""
+    return a if a is not None else b
+
+
 def _total_bytes(values: list[int | None]) -> str:
     total = _sum_or_none(values)
     return format_size(total) if total is not None else DASH
@@ -266,13 +282,71 @@ class BuildSummary(BaseModel):
         ]
 
         return cls(
-            rows=[
-                BuildSummaryRow(key="build_targets", label="Build Targets", value=len(targets)),
-                BuildSummaryRow(key="platform_builds", label="Platform Builds", value=sum(platform_counts)),
-                BuildSummaryRow(key="registry_tags", label="Registry Tags", value=registry_tags),
-            ],
+            rows=cls._aggregate_rows(target_rows),
             targets=target_rows,
         )
+
+    @staticmethod
+    def _aggregate_rows(targets: list[BuildSummaryTarget]) -> list[BuildSummaryRow]:
+        """The three aggregate rows, derived from a target list -- the single source of
+        truth `from_image_targets`, `from_json_file`, and `merge` all share."""
+        return [
+            BuildSummaryRow(key="build_targets", label="Build Targets", value=len(targets)),
+            BuildSummaryRow(key="platform_builds", label="Platform Builds", value=sum(t.platforms for t in targets)),
+            BuildSummaryRow(key="registry_tags", label="Registry Tags", value=sum(t.tags for t in targets)),
+        ]
+
+    @classmethod
+    def from_json_file(cls, path: Path) -> Self:
+        """Reconstructs a `BuildSummary` from a file written by `--summary-format json`
+        (either `bakery build` or `bakery ci publish`).
+
+        Rebuilds `targets` from the dumped `targets` list and recomputes the three
+        aggregate rows from that list, rather than trusting the file's own top-level
+        counts -- keeps a single source of truth for how aggregates are derived, shared
+        with `merge()` below.
+        """
+        data = json.loads(path.read_text())
+        targets = [BuildSummaryTarget(**t) for t in data.get("targets", [])]
+        return cls(rows=cls._aggregate_rows(targets), targets=targets)
+
+    @classmethod
+    def merge(cls, summaries: list[Self]) -> Self:
+        """Combines multiple summaries into one, deduped by `BuildSummaryTarget.uid`.
+
+        `uid` has no platform component, so the same uid can appear in more than one
+        input summary -- e.g. one JSON file per platform for a multi-platform target, or
+        a build-time file and a separate publish-time file for the same target. Slices
+        sharing a uid are folded into a single row:
+
+        - `platforms`, `registry_size`, `local_size` are summed: each slice reports only
+          what it measured (its own platform's share), so summing reconstructs the true
+          total, the same way a single combined multi-platform registry inspect already
+          sums across manifest children internally.
+        - `tags`, `layers`, `cache_ref`, `cache_size` take the first non-`None` value
+          across a uid's slices -- they describe the whole manifest, not one platform's
+          share, so summing them would be wrong (and, for `cache_size`, would double-count
+          a cache tag shared by more than one platform slice).
+
+        Aggregate rows are recomputed from the merged, deduped-by-uid target list --
+        never by summing each input's own aggregate rows, which would double-count any
+        uid appearing in more than one input.
+        """
+        merged: dict[str, BuildSummaryTarget] = {}
+        for summary in summaries:
+            for target in summary.targets:
+                if target.uid not in merged:
+                    merged[target.uid] = target.model_copy(deep=True)
+                    continue
+                base = merged[target.uid]
+                base.platforms += target.platforms
+                base.registry_size = _combine_optional(base.registry_size, target.registry_size)
+                base.local_size = _combine_optional(base.local_size, target.local_size)
+                base.layers = _first_non_none(base.layers, target.layers)
+                base.cache_ref = _first_non_none(base.cache_ref, target.cache_ref)
+                base.cache_size = _first_non_none(base.cache_size, target.cache_size)
+        merged_targets = list(merged.values())
+        return cls(rows=cls._aggregate_rows(merged_targets), targets=merged_targets)
 
     def as_dict(self) -> dict[str, Any]:
         """Flatten to a CI-friendly dict for `--summary-format json`.

--- a/posit-bakery/posit_bakery/image/summary.py
+++ b/posit-bakery/posit_bakery/image/summary.py
@@ -195,6 +195,17 @@ def _first_non_none(a: Any, b: Any) -> Any:
     return a if a is not None else b
 
 
+def _md_row(cells: list[str]) -> str:
+    """One Markdown table row from a list of cell strings.
+
+    The single place that joins cells with pipes for `to_markdown()` -- shared by the
+    header, every per-target row, and the total row, so a column added to one can't
+    silently drift out of alignment with the others the way three independently
+    hand-built pipe strings could.
+    """
+    return "| " + " | ".join(cells) + " |"
+
+
 def _total_bytes(values: list[int | None]) -> str:
     total = _sum_or_none(values)
     return format_size(total) if total is not None else DASH
@@ -543,37 +554,42 @@ class BuildSummary(BaseModel):
             "Local Size",
             "Cache Size",
         ]
-        lines.append("| " + " | ".join(header) + " |")
+        lines.append(_md_row(header))
         lines.append("|" + "|".join(["---"] * len(header)) + "|")
 
         sorted_targets = sorted(self.targets, key=lambda t: (t.image_name, t.version, t.os, t.variant))
-        for t in sorted_targets:
-            lines.append(
-                "| "
-                + " | ".join(
-                    [
-                        t.image_name,
-                        t.version,
-                        t.os,
-                        t.variant,
-                        str(t.platforms),
-                        str(t.tags),
-                        str(t.layers) if t.layers is not None else DASH,
-                        format_size(t.registry_size) if t.registry_size is not None else DASH,
-                        format_size(t.local_size) if t.local_size is not None else DASH,
-                        format_size(t.cache_size) if t.cache_size is not None else DASH,
-                    ]
-                )
-                + " |"
+        lines += [
+            _md_row(
+                [
+                    t.image_name,
+                    t.version,
+                    t.os,
+                    t.variant,
+                    str(t.platforms),
+                    str(t.tags),
+                    str(t.layers) if t.layers is not None else DASH,
+                    format_size(t.registry_size) if t.registry_size is not None else DASH,
+                    format_size(t.local_size) if t.local_size is not None else DASH,
+                    format_size(t.cache_size) if t.cache_size is not None else DASH,
+                ]
             )
+            for t in sorted_targets
+        ]
 
-        total_platforms = sum(t.platforms for t in sorted_targets)
-        total_tags = sum(t.tags for t in sorted_targets)
         lines.append(
-            f"| **Total ({len(sorted_targets)} targets)** | | | | "
-            f"**{total_platforms}** | **{total_tags}** | | "
-            f"**{_total_bytes([t.registry_size for t in sorted_targets])}** | "
-            f"**{_total_bytes([t.local_size for t in sorted_targets])}** | "
-            f"**{_total_bytes(_deduped_cache_sizes(sorted_targets))}** |"
+            _md_row(
+                [
+                    f"**Total ({len(sorted_targets)} targets)**",
+                    "",
+                    "",
+                    "",
+                    f"**{sum(t.platforms for t in sorted_targets)}**",
+                    f"**{sum(t.tags for t in sorted_targets)}**",
+                    "",
+                    f"**{_total_bytes([t.registry_size for t in sorted_targets])}**",
+                    f"**{_total_bytes([t.local_size for t in sorted_targets])}**",
+                    f"**{_total_bytes(_deduped_cache_sizes(sorted_targets))}**",
+                ]
+            )
         )
         return "\n".join(lines) + "\n"

--- a/posit-bakery/posit_bakery/plugins/builtin/imagetools/imagetools.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/imagetools/imagetools.py
@@ -538,6 +538,8 @@ class ImageToolsPlugin(BakeryToolPlugin):
         dev_channel: Any = None,
         dev_spec: Any = None,
         jobs: int | None = None,
+        summary: bool = False,
+        summary_format: Any = None,
     ) -> None:
         """Publish multi-platform images by composing wait -> index-create -> soci-convert ->
         index-copy -> verify.
@@ -709,8 +711,38 @@ class ImageToolsPlugin(BakeryToolPlugin):
         # place; they are cleaned up out-of-band by the clean.yml workflow (bakery clean
         # temp-registry) rather than deleted here.
 
+        def _emit_publish_summary() -> None:
+            # Imported locally: this whole block only runs when --summary is set, and
+            # BuildSummary/SummaryOutputFormat/console imports are otherwise unused by
+            # publish()'s normal path.
+            from posit_bakery.const import SummaryOutputFormat
+            from posit_bakery.image import BuildSummary
+            from posit_bakery.log import stderr_console, stdout_console
+
+            build_summary = BuildSummary.from_image_targets(targets)
+            build_summary.measure_sizes(
+                targets,
+                push=not dry_run,
+                load=False,
+                jobs=jobs,
+                succeeded_uids={t.uid for t in copied_targets},
+            )
+            fmt = summary_format or SummaryOutputFormat.TABLE
+            if fmt == SummaryOutputFormat.JSON:
+                stdout_console.print_json(data=build_summary.as_dict())
+            else:
+                stderr_console.print(build_summary.table(sizes=True))
+
         if stage1_failed or copy_failed or verify_failed:
             log.error(f"publish failed ({len(failures)} target/operation failure(s)):")
             for target, operation, error in failures:
                 log.error(f"  - {target} [{operation}]: {error}")
+            if summary:
+                try:
+                    _emit_publish_summary()
+                except Exception:
+                    log.debug("Failed to emit --summary on the publish-failure path", exc_info=True)
             raise typer.Exit(code=1)
+
+        if summary:
+            _emit_publish_summary()

--- a/posit-bakery/posit_bakery/plugins/builtin/imagetools/imagetools.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/imagetools/imagetools.py
@@ -30,6 +30,7 @@ from posit_bakery.plugins.builtin.imagetools.soci import SociConvertWorkflow, fi
 from posit_bakery.plugins.protocol import BakeryToolPlugin, ToolCallResult
 
 if TYPE_CHECKING:
+    from posit_bakery.const import SummaryOutputFormat
     from posit_bakery.parallel import CommandRunner
 
 log = logging.getLogger(__name__)
@@ -539,7 +540,7 @@ class ImageToolsPlugin(BakeryToolPlugin):
         dev_spec: Any = None,
         jobs: int | None = None,
         summary: bool = False,
-        summary_format: Any = None,
+        summary_format: "SummaryOutputFormat | None" = None,
     ) -> None:
         """Publish multi-platform images by composing wait -> index-create -> soci-convert ->
         index-copy -> verify.

--- a/posit-bakery/test/cli/test_ci_publish.py
+++ b/posit-bakery/test/cli/test_ci_publish.py
@@ -358,3 +358,41 @@ def test_publish_summary_skips_registry_measurement_on_dry_run(tmp_path):
 
     _, kwargs = measure_sizes.call_args
     assert kwargs["push"] is False
+
+
+def test_publish_summary_measures_registry_on_a_real_push(tmp_path):
+    """Companion to the dry-run test above: a real (non-dry-run) publish must measure the
+    registry ref, or a hardcoded `push=False` regression would go undetected."""
+    from posit_bakery.plugins.builtin.imagetools.imagetools import ImageToolsPlugin
+
+    target = _fake_target("uid-a")
+    target.image_name = "connect"
+    target.image_version.name = "2026.01.1"
+    target.image_os = None
+    target.image_variant = None
+    target.tags = ["ghcr.io/posit-dev/connect:2026.01.1"]
+    target.cache_name.return_value = None
+
+    with (
+        patch("posit_bakery.config.BakeryConfig.from_context") as from_context,
+        patch("posit_bakery.plugins.builtin.imagetools.oras.find_oras_bin", return_value="oras"),
+        patch("posit_bakery.plugins.builtin.imagetools.soci.find_soci_bin", return_value="soci"),
+        _bypass_pydantic_init(OrasIndexCreateWorkflow),
+        _bypass_pydantic_init(OrasIndexCopyWorkflow),
+        patch.object(OrasIndexCopyWorkflow, "run") as copy_run,
+        patch("posit_bakery.image.BuildSummary.measure_sizes") as measure_sizes,
+    ):
+        config = from_context.return_value
+        config.load_build_metadata_from_file.return_value = ["uid-a"]
+        config.get_image_target_by_uid.return_value = target
+        copy_run.return_value = Mock(success=True)
+
+        ImageToolsPlugin().publish(
+            metadata_file=[tmp_path / "a-metadata.json"],
+            context=tmp_path,
+            dry_run=False,
+            summary=True,
+        )
+
+    _, kwargs = measure_sizes.call_args
+    assert kwargs["push"] is True

--- a/posit-bakery/test/cli/test_ci_publish.py
+++ b/posit-bakery/test/cli/test_ci_publish.py
@@ -5,7 +5,7 @@ The orchestration logic lives in the ``imagetools`` plugin
 delegates to it.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from typer.testing import CliRunner
@@ -37,6 +37,39 @@ def test_publish_command_flags_present():
     # SOCI is config-driven and standalone-only; there is no CLI flag for it.
     assert "--soci-mode" not in result.stdout
     assert "--enable-soci" not in result.stdout
+
+
+def test_publish_command_summary_flags_present():
+    runner = CliRunner()
+    result = runner.invoke(app, ["ci", "publish", "--help"], env=_WIDE_TERM_ENV)
+    assert result.exit_code == 0
+    assert "--summary" in result.stdout
+    assert "--summary-format" in result.stdout
+
+
+def test_publish_with_summary_json_calls_plugin_with_summary_flags(tmp_path):
+    metadata_file = tmp_path / "a-metadata.json"
+    metadata_file.write_text("{}")
+    runner = CliRunner()
+
+    with patch("posit_bakery.plugins.registry.get_plugin") as get_plugin:
+        result = runner.invoke(
+            app,
+            [
+                "ci",
+                "publish",
+                "--summary",
+                "--summary-format",
+                "json",
+                str(metadata_file),
+            ],
+        )
+
+    assert result.exit_code == 0, result.stdout
+    plugin = get_plugin.return_value
+    _, kwargs = plugin.publish.call_args
+    assert kwargs["summary"] is True
+    assert kwargs["summary_format"].value == "json"
 
 
 def _fake_target(uid: str, merge_sources: list[str] | None = None):
@@ -282,3 +315,46 @@ def test_publish_jobs_flag_passed_through(tmp_path):
 
     assert result.exit_code == 0, result.stdout
     assert captured["jobs"] == 4
+
+
+def test_publish_summary_skips_registry_measurement_on_dry_run(tmp_path):
+    """--dry-run must never measure a target's registry ref -- there is nothing new
+    published to measure, and the tag may already hold a previous, unrelated release."""
+    from posit_bakery.plugins.builtin.imagetools.imagetools import ImageToolsPlugin
+
+    target = _fake_target("uid-a")
+    target.image_name = "connect"
+    target.image_version.name = "2026.01.1"
+    # `from_image_targets` runs for real (only `measure_sizes` is mocked below), so every
+    # attribute it actually reads must be a real value, not an unconfigured MagicMock:
+    # `image_os=None` takes the falsy branch (skips needing a real `.platforms` list),
+    # `tags` must be a real list (`len()` is called on it), and `cache_name(...)` must
+    # return `None`/`str`, not a MagicMock, since it becomes `BuildSummaryTarget.cache_ref`.
+    target.image_os = None
+    target.image_variant = None
+    target.tags = ["ghcr.io/posit-dev/connect:2026.01.1"]
+    target.cache_name.return_value = None
+
+    with (
+        patch("posit_bakery.config.BakeryConfig.from_context") as from_context,
+        patch("posit_bakery.plugins.builtin.imagetools.oras.find_oras_bin", return_value="oras"),
+        patch("posit_bakery.plugins.builtin.imagetools.soci.find_soci_bin", return_value="soci"),
+        _bypass_pydantic_init(OrasIndexCreateWorkflow),
+        _bypass_pydantic_init(OrasIndexCopyWorkflow),
+        patch.object(OrasIndexCopyWorkflow, "run") as copy_run,
+        patch("posit_bakery.image.BuildSummary.measure_sizes") as measure_sizes,
+    ):
+        config = from_context.return_value
+        config.load_build_metadata_from_file.return_value = ["uid-a"]
+        config.get_image_target_by_uid.return_value = target
+        copy_run.return_value = Mock(success=True)
+
+        ImageToolsPlugin().publish(
+            metadata_file=[tmp_path / "a-metadata.json"],
+            context=tmp_path,
+            dry_run=True,
+            summary=True,
+        )
+
+    _, kwargs = measure_sizes.call_args
+    assert kwargs["push"] is False

--- a/posit-bakery/test/cli/test_ci_summary.py
+++ b/posit-bakery/test/cli/test_ci_summary.py
@@ -1,0 +1,95 @@
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from posit_bakery.cli.main import app
+
+pytestmark = [pytest.mark.unit]
+
+_WIDE_TERM_ENV = {"COLUMNS": "200", "TERM": "dumb", "NO_COLOR": "1"}
+
+
+def _write_summary_json(path, *, uid, platforms=1, tags=8, registry_size=None):
+    path.write_text(
+        json.dumps(
+            {
+                "targets": [
+                    {
+                        "uid": uid,
+                        "image_name": "connect",
+                        "version": "2026.01.1",
+                        "os": "Ubuntu 24.04",
+                        "variant": "Standard",
+                        "platforms": platforms,
+                        "tags": tags,
+                        "layers": None,
+                        "registry_size": registry_size,
+                        "local_size": None,
+                        "cache_ref": None,
+                        "cache_size": None,
+                    }
+                ]
+            }
+        )
+    )
+
+
+def test_help_lists_output_and_disclaimer_flags():
+    runner = CliRunner()
+    result = runner.invoke(app, ["ci", "summary", "--help"], env=_WIDE_TERM_ENV)
+    assert result.exit_code == 0
+    assert "--output" in result.stdout
+    assert "--disclaimer" in result.stdout
+
+
+def test_renders_a_single_file_to_markdown(tmp_path):
+    summary_file = tmp_path / "a.json"
+    _write_summary_json(summary_file, uid="a", registry_size=100)
+    output = tmp_path / "out.md"
+    runner = CliRunner()
+
+    result = runner.invoke(app, ["ci", "summary", str(summary_file), "--output", str(output)])
+
+    assert result.exit_code == 0, result.stdout
+    markdown = output.read_text()
+    assert "connect" in markdown
+    assert "100" in markdown or "B" in markdown  # rich.filesize formats bytes with a unit
+
+
+def test_merges_two_files_for_the_same_uid_without_double_counting(tmp_path):
+    amd64 = tmp_path / "amd64.json"
+    arm64 = tmp_path / "arm64.json"
+    _write_summary_json(amd64, uid="a", platforms=1, registry_size=100)
+    _write_summary_json(arm64, uid="a", platforms=1, registry_size=150)
+    output = tmp_path / "out.md"
+    runner = CliRunner()
+
+    result = runner.invoke(app, ["ci", "summary", str(amd64), str(arm64), "--output", str(output)])
+
+    assert result.exit_code == 0, result.stdout
+    markdown = output.read_text()
+    assert "**Total (1 targets)**" in markdown  # one uid, not two
+
+
+def test_disclaimer_is_written_into_the_output(tmp_path):
+    summary_file = tmp_path / "a.json"
+    _write_summary_json(summary_file, uid="a")
+    output = tmp_path / "out.md"
+    runner = CliRunner()
+
+    result = runner.invoke(
+        app,
+        [
+            "ci",
+            "summary",
+            str(summary_file),
+            "--output",
+            str(output),
+            "--disclaimer",
+            "This summary is incomplete.",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert "This summary is incomplete." in output.read_text()

--- a/posit-bakery/test/cli/test_ci_summary.py
+++ b/posit-bakery/test/cli/test_ci_summary.py
@@ -72,6 +72,36 @@ def test_merges_two_files_for_the_same_uid_without_double_counting(tmp_path):
     assert "**Total (1 targets)**" in markdown  # one uid, not two
 
 
+def test_skips_a_malformed_file_and_still_renders_the_rest(tmp_path):
+    good = tmp_path / "good.json"
+    bad = tmp_path / "bad.json"
+    _write_summary_json(good, uid="a", registry_size=100)
+    bad.write_text("{not valid json")
+    output = tmp_path / "out.md"
+    runner = CliRunner()
+
+    result = runner.invoke(app, ["ci", "summary", str(good), str(bad), "--output", str(output)])
+
+    assert result.exit_code == 0, result.stdout
+    assert "Skipping unreadable summary file" in result.stderr
+    markdown = output.read_text()
+    assert "connect" in markdown
+    assert "**Total (1 targets)**" in markdown
+
+
+def test_renders_an_empty_report_when_every_file_is_malformed(tmp_path):
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not valid json")
+    output = tmp_path / "out.md"
+    runner = CliRunner()
+
+    result = runner.invoke(app, ["ci", "summary", str(bad), "--output", str(output)])
+
+    assert result.exit_code == 0, result.stdout
+    assert "Skipping unreadable summary file" in result.stderr
+    assert "**Total (0 targets)**" in output.read_text()
+
+
 def test_disclaimer_is_written_into_the_output(tmp_path):
     summary_file = tmp_path / "a.json"
     _write_summary_json(summary_file, uid="a")

--- a/posit-bakery/test/image/test_summary.py
+++ b/posit-bakery/test/image/test_summary.py
@@ -828,3 +828,124 @@ class TestAsDict:
         data = summary.as_dict()
 
         assert data["cache_size_bytes"] == 300  # not 600
+
+
+class TestFromJsonFile:
+    def test_reconstructs_targets_and_recomputes_rows(self, tmp_path):
+        path = tmp_path / "a-summary.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "build_targets": 1,
+                    "platform_builds": 1,
+                    "registry_tags": 8,
+                    "registry_size_bytes": 100,
+                    "local_size_bytes": 200,
+                    "cache_size_bytes": None,
+                    "targets": [
+                        {
+                            "uid": "a",
+                            "image_name": "connect",
+                            "version": "2026.01.1",
+                            "os": "Ubuntu 24.04",
+                            "variant": "Standard",
+                            "platforms": 1,
+                            "tags": 8,
+                            "layers": 10,
+                            "registry_size": 100,
+                            "local_size": 200,
+                            "cache_ref": None,
+                            "cache_size": None,
+                        }
+                    ],
+                }
+            )
+        )
+
+        summary = BuildSummary.from_json_file(path)
+
+        assert [t.uid for t in summary.targets] == ["a"]
+        assert {row.key: row.value for row in summary.rows} == {
+            "build_targets": 1,
+            "platform_builds": 1,
+            "registry_tags": 8,
+        }
+
+
+class TestMerge:
+    def _target(self, **overrides):
+        defaults = dict(
+            uid="a",
+            image_name="connect",
+            version="2026.01.1",
+            os="Ubuntu 24.04",
+            variant="Standard",
+            platforms=1,
+            tags=8,
+        )
+        defaults.update(overrides)
+        return BuildSummaryTarget(**defaults)
+
+    def test_single_summary_round_trips_unchanged(self):
+        summary = BuildSummary(rows=[], targets=[self._target()])
+
+        merged = BuildSummary.merge([summary])
+
+        assert len(merged.targets) == 1
+        assert merged.targets[0].uid == "a"
+
+    def test_platform_slices_of_the_same_uid_sum_not_double_count(self):
+        """Two per-platform files for the same multi-platform target must not double
+        `build_targets`/`registry_tags` -- only `platforms`/`registry_size` sum."""
+        amd64 = BuildSummary(
+            rows=[],
+            targets=[self._target(platforms=1, tags=8, registry_size=100, local_size=200)],
+        )
+        arm64 = BuildSummary(
+            rows=[],
+            targets=[self._target(platforms=1, tags=8, registry_size=150, local_size=250)],
+        )
+
+        merged = BuildSummary.merge([amd64, arm64])
+
+        assert len(merged.targets) == 1
+        row = merged.targets[0]
+        assert row.platforms == 2
+        assert row.registry_size == 250
+        assert row.local_size == 450
+        assert row.tags == 8  # identity field: not summed
+        aggregate = {row.key: row.value for row in merged.rows}
+        assert aggregate["build_targets"] == 1  # one distinct uid, not two
+        assert aggregate["platform_builds"] == 2
+        assert aggregate["registry_tags"] == 8  # not 16
+
+    def test_distinct_uids_across_files_both_survive(self):
+        first = BuildSummary(rows=[], targets=[self._target(uid="a")])
+        second = BuildSummary(rows=[], targets=[self._target(uid="b", variant="Minimal")])
+
+        merged = BuildSummary.merge([first, second])
+
+        assert {t.uid for t in merged.targets} == {"a", "b"}
+        aggregate = {row.key: row.value for row in merged.rows}
+        assert aggregate["build_targets"] == 2
+
+    def test_layers_take_first_non_none_slice(self):
+        no_layers = BuildSummary(rows=[], targets=[self._target(layers=None)])
+        with_layers = BuildSummary(rows=[], targets=[self._target(layers=12)])
+
+        merged = BuildSummary.merge([no_layers, with_layers])
+
+        assert merged.targets[0].layers == 12
+
+    def test_cache_size_deduped_by_shared_cache_ref_after_merge(self):
+        """Two platform slices of the same uid can carry the same unsuffixed cache_ref
+        (`ImageTarget.cache_name()` for a true multi-platform target) -- merging must not
+        sum the same cache blob twice."""
+        shared_ref = "ghcr.io/posit-dev/connect/cache:shared"
+        amd64 = BuildSummary(rows=[], targets=[self._target(cache_ref=shared_ref, cache_size=300_000_000)])
+        arm64 = BuildSummary(rows=[], targets=[self._target(cache_ref=shared_ref, cache_size=300_000_000)])
+
+        merged = BuildSummary.merge([amd64, arm64])
+
+        assert merged.targets[0].cache_ref == shared_ref
+        assert merged.targets[0].cache_size == 300_000_000  # first slice's value, not summed

--- a/posit-bakery/test/image/test_summary.py
+++ b/posit-bakery/test/image/test_summary.py
@@ -949,3 +949,58 @@ class TestMerge:
 
         assert merged.targets[0].cache_ref == shared_ref
         assert merged.targets[0].cache_size == 300_000_000  # first slice's value, not summed
+
+
+class TestToMarkdown:
+    def _target(self, **overrides):
+        defaults = dict(
+            uid="a",
+            image_name="connect",
+            version="2026.01.1",
+            os="Ubuntu 24.04",
+            variant="Standard",
+            platforms=1,
+            tags=8,
+        )
+        defaults.update(overrides)
+        return BuildSummaryTarget(**defaults)
+
+    def test_renders_a_row_per_target_and_a_total_row(self):
+        summary = BuildSummary(
+            rows=[],
+            targets=[
+                self._target(uid="a", variant="Standard", registry_size=1_000_000_000, layers=8),
+                self._target(uid="b", variant="Minimal", registry_size=500_000_000, layers=6),
+            ],
+        )
+
+        markdown = summary.to_markdown()
+
+        assert "connect" in markdown
+        assert "Standard" in markdown
+        assert "Minimal" in markdown
+        assert "1.0 GB" in markdown
+        assert "**Total" in markdown
+        assert "1.5 GB" in markdown  # summed registry size
+
+    def test_unmeasured_size_renders_as_dash_not_zero(self):
+        summary = BuildSummary(rows=[], targets=[self._target()])
+
+        markdown = summary.to_markdown()
+
+        assert "—" in markdown
+
+    def test_no_disclaimer_by_default(self):
+        summary = BuildSummary(rows=[], targets=[self._target()])
+
+        markdown = summary.to_markdown()
+
+        assert "⚠️" not in markdown
+
+    def test_disclaimer_is_prepended_as_a_banner(self):
+        summary = BuildSummary(rows=[], targets=[self._target()])
+
+        markdown = summary.to_markdown(disclaimer="This summary is incomplete.")
+
+        assert markdown.index("⚠️") < markdown.index("| Image |")
+        assert "This summary is incomplete." in markdown


### PR DESCRIPTION
Closes https://github.com/posit-dev/images-shared/issues/749

## Summary

`bakery build --summary` reports build counts, image sizes, layer counts, and cache size. CI never showed this data before. Now each build and publish step writes its summary to a JSON file and uploads it as an artifact. A new `summary` job in each reusable workflow merges the artifacts. It posts one combined report to the run's Summary page. The job always runs. If an earlier job failed, the report includes a disclaimer.

Two CLI additions:

- `bakery ci summary FILE... --output PATH [--disclaimer TEXT]` merges summary files into one Markdown table. A target has no per-platform ID, so `BuildSummary.merge()` sums the size fields and keeps one copy of the identity fields per target. This avoids counting a multi-platform target twice.
- `bakery ci publish` gains `--summary`/`--summary-format`, like `bakery build`. On `--dry-run`, it skips the registry-size check. This avoids measuring a stale tag from an earlier release.

An earlier version also posted each matrix job's summary to its own job summary. A 15-cell matrix in images-package-manager produced 15 near-duplicate sections that buried the combined report. This version removes the per-job posting. Only the final `summary` job posts to the run's Summary page.

## Verification

Point `bakery-build-native.yml`, `bakery-build.yml`, or `bakery-build-pr.yml` at this branch in a product repo. Open a PR. Check the run's Summary page for the combined report.

A temporary test PR against images-package-manager confirms this works end to end:

- https://github.com/posit-dev/images-package-manager/pull/139