### PR TITLE
Scan only latest image for production builds

### DIFF
--- a/.github/workflows/bakery-build-native.yml
+++ b/.github/workflows/bakery-build-native.yml
@@ -473,6 +473,11 @@ jobs:
           [[ -n "$WIZ_POLICY_ID" ]] && POLICY_FLAGS=(--policies "$WIZ_POLICY_ID")
           PROJECT_FLAGS=()
           [[ -n "$WIZ_PROJECT_ID" ]] && PROJECT_FLAGS=(--projects "$WIZ_PROJECT_ID")
+          # Production builds (dev-versions != only) scan only the --latest
+          # version of each image now that the backlog has been scanned once.
+          # Development builds keep scanning every push.
+          LATEST_FLAGS=()
+          [[ "$DEV_VERSIONS" != "only" ]] && LATEST_FLAGS=(--latest)
           WIZCLI_PATH=${GITHUB_WORKSPACE}/tools/wizcli \
           bakery wizcli scan \
             --image-name "^${IMAGE_NAME}$" \
@@ -483,6 +488,7 @@ jobs:
             "${DEV_SPEC_FLAGS[@]}" \
             "${POLICY_FLAGS[@]}" \
             "${PROJECT_FLAGS[@]}" \
+            "${LATEST_FLAGS[@]}" \
             --metadata-file "./${IMAGE_NAME}-${IMAGE_VERSION}-${NORMALIZED_PLATFORM}-metadata.json" \
             --context "$CONTEXT"
       - name: Upload Metadata


### PR DESCRIPTION
Closes https://github.com/posit-dev/images-shared/issues/763

Production and content/session workflows (production.yml, content.yml, session.yml) call the shared bakery-build-native.yml workflow with dev-versions: exclude (default). This adds --latest to the bakery wizcli scan invocation whenever dev-versions != only, so those workflows only scan each image's latest-flagged version (or matrix combination) per push, now that the version backlog has been backfilled with Wiz scans.

Development workflows (development.yml, development-workbench.yml, development-positron.yml) call with dev-versions: only and are unaffected — they continue to scan every version on every push.

The --latest filter already exists in bakery's wizcli scan command and correctly resolves to a single version for both plain and matrix-derived (session/content) images, since is_latest is computed per matrix combination based on dependencyConstraints.latest.

Note: since the Scan step runs per (image, version, platform) build job, jobs for non-latest versions now hit bakery's "no targets" exit path when combined with the existing per-job --image-version filter. This is swallowed by the step's existing continue-on-error: true.