### PR TITLE
fix: tolerate non-target Buildx metadata entries

### DIFF
--- a/posit-bakery/posit_bakery/image/image_metadata.py
+++ b/posit-bakery/posit_bakery/image/image_metadata.py
@@ -1,10 +1,11 @@
 import datetime
 import json
 import logging
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Annotated, Self
 
-from pydantic import ConfigDict, BaseModel, Field, RootModel
+from pydantic import ConfigDict, BaseModel, Field, RootModel, model_validator
 
 log = logging.getLogger(__name__)
 
@@ -246,6 +247,32 @@ class BuildMetadata(BaseModel):
 
 class BuildMetadataMap(RootModel[dict[str, BuildMetadata]]):
     """Representation of a mapping from target UIDs to build metadata."""
+
+    @model_validator(mode="before")
+    @classmethod
+    def discard_non_target_entries(cls, value):
+        """Remove buildx metadata entries that are not associated with a target UID."""
+        if not isinstance(value, Mapping):
+            return value
+
+        metadata_by_target = {}
+        discarded_keys = []
+        for key, metadata in value.items():
+            # ImageTarget.uid() replaces dots, plus signs, slashes, and spaces with hyphens.
+            # Buildx uses dotted keys for global metadata such as buildx.build.warnings.
+            if (
+                not isinstance(key, str)
+                or any(character in key for character in ".+/ ")
+                or not isinstance(metadata, (Mapping, BuildMetadata))
+            ):
+                discarded_keys.append(str(key))
+                continue
+            metadata_by_target[key] = metadata
+
+        if discarded_keys:
+            log.debug("Ignoring non-target build metadata entries: %s", ", ".join(discarded_keys))
+
+        return metadata_by_target
 
 
 class MetadataFile(BaseModel):

--- a/posit-bakery/test/image/test_image_metadata.py
+++ b/posit-bakery/test/image/test_image_metadata.py
@@ -225,6 +225,33 @@ class TestMetadataFile:
         assert len(metadata_file.metadata_map.root.keys()) == 4
         assert metadata_file.filepath is None
 
+    @pytest.mark.parametrize("unexpected_value", [[], {"details": "unexpected metadata"}])
+    @pytest.mark.parametrize(
+        "load_metadata",
+        [
+            pytest.param(MetadataFile.load, id="load"),
+            pytest.param(lambda filepath: MetadataFile.loads(filepath.read_text()), id="loads"),
+        ],
+    )
+    def test_metadata_file_loading_ignores_non_target_entries(self, tmp_path, unexpected_value, load_metadata, caplog):
+        """Buildx global metadata must not be mistaken for a target's metadata."""
+        metadata_filepath = tmp_path / "metadata.json"
+        metadata_filepath.write_text(
+            json.dumps(
+                {
+                    "example-1-0-0": {"image.name": "example:1.0.0"},
+                    "buildx.build.warnings": unexpected_value,
+                }
+            )
+        )
+        caplog.set_level("DEBUG", logger="posit_bakery.image.image_metadata")
+
+        metadata_file = load_metadata(metadata_filepath)
+
+        assert list(metadata_file.metadata_map.root) == ["example-1-0-0"]
+        assert metadata_file.get_target_metadata_by_uid("example-1-0-0").image_name == "example:1.0.0"
+        assert "Ignoring non-target build metadata entries: buildx.build.warnings" in caplog.text
+
     def test_metadata_file_no_filepath_or_metadata_value_error(self):
         with pytest.raises(ValueError):
             MetadataFile()


### PR DESCRIPTION
## Summary
- ignore non-target top-level Buildx metadata before target validation
- log discarded metadata keys at debug level
- cover dict- and list-valued warnings through both metadata loaders

## Validation
- `uv run ruff check posit_bakery/image/image_metadata.py test/image/test_image_metadata.py`
- `uv run ruff format --check posit_bakery/image/image_metadata.py test/image/test_image_metadata.py`
- `uv run pytest test/image/test_image_metadata.py`

Fixes #737