### PR TITLE
fix: apply image-level tool options fallback for variant-less images

### DIFF
--- a/posit-bakery/posit_bakery/image/image_target.py
+++ b/posit-bakery/posit_bakery/image/image_target.py
@@ -17,6 +17,7 @@ from posit_bakery.config.image.posit_product.const import ReleaseChannelEnum
 from posit_bakery.config.registry import Registry, BaseRegistry
 from posit_bakery.config.repository import Repository
 from posit_bakery.config.tag import TagPattern, TagPatternFilter
+from posit_bakery.config.tools import ToolOptions
 from posit_bakery.const import OCI_LABEL_PREFIX, POSIT_LABEL_PREFIX, REGEX_IMAGE_TAG_SUFFIX_ALLOWED_CHARACTERS_PATTERN
 from posit_bakery.error import BakeryError, BakeryToolRuntimeError, BakeryFileError
 from posit_bakery.image.image_metadata import MetadataFile, BuildMetadata
@@ -646,6 +647,28 @@ class ImageTarget(BaseModel):
     def temp_registry(self) -> str | None:
         """Get the temporary registry from settings."""
         return self.settings.temp_registry
+
+    def get_tool_option(self, tool: str) -> ToolOptions | None:
+        """Returns tool options for this image target, falling back from variant to parent image.
+
+        When the target has a variant, this delegates to ``ImageVariant.get_tool_option``, which
+        already merges the variant's options with its parent ``Image``'s options. When the target
+        has no variant, this falls back directly to the parent ``Image``'s own ``get_tool_option``
+        so variant-less images can still configure tool options via ``Image.options`` in
+        bakery.yaml, instead of that configuration being silently ignored.
+
+        :param tool: The name of the tool to get options for.
+
+        :return: The ToolOptions object for the specified tool, or None if not found.
+        """
+        if self.image_variant is not None:
+            return self.image_variant.get_tool_option(tool)
+
+        image = self.image_version.parent
+        if image is not None:
+            return image.get_tool_option(tool)
+
+        return None
 
     def remove(self, prune: bool = True, force: bool = False):
         """Remove the image from the local image cache or registry."""

--- a/posit-bakery/posit_bakery/plugins/builtin/dgoss/command.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/dgoss/command.py
@@ -124,13 +124,12 @@ class DGossCommand(BaseModel):
         }
         if platform:
             args["platform"] = platform
-        if image_target.image_variant:
-            goss_options = image_target.image_variant.get_tool_option("goss")
-            if goss_options is not None:
-                args["runtime_options"] = goss_options.runtimeOptions
-                args["image_command"] = goss_options.command
-                args["wait"] = goss_options.wait
-                args["timeout"] = goss_options.timeout
+        goss_options = image_target.get_tool_option("goss")
+        if goss_options is not None:
+            args["runtime_options"] = goss_options.runtimeOptions
+            args["image_command"] = goss_options.command
+            args["wait"] = goss_options.wait
+            args["timeout"] = goss_options.timeout
         return cls(**args)
 
     @model_validator(mode="after")

--- a/posit-bakery/posit_bakery/plugins/builtin/hadolint/command.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/hadolint/command.py
@@ -30,17 +30,16 @@ class HadolintCommand(BaseModel):
         hadolint_bin = find_hadolint_bin(image_target.context.base_path)
         containerfile_path = image_target.context.base_path / image_target.containerfile
 
-        # Load options from variant, then merge with override
-        variant_options = None
-        if image_target.image_variant:
-            variant_options = image_target.image_variant.get_tool_option("hadolint")
+        # Load options from the variant or, for variant-less images, the parent Image, then
+        # merge with override
+        resolved_options = image_target.get_tool_option("hadolint")
 
-        if options_override and variant_options:
-            options = options_override.update(variant_options)
+        if options_override and resolved_options:
+            options = options_override.update(resolved_options)
         elif options_override:
             options = options_override
-        elif variant_options:
-            options = variant_options
+        elif resolved_options:
+            options = resolved_options
         else:
             options = HadolintOptions()
 

--- a/posit-bakery/posit_bakery/plugins/builtin/wizcli/command.py
+++ b/posit-bakery/posit_bakery/plugins/builtin/wizcli/command.py
@@ -81,9 +81,10 @@ class WizCLICommand(BaseModel):
         no_publish: bool = False,
         log_file: str | None = None,
     ) -> "WizCLICommand":
-        # Resolve tool options from variant config if not explicitly provided
-        if tool_options is None and image_target.image_variant:
-            tool_options = image_target.image_variant.get_tool_option("wizcli")
+        # Resolve tool options from variant (or, for variant-less images, the parent Image)
+        # config if not explicitly provided
+        if tool_options is None:
+            tool_options = image_target.get_tool_option("wizcli")
 
         image_subdir = results_dir / image_target.image_name
         results_file = image_subdir / f"{image_target.uid}.json"

--- a/posit-bakery/test/image/test_image_target.py
+++ b/posit-bakery/test/image/test_image_target.py
@@ -1294,6 +1294,60 @@ class TestImageTarget:
         assert sources == ["image@sha256:digest"]
 
 
+class TestGetToolOption:
+    """Tests for ImageTarget.get_tool_option — see posit-dev/images-shared#756."""
+
+    def test_delegates_to_variant_when_present(self, basic_standard_image_target):
+        """When a variant is set, resolution delegates to ImageVariant.get_tool_option (which
+        already merges with the parent Image's options)."""
+        assert basic_standard_image_target.image_variant is not None
+        expected = basic_standard_image_target.image_variant.get_tool_option("goss")
+        assert basic_standard_image_target.get_tool_option("goss") == expected
+
+    def test_falls_back_to_parent_image_when_variant_less(self, get_config_obj):
+        """When no variant is set, image-level Image.options must not be silently ignored."""
+        config_obj = get_config_obj("variant-less-options")
+        image = config_obj.model.get_image("no-variant-image")
+        version = image.get_version("1.0.0")
+        os = version.os[0]
+
+        target = ImageTarget.new_image_target(
+            repository=config_obj.model.repository,
+            image_version=version,
+            image_variant=None,
+            image_os=os,
+        )
+
+        goss_options = target.get_tool_option("goss")
+        assert goss_options is not None
+        assert goss_options.command == "entrypoint-jupyter-server"
+        assert goss_options.wait == 20
+
+        hadolint_options = target.get_tool_option("hadolint")
+        assert hadolint_options is not None
+        assert hadolint_options.failureThreshold == "warning"
+
+        wizcli_options = target.get_tool_option("wizcli")
+        assert wizcli_options is not None
+        assert wizcli_options.projects == ["test-project"]
+
+    def test_returns_none_when_no_options_configured(self, get_config_obj):
+        """A variant-less image with no matching tool option returns None, not a default."""
+        config_obj = get_config_obj("barebones")
+        image = config_obj.model.get_image("scratch")
+        version = image.get_version("1.0.0")
+        os = version.os[0]
+
+        target = ImageTarget.new_image_target(
+            repository=config_obj.model.repository,
+            image_version=version,
+            image_variant=None,
+            image_os=os,
+        )
+
+        assert target.get_tool_option("goss") is None
+
+
 class TestPushSortKey:
     """Tests for ImageTarget.push_sort_key — see ordered-push design spec."""
 

--- a/posit-bakery/test/plugins/builtin/dgoss/conftest.py
+++ b/posit-bakery/test/plugins/builtin/dgoss/conftest.py
@@ -28,3 +28,24 @@ def basic_standard_image_target(get_config_obj):
         image_variant=variant,
         image_os=os,
     )
+
+
+@pytest.fixture
+def no_variant_image_target(get_config_obj):
+    """Return a variant-less ImageTarget with image-level tool options set.
+
+    Regression fixture for posit-dev/images-shared#756: image-level `options:` must not be
+    silently ignored for images with no `variants:` entries.
+    """
+    config_obj = get_config_obj("variant-less-options")
+
+    image = config_obj.model.get_image("no-variant-image")
+    version = image.get_version("1.0.0")
+    os = version.os[0]
+
+    return ImageTarget.new_image_target(
+        repository=config_obj.model.repository,
+        image_version=version,
+        image_variant=None,
+        image_os=os,
+    )

--- a/posit-bakery/test/plugins/builtin/dgoss/test_command.py
+++ b/posit-bakery/test/plugins/builtin/dgoss/test_command.py
@@ -30,6 +30,16 @@ class TestDGossCommand:
         cmd = DGossCommand.from_image_target(basic_standard_image_target)
         assert cmd.timeout == 900
 
+    def test_from_image_target_uses_parent_image_options_when_variant_less(self, no_variant_image_target):
+        """Image-level goss options must apply to images with no `variants:` entry.
+
+        Regression test for posit-dev/images-shared#756.
+        """
+        assert no_variant_image_target.image_variant is None
+        dgoss_command = DGossCommand.from_image_target(image_target=no_variant_image_target)
+        assert dgoss_command.image_command == "entrypoint-jupyter-server"
+        assert dgoss_command.wait == 20
+
     def test_dgoss_environment(self, basic_standard_image_target):
         """Test that DGossCommand dgoss_environment returns the expected environment variables."""
         dgoss_command = DGossCommand.from_image_target(image_target=basic_standard_image_target)

--- a/posit-bakery/test/plugins/builtin/hadolint/conftest.py
+++ b/posit-bakery/test/plugins/builtin/hadolint/conftest.py
@@ -19,3 +19,24 @@ def basic_standard_image_target(get_config_obj):
         image_variant=variant,
         image_os=os,
     )
+
+
+@pytest.fixture
+def no_variant_image_target(get_config_obj):
+    """Return a variant-less ImageTarget with image-level tool options set.
+
+    Regression fixture for posit-dev/images-shared#756: image-level `options:` must not be
+    silently ignored for images with no `variants:` entries.
+    """
+    config_obj = get_config_obj("variant-less-options")
+
+    image = config_obj.model.get_image("no-variant-image")
+    version = image.get_version("1.0.0")
+    os = version.os[0]
+
+    return ImageTarget.new_image_target(
+        repository=config_obj.model.repository,
+        image_version=version,
+        image_variant=None,
+        image_os=os,
+    )

--- a/posit-bakery/test/plugins/builtin/hadolint/test_command.py
+++ b/posit-bakery/test/plugins/builtin/hadolint/test_command.py
@@ -21,6 +21,17 @@ class TestHadolintCommand:
             basic_standard_image_target.context.base_path / basic_standard_image_target.containerfile
         )
 
+    def test_from_image_target_uses_parent_image_options_when_variant_less(self, no_variant_image_target):
+        """Image-level hadolint options must apply to images with no `variants:` entry.
+
+        Regression test for posit-dev/images-shared#756.
+        """
+        assert no_variant_image_target.image_variant is None
+        cmd = HadolintCommand.from_image_target(no_variant_image_target)
+        assert "--failure-threshold" in cmd.command
+        idx = cmd.command.index("--failure-threshold")
+        assert cmd.command[idx + 1] == "warning"
+
     def test_command_includes_format_json(self, basic_standard_image_target):
         """Test that the command always includes --format json."""
         cmd = HadolintCommand.from_image_target(basic_standard_image_target)

--- a/posit-bakery/test/plugins/builtin/wizcli/conftest.py
+++ b/posit-bakery/test/plugins/builtin/wizcli/conftest.py
@@ -19,3 +19,24 @@ def basic_standard_image_target(get_config_obj):
         image_variant=variant,
         image_os=os,
     )
+
+
+@pytest.fixture
+def no_variant_image_target(get_config_obj):
+    """Return a variant-less ImageTarget with image-level tool options set.
+
+    Regression fixture for posit-dev/images-shared#756: image-level `options:` must not be
+    silently ignored for images with no `variants:` entries.
+    """
+    config_obj = get_config_obj("variant-less-options")
+
+    image = config_obj.model.get_image("no-variant-image")
+    version = image.get_version("1.0.0")
+    os = version.os[0]
+
+    return ImageTarget.new_image_target(
+        repository=config_obj.model.repository,
+        image_version=version,
+        image_variant=None,
+        image_os=os,
+    )

--- a/posit-bakery/test/plugins/builtin/wizcli/test_command.py
+++ b/posit-bakery/test/plugins/builtin/wizcli/test_command.py
@@ -27,6 +27,23 @@ class TestWizCLICommand:
         assert "--no-style" in cmd.command
         assert "--json-output-file" in " ".join(cmd.command)
 
+    def test_from_image_target_uses_parent_image_options_when_variant_less(self, no_variant_image_target):
+        """Image-level wizcli options must apply to images with no `variants:` entry.
+
+        Regression test for posit-dev/images-shared#756.
+        """
+        assert no_variant_image_target.image_variant is None
+        results_dir = no_variant_image_target.context.base_path / "results" / "wizcli"
+        cmd = WizCLICommand.from_image_target(
+            image_target=no_variant_image_target,
+            results_dir=results_dir,
+        )
+        assert cmd.tool_options is not None
+        assert cmd.tool_options.projects == ["test-project"]
+        assert "--projects" in cmd.command
+        idx = cmd.command.index("--projects")
+        assert cmd.command[idx + 1] == "test-project"
+
     def test_command_includes_dockerfile(self, basic_standard_image_target):
         """Test that --dockerfile is set to the target's containerfile."""
         results_dir = basic_standard_image_target.context.base_path / "results" / "wizcli"

--- a/posit-bakery/test/resources/variant-less-options/bakery.yaml
+++ b/posit-bakery/test/resources/variant-less-options/bakery.yaml
@@ -1,0 +1,28 @@
+repository:
+  url: "github.com/posit-dev/images-shared"
+  vendor: "Posit Software, PBC"
+  maintainer:
+    name: "Posit Docker Team"
+    email: "docker@posit.co"
+
+registries:
+  - host: "ghcr.io"
+    namespace: "posit-dev"
+
+images:
+  - name: "no-variant-image"
+    options:
+      - tool: "goss"
+        wait: 20
+        command: "entrypoint-jupyter-server"
+      - tool: "hadolint"
+        failureThreshold: "warning"
+      - tool: "wizcli"
+        projects:
+          - "test-project"
+    versions:
+      - name: 1.0.0
+        latest: true
+        os:
+          - name: Ubuntu 22.04
+            primary: true

--- a/posit-bakery/test/resources/variant-less-options/no-variant-image/1.0.0/Containerfile.ubuntu2204
+++ b/posit-bakery/test/resources/variant-less-options/no-variant-image/1.0.0/Containerfile.ubuntu2204
@@ -1,0 +1,1 @@
+FROM ubuntu:22.04


### PR DESCRIPTION
## Summary

Fixes #756. `ImageTarget`-level tool options (`goss`, `hadolint`, `wizcli`) set
directly on an `Image` in `bakery.yaml` were silently ignored for any image
that does not declare at least one `variants` entry, because all three
built-in tool command builders only checked
`image_target.image_variant.get_tool_option(...)` and had no fallback to the
parent `Image`'s own `options`/`get_tool_option()` when `image_variant` is
`None`.

## Fix

Added `ImageTarget.get_tool_option(tool)` in `posit_bakery/image/image_target.py`
as a single shared resolution point, per the issue's suggestion:

- Delegates to `ImageVariant.get_tool_option` (which already merges with the
  parent `Image`'s options) when a variant is present.
- Falls back directly to `Image.get_tool_option` when there is no variant.

Updated `DGossCommand.from_image_target`, `HadolintCommand.from_image_target`,
and `WizCLICommand.from_image_target` to call `image_target.get_tool_option(...)`
instead of duplicating the `if image_target.image_variant:` gate, so any
future tool integration gets the same fallback for free.

## Testing

- New test resource `test/resources/variant-less-options/`: a variant-less
  image with `goss`/`hadolint`/`wizcli` options set directly on `Image`.
- `TestGetToolOption` in `test/image/test_image_target.py`: variant
  delegation, variant-less fallback, and no-options-configured cases.
- Regression tests in `dgoss`, `hadolint`, and `wizcli` `test_command.py`
  verifying built commands honor image-level options for variant-less
  targets.
- `just test` passes (2194 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)